### PR TITLE
fix: harden auth token handling

### DIFF
--- a/storage/framework/core/auth/src/email-verification.ts
+++ b/storage/framework/core/auth/src/email-verification.ts
@@ -29,17 +29,26 @@ export interface EmailVerificationResult {
  */
 function generateVerificationToken(userId: number): { token: string, hash: string } {
   const nonce = randomBytes(32).toString('hex')
-  const appKey = config.app.key || 'stacks-default-key'
+  const appKey = getAppKey()
   const payload = `${userId}:${nonce}`
   const hash = createHmac('sha256', appKey).update(payload).digest('hex')
   return { token: nonce, hash }
+}
+
+function getAppKey(): string {
+  const appKey = config.app.key
+  if (typeof appKey !== 'string' || appKey.length === 0) {
+    throw new Error('[auth/email-verification] Missing config.app.key; refusing to sign verification tokens with a fallback key')
+  }
+
+  return appKey
 }
 
 /**
  * Verify a token matches the stored hash
  */
 function verifyToken(userId: number, token: string, storedHash: string): boolean {
-  const appKey = config.app.key || 'stacks-default-key'
+  const appKey = getAppKey()
   const payload = `${userId}:${token}`
   const hash = createHmac('sha256', appKey).update(payload).digest('hex')
   const a = Buffer.from(hash)

--- a/storage/framework/core/auth/src/password/reset.ts
+++ b/storage/framework/core/auth/src/password/reset.ts
@@ -64,6 +64,11 @@ export function passwordResets(email: string): PasswordResetActions {
     const hashedToken = await makeHash(token, { algorithm: 'bcrypt' })
 
     await db
+      .deleteFrom('password_resets')
+      .where('email', '=', email)
+      .execute()
+
+    await db
       .insertInto('password_resets')
       .values({
         email,
@@ -139,6 +144,7 @@ export function passwordResets(email: string): PasswordResetActions {
       const resetRecord = await trx
         .selectFrom('password_resets')
         .where('email', '=', email)
+        .orderBy('created_at', 'desc')
         .selectAll()
         .executeTakeFirst()
 


### PR DESCRIPTION
Fixes #1861.

This tightens two auth token paths from the security report:

- removes the hardcoded email verification HMAC fallback key and fails closed when `config.app.key` is missing
- invalidates prior password reset tokens before issuing a new one so stale tokens cannot remain valid for the same email
- reads the newest reset token during reset verification as a defensive guard for existing duplicate rows

I kept this PR intentionally focused on the token-forgery and stale-reset-token portions of the report so it is easier to review. The remaining WebAuthn counter/challenge and OAuth secret-storage items can be handled separately.

Validation: could not run the project typecheck locally because `bun` is not installed in this environment.
