### PR TITLE
chore(buddy): bump @stacksjs/rpx to ^0.11.12

### DIFF
--- a/storage/framework/core/buddy/package.json
+++ b/storage/framework/core/buddy/package.json
@@ -115,7 +115,7 @@
     "@stacksjs/payments": "^0.70.23",
     "@stacksjs/realtime": "^0.70.23",
     "@stacksjs/router": "^0.70.23",
-    "@stacksjs/rpx": "^0.11.11",
+    "@stacksjs/rpx": "^0.11.12",
     "@stacksjs/search-engine": "^0.70.23",
     "@stacksjs/security": "^0.70.23",
     "@stacksjs/server": "^0.70.23",


### PR DESCRIPTION
0.11.12 ships the TLS-helper exports (`getRootCAPaths`, `certIncludesSanHostnames`, `verifyHttpsChain`, …) that `dev.ts` uses for the HTTPS proxy. Declares the version that has them (pairs with the earlier guard so the dev server no longer crashes when an older rpx lacks them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)