### PR TITLE
fix(email,commerce): fail-open missing-table guards miss Postgres phrasing

### DIFF
--- a/storage/framework/core/commerce/src/orders/place-order.ts
+++ b/storage/framework/core/commerce/src/orders/place-order.ts
@@ -82,6 +82,23 @@ export type PlaceOrderResult =
  * `order_idempotency` dedup table isn't migrated yet.
  */
 let warnedAboutMissingOrderIdempotencyTable = false
+
+/**
+ * True when the error is just "table not migrated yet". Each dialect phrases
+ * it differently; the Postgres form (`relation "..." does not exist` / SQLSTATE
+ * 42P01) was previously missed, so this fail-open guard hard-failed on an
+ * un-migrated Postgres DB instead of degrading (stacksjs/stacks#1976). Scoped
+ * to `undefined_table` so a real `column ... does not exist` bug still throws.
+ */
+function isMissingTableError(err: unknown): boolean {
+  const e = err as { message?: string, code?: string } | null
+  const msg = e?.message ?? ''
+  return e?.code === '42P01' // postgres SQLSTATE: undefined_table
+    || msg.includes('no such table') // sqlite
+    || msg.includes("doesn't exist") // mysql
+    || /relation "[^"]*" does not exist/i.test(msg) // postgres wording
+}
+
 async function findOrderByIdempotencyKey(key: string): Promise<OrderJsonResponse | null> {
   try {
     const row = await (db as any)
@@ -98,7 +115,7 @@ async function findOrderByIdempotencyKey(key: string): Promise<OrderJsonResponse
     return (order ?? null) as OrderJsonResponse | null
   }
   catch (err: any) {
-    if (err?.message?.includes('no such table') || err?.message?.includes("doesn't exist")) {
+    if (isMissingTableError(err)) {
       if (!warnedAboutMissingOrderIdempotencyTable) {
         warnedAboutMissingOrderIdempotencyTable = true
         // eslint-disable-next-line no-console
@@ -230,7 +247,7 @@ export async function placeOrder(input: PlaceOrderInput): Promise<PlaceOrderResu
             throw Object.assign(new Error('idempotency-key collision'), { __placeFail: true, failedAt: 'idempotency', reason: 'duplicate-idempotency-key' })
           // Missing table: degrade silently (the pre-transaction
           // lookup already warned).
-          if (!(err?.message?.includes('no such table') || err?.message?.includes("doesn't exist")))
+          if (!isMissingTableError(err))
             throw err
         }
       }

--- a/storage/framework/core/commerce/src/orders/webhook.ts
+++ b/storage/framework/core/commerce/src/orders/webhook.ts
@@ -88,6 +88,23 @@ async function findOrderByPaymentIntent(paymentIntentId: string): Promise<Record
  * table get a warn-once at startup.
  */
 let warnedAboutMissingDedupTable = false
+
+/**
+ * True when the error is just "table not migrated yet". Each dialect phrases
+ * it differently; the Postgres form (`relation "..." does not exist` / SQLSTATE
+ * 42P01) was previously missed, so this fail-open guard hard-failed on an
+ * un-migrated Postgres DB instead of degrading (stacksjs/stacks#1976). Scoped
+ * to `undefined_table` so a real `column ... does not exist` bug still throws.
+ */
+function isMissingTableError(err: unknown): boolean {
+  const e = err as { message?: string, code?: string } | null
+  const msg = e?.message ?? ''
+  return e?.code === '42P01' // postgres SQLSTATE: undefined_table
+    || msg.includes('no such table') // sqlite
+    || msg.includes("doesn't exist") // mysql
+    || /relation "[^"]*" does not exist/i.test(msg) // postgres wording
+}
+
 async function recordEventOrSkip(eventId: string, trx: any): Promise<boolean> {
   try {
     await trx
@@ -105,7 +122,7 @@ async function recordEventOrSkip(eventId: string, trx: any): Promise<boolean> {
       return false
     // Missing table → degrade to "process every time" with a warn
     // on first occurrence so ops can spot the missing migration.
-    if (err?.message?.includes('no such table') || err?.message?.includes("doesn't exist")) {
+    if (isMissingTableError(err)) {
       if (!warnedAboutMissingDedupTable) {
         warnedAboutMissingDedupTable = true
         // eslint-disable-next-line no-console

--- a/storage/framework/core/email/src/suppression.ts
+++ b/storage/framework/core/email/src/suppression.ts
@@ -52,9 +52,25 @@ function warnOnceAboutMissingTable(): void {
   )
 }
 
-function isMissingTableError(err: unknown): boolean {
-  const msg = (err as { message?: string } | null)?.message ?? ''
-  return msg.includes('no such table') || msg.includes("doesn't exist")
+/**
+ * Does this error mean the backing table simply hasn't been migrated yet?
+ * Exported for direct unit coverage across dialects.
+ *
+ * Each supported database phrases "missing table" differently, and the
+ * suppression layer is fail-open — so a matcher that only knows sqlite/mysql
+ * would let Postgres's wording slip through and hard-fail every send on an
+ * un-migrated Postgres DB (stacksjs/stacks#1976). We scope the Postgres check
+ * to `undefined_table` specifically (SQLSTATE 42P01 / `relation "..." does not
+ * exist`) rather than a bare `does not exist`, so a genuine `column ... does
+ * not exist` schema bug still surfaces instead of being silently swallowed.
+ */
+export function isMissingTableError(err: unknown): boolean {
+  const e = err as { message?: string, code?: string } | null
+  const msg = e?.message ?? ''
+  return e?.code === '42P01' // postgres SQLSTATE: undefined_table
+    || msg.includes('no such table') // sqlite
+    || msg.includes("doesn't exist") // mysql: Table '...' doesn't exist
+    || /relation "[^"]*" does not exist/i.test(msg) // postgres wording
 }
 
 /**

--- a/storage/framework/core/email/tests/suppression.test.ts
+++ b/storage/framework/core/email/tests/suppression.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test'
+import { isMissingTableError } from '../src/suppression'
+
+// stacksjs/stacks#1976 — the suppression layer is fail-open: a missing
+// `email_suppressions` table must warn-once and proceed, never hard-fail a
+// send. The matcher previously only knew sqlite/mysql phrasing, so on Postgres
+// (`relation "..." does not exist`) the guard missed and every outbound email
+// threw. These pin the cross-dialect behavior, including the SQLSTATE path and
+// the deliberate scoping that keeps real schema bugs surfacing.
+
+describe('isMissingTableError', () => {
+  test('sqlite: "no such table"', () => {
+    expect(isMissingTableError(new Error('no such table: email_suppressions'))).toBe(true)
+  })
+
+  test('mysql: "doesn\'t exist"', () => {
+    expect(isMissingTableError(new Error("Table 'stacks.email_suppressions' doesn't exist"))).toBe(true)
+  })
+
+  test('postgres: relation "..." does not exist (#1976)', () => {
+    expect(isMissingTableError(new Error('relation "email_suppressions" does not exist'))).toBe(true)
+  })
+
+  test('postgres: SQLSTATE 42P01 without recognizable message', () => {
+    expect(isMissingTableError(Object.assign(new Error('db error'), { code: '42P01' }))).toBe(true)
+  })
+
+  test('does NOT match a real column error (over-matching guard)', () => {
+    // A `column ... does not exist` bug must still surface, not be swallowed
+    // by a bare "does not exist" match.
+    expect(isMissingTableError(new Error('column "emial" does not exist'))).toBe(false)
+  })
+
+  test('does NOT match unrelated errors', () => {
+    expect(isMissingTableError(new Error('connection refused'))).toBe(false)
+    expect(isMissingTableError(null)).toBe(false)
+    expect(isMissingTableError(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #1976.

## Problem
`@stacksjs/email`'s suppression layer is designed to **fail open** when `email_suppressions` isn't migrated (warn once, then send). But the matcher only knew sqlite/mysql phrasing:

```ts
return msg.includes('no such table') || msg.includes("doesn't exist")
```

Postgres says `relation "email_suppressions" does not exist` - so on Postgres the guard missed, the error propagated, and **every outbound email hard-failed** on an un-migrated DB (e.g. `passwordResets().sendEmail()` throws, no reset email ever sent).

## Sibling defects fixed
The same fail-open guard, with the same Postgres gap, also lives in commerce - where it would hard-fail order placement and Stripe webhook processing on un-migrated Postgres:
- `orders/place-order.ts` (order-idempotency dedup, 2 sites)
- `orders/webhook.ts` (webhook-event dedup)

## Fix
Detect Postgres `undefined_table` via **SQLSTATE `42P01`** and the `relation "..." does not exist` phrasing. Deliberately scoped to undefined_table rather than a bare `does not exist`, so a genuine `column ... does not exist` schema bug still surfaces instead of being silently swallowed (especially important in the commerce paths, where over-matching could mask duplicate order processing).

## Tests
`isMissingTableError` is exported and unit-tested (6 cases): sqlite / mysql / postgres phrasing, the SQLSTATE-only path, the negative column-error case, and unrelated errors. All pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)