### PR TITLE
fix(buddy): gate --conditions development on packages shipping src

### DIFF
--- a/buddy
+++ b/buddy
@@ -88,12 +88,19 @@ run_buddy() {
   BUN_CMD="$1"
   shift
 
-  # When the framework SOURCE is vendored here (storage/framework/core), resolve
-  # @stacksjs/* from src via the `development` export condition, so the monorepo
-  # runs build-free (a fresh checkout has no dist yet). A node_modules-based app
-  # has no vendored core, so it omits the flag and resolves the published dist.
+  # When the framework SOURCE is vendored here (storage/framework/core) AND the
+  # installed @stacksjs/* packages actually ship src (a workspace/source-linked
+  # checkout), resolve them from src via the `development` export condition so the
+  # monorepo runs build-free (a fresh checkout has no dist yet).
+  #
+  # Guard on a representative package having src: an app that vendors the core but
+  # installs the PUBLISHED (dist-only) packages has no src, so the `development`
+  # condition would resolve to ./src/* files that were never shipped (`error:
+  # preload not found "@stacksjs/env/plugin.js"`, then Cannot-find-module for
+  # every other import). In that case omit the flag and let bun/import/default
+  # resolve the dist.
   CONDITIONS=""
-  if [ -d "${ROOT_DIR}/storage/framework/core" ]; then
+  if [ -d "${ROOT_DIR}/storage/framework/core" ] && [ -f "${ROOT_DIR}/node_modules/@stacksjs/env/src/index.ts" ]; then
     CONDITIONS="--conditions development"
   fi
 


### PR DESCRIPTION
### `./buddy dev` preload failure on apps that vendor the core but install published packages (Closes #1970)

The buddy gate enables `--conditions development` whenever the framework source is vendored at `storage/framework/core`:

```sh
CONDITIONS=""
if [ -d "${ROOT_DIR}/storage/framework/core" ]; then
  CONDITIONS="--conditions development"
fi
```

That assumes "vendored core ⟹ `@stacksjs/*` resolve from source." It's false for an app that vendors the core **and** installs the published (dist-only) packages — the `development` condition then resolves to `./src/*` files that were never shipped:

```
error: preload not found "@stacksjs/env/plugin.js"
```

and then `Cannot find module` for every other `@stacksjs/*` import under that condition.

**Fix:** also require a representative package (`@stacksjs/env`) to actually have `src` before using the flag, so dist-only installs fall back to `bun`/`import`/`default` → `dist`. Verified: with this guard, `./buddy dev` boots (preload error gone, servers serve 200); a true source-linked/workspace checkout (where `@stacksjs/env/src` exists) still gets build-free `development` resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
