### PR TITLE
fix(buddy): don't let optional rpx HTTPS preflight crash dev server

### DIFF
--- a/storage/framework/core/buddy/src/commands/dev.ts
+++ b/storage/framework/core/buddy/src/commands/dev.ts
@@ -393,6 +393,14 @@ export async function startDevelopmentServer(_options: DevOptions, _startTime?: 
   const rpxTlsPreflight = hasCustomDomain && domain
     ? prepareRpxTlsForDev({ domain, includeDashboard, options })
     : Promise.resolve()
+  // The HTTPS proxy is optional. This preflight is only awaited later (inside the
+  // readiness handler, behind the frontend port probe), so without a handler
+  // attached now an early failure — e.g. falling back to an @stacksjs/rpx build
+  // that predates the TLS helpers `ensureRpxDevelopmentHttps` calls — would
+  // surface as an unhandled rejection and kill the dev server before the frontend
+  // even binds. The no-op catch keeps it "handled"; the await below still warns
+  // and the dev server degrades to http://localhost.
+  void rpxTlsPreflight.catch(() => {})
 
   // Clean up child processes on exit to prevent orphaned processes.
   //


### PR DESCRIPTION
`startDevelopmentServer` starts `rpxTlsPreflight` early but only `await`s it later, inside the readiness handler gated behind the frontend port probe. If the preflight rejects before then — e.g. `importDevelopmentRpx()` falls back to an `@stacksjs/rpx` build that lacks the TLS helpers `ensureRpxDevelopmentHttps` calls (`getRootCAPaths`, `verifyHttpsChain`, …) — the rejection is unhandled and Bun kills the dev server before the frontend binds, so no server URLs are ever logged.

Attach a no-op handler at creation so an optional-proxy failure can't crash dev. The readiness handler still awaits it in a try/catch and reports `HTTPS proxy unavailable`, degrading to `http://localhost`.

(Surfaced via `stacksjs/postline`, where the published `@stacksjs/rpx@0.11.8` lacks those exports and `./buddy dev` exited without logging any servers.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)