### PR TITLE
fix(queue): import from @stacksjs/bun-queue instead of unscoped bun-queue

### DIFF
--- a/storage/framework/core/queue/src/bun-queue.ts
+++ b/storage/framework/core/queue/src/bun-queue.ts
@@ -82,5 +82,5 @@ export {
   // Failed job management
   FailedJobManager,
   type FailedJob,
-  // @ts-ignore - bun-queue resolved by Bun's module resolver
-} from 'bun-queue'
+  // @ts-ignore - resolved by Bun's module resolver
+} from '@stacksjs/bun-queue'

--- a/storage/framework/core/queue/src/drivers/redis.ts
+++ b/storage/framework/core/queue/src/drivers/redis.ts
@@ -19,7 +19,7 @@ import {
   getQueueManager,
   QueueManager,
   setQueueManager,
-} from 'bun-queue'
+} from '@stacksjs/bun-queue'
 import { log } from '@stacksjs/logging'
 
 // Re-export bun-queue types and utilities

--- a/storage/framework/core/queue/src/shims.d.ts
+++ b/storage/framework/core/queue/src/shims.d.ts
@@ -3,9 +3,9 @@ declare module 'redis' {
   export function createClient(options?: { url?: string }): RedisClient
 }
 
-declare module 'bun-queue' {
-  // Wide ambient: bun-queue isn't installed in node_modules; this shim
-  // exists so that imports type-check. The actual values are resolved
+declare module '@stacksjs/bun-queue' {
+  // Wide ambient: @stacksjs/bun-queue may not be installed in node_modules; this
+  // shim exists so that imports type-check. The actual values are resolved
   // by Bun's module resolver at runtime. Each name is declared as both
   // a class (so it can be used as a type and a value) and via `any`
   // semantics inside.


### PR DESCRIPTION
Fixes the `@stacksjs/queue` import specifier so any route/action whose import graph reaches the queue actually loads.

### `@stacksjs/queue` import specifier (Closes #1969)
The queue source imported from the unscoped `bun-queue`, but the declared dependency (and the real package) is `@stacksjs/bun-queue`. The names disagreed, so the specifier never resolved:
```
Cannot find package 'bun-queue' from '.../@stacksjs/queue/dist/index.js'
```
Any route/action whose import graph reached `@stacksjs/queue` (e.g. via `@stacksjs/auth`) then failed to load — the loader swallows the error, so the only visible symptom was a 404 (cf. #1835 root cause 1b). Fix: import from `@stacksjs/bun-queue` in `bun-queue.ts` + `drivers/redis.ts`, and rename the ambient shim to match.

> Note: this PR originally also fixed #1968 (error-handling build target), but `main` has since rewritten that build to use `transpilePackage` (file-by-file transpile instead of bundling), which resolves #1968 independently — so that commit was dropped on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
