### PR TITLE
fix(orm): retry .default reads that hit a mid-cycle TDZ during model warmup

### DIFF
--- a/storage/framework/core/orm/src/index.ts
+++ b/storage/framework/core/orm/src/index.ts
@@ -95,6 +95,32 @@ autoConfigureOrm()
 //   - installed: `node_modules/@stacksjs/orm/src/index.ts` → 4 ups
 // projectPath() handles both because it walks up looking for the project
 // root (package.json with no parent), so the same code works regardless.
+/**
+ * `(await import(path)).default`, resilient to a temporal-dead-zone read.
+ *
+ * A framework-default model statically imports `{ defineModel }` from this
+ * module, so importing one during the deferred warmup forms a cycle. If the
+ * model is still mid-evaluation when we read `.default`, the getter throws
+ * `ReferenceError: Cannot access 'default' before initialization`. Yielding a
+ * macrotask lets the in-flight evaluation settle; the module is already cached,
+ * so re-reading doesn't re-import. Bounded retries avoid any spin.
+ */
+async function importDefault(modulePath: string): Promise<any> {
+  for (let attempt = 0; ; attempt++) {
+    const mod = await import(modulePath)
+    try {
+      return mod.default
+    }
+    catch (err) {
+      if (attempt < 5 && err instanceof ReferenceError && /before initialization/.test(err.message)) {
+        await new Promise(resolve => setTimeout(resolve, 0))
+        continue
+      }
+      throw err
+    }
+  }
+}
+
 async function loadUserlandModel(modelName: string, subdirs: string[] = ['']): Promise<any> {
   const { path } = await import('@stacksjs/path')
   // 1) User override at app/Models/<Name>.ts (always wins, no subdir search
@@ -102,7 +128,7 @@ async function loadUserlandModel(modelName: string, subdirs: string[] = ['']): P
   const userPath = path.userModelsPath(`${modelName}.ts`)
   try {
     if (await Bun.file(userPath).exists()) {
-      return (await import(userPath)).default
+      return await importDefault(userPath)
     }
   }
   catch (err) {
@@ -121,7 +147,7 @@ async function loadUserlandModel(modelName: string, subdirs: string[] = ['']): P
     const defaultPath = path.frameworkPath(`defaults/app/Models/${prefix}${modelName}.ts`)
     try {
       if (await Bun.file(defaultPath).exists()) {
-        return (await import(defaultPath)).default
+        return await importDefault(defaultPath)
       }
     }
     catch (err) {


### PR DESCRIPTION
### ORM model warmup TDZ (`Cannot access 'default' before initialization`) — Closes #1971

Framework-default models statically import `{ defineModel }` from `@stacksjs/orm`, so the deferred warmup (`queueMicrotask` in `src/index.ts`) importing them forms a cycle. When a model file is still mid-evaluation, reading its `default` binding throws:

```
ReferenceError: Cannot access 'default' before initialization
```

It's caught and logged, so it's non-fatal — but it floods `./buddy dev` with ~20 `[orm] Failed to import framework default model …` errors per boot and leaves those models unloaded until first lazy access.

**Fix:** an `importDefault()` helper — on a TDZ `ReferenceError`, yield one macrotask so the in-flight module evaluation settles (the module is already in the cache, so re-reading doesn't re-import), bounded at 5 retries. Both `.default` reads in `loadUserlandModel` go through it.

**Verified** against the bundled shipping build in a real app boot (`./buddy dev`, full boot graph):

| configuration | TDZ errors |
|---|---|
| bundled `dist`, no fix (baseline) | 20 |
| bundled `dist` + `importDefault` | **0** |

No residual `[orm]` errors, servers boot and serve 200.

Notes from the investigation (also on the issue): the raw source never reproduces this in isolation — it needs the full boot graph's concurrent importers — and a file-by-file transpile alone (the #1968 remedy) only reduced it (20 → 12), so the retry is the correct fix rather than a build-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
