### PR TITLE
fix(router): fail loudly on split @stacksjs/router instances (#1975)

### DIFF
--- a/storage/framework/core/router/src/index.ts
+++ b/storage/framework/core/router/src/index.ts
@@ -22,7 +22,7 @@ export * from '@stacksjs/bun-router'
 export type { StacksRequestExtensions, StacksRequestMacros, StacksRequestMarkers } from './request-augmentation'
 
 // Export Stacks-specific action resolver and URL helper
-export { assertRouteMiddlewareResolvable, clearMiddlewareCache, createStacksRouter, findUnresolvableRouteMiddleware, installMiddlewareHotReload, route, serve, serverResponse, url } from './stacks-router'
+export { assertRouteMiddlewareResolvable, assertSingleRouterInstance, clearMiddlewareCache, createStacksRouter, findUnresolvableRouteMiddleware, installMiddlewareHotReload, route, serve, serverResponse, url } from './stacks-router'
 
 // Export request context helpers
 export { cacheRequestQuery, getCurrentRequest, getTraceId, request, runWithRequest, setCurrentRequest, withTraceId } from './request-context'

--- a/storage/framework/core/router/src/stacks-router.ts
+++ b/storage/framework/core/router/src/stacks-router.ts
@@ -22,6 +22,40 @@ import { path as p } from '@stacksjs/path'
 import { UploadedFile } from '@stacksjs/storage'
 import { applyRequestEnhancements, Router } from '@stacksjs/bun-router'
 
+// --- Split-router-instance guard (stacksjs/stacks#1975) --------------------
+// If two physically distinct @stacksjs/router modules load in one process,
+// user routes register on one `route` singleton while the server serves the
+// other — every route 404s with NO error logged. The classic trigger: an app
+// vendors storage/framework/core AND installs the published dist package, and a
+// tsconfig `paths` mismatch (`@stacksjs/* -> ./*/src`) resolves core files to
+// ./router/src while root files (routes/, app/) resolve to node_modules dist.
+//
+// Each loaded router module records its own path on a process-global set (keyed
+// by a well-known Symbol so the src and dist copies share it). serve() then
+// asserts the set has exactly one entry and fails loudly on a split.
+const ROUTER_INSTANCES_KEY = Symbol.for('@stacksjs/router:loaded-instances')
+const loadedRouterInstances: Set<string> = ((globalThis as Record<symbol, unknown>)[ROUTER_INSTANCES_KEY] ??= new Set<string>()) as Set<string>
+loadedRouterInstances.add(import.meta.path)
+
+/**
+ * Throw if more than one @stacksjs/router module has loaded in this process
+ * (stacksjs/stacks#1975). Called at serve() boot so the otherwise-silent
+ * split-router 404 becomes a loud, actionable error naming the culprit files.
+ */
+export function assertSingleRouterInstance(): void {
+  if (loadedRouterInstances.size <= 1)
+    return
+  const paths = [...loadedRouterInstances].map(p => `    - ${p}`).join('\n')
+  throw new Error(
+    `[router] ${loadedRouterInstances.size} distinct @stacksjs/router instances loaded in one process. `
+    + `User routes register on one instance while the server serves another, so every route 404s silently. `
+    + `This usually means an app vendors storage/framework/core AND installs the published @stacksjs/* dist, and a `
+    + `tsconfig \`paths\` mapping (\`@stacksjs/* -> ./*/src\`) splits module resolution between core files and root files. `
+    + `Unify resolution so root files and core files load the same @stacksjs/router. See stacksjs/stacks#1975.\n`
+    + `Loaded instances:\n${paths}`,
+  )
+}
+
 // Resolve a scaffold-defaults file (under storage/framework/defaults). A
 // vendored checkout has it on disk and wins; a node_modules app has no
 // storage/framework, so fall back to the published @stacksjs/defaults package
@@ -2743,6 +2777,10 @@ export function createStacksRouter(config: StacksRouterConfig = {}): StacksRoute
 
     // Serve the router
     async serve(options: ServerOptions = {}): Promise<Server<unknown>> {
+      // Fail loudly on a split router (#1975) instead of serving an empty
+      // route table. By now importRoutes() has run, so any second instance
+      // pulled in by user route files is already registered.
+      assertSingleRouterInstance()
       return bunRouter.serve(options)
     },
 

--- a/storage/framework/core/router/tests/split-instance-guard.test.ts
+++ b/storage/framework/core/router/tests/split-instance-guard.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { assertSingleRouterInstance } from '../src/stacks-router'
+
+// stacksjs/stacks#1975 — a dist-only app that also vendors storage/framework/core
+// can load two physically distinct @stacksjs/router modules (tsconfig `paths`
+// splits core files -> ./router/src and root files -> node_modules dist). User
+// routes register on one `route` singleton, the server serves the other, and
+// every route 404s with no error logged. serve() now asserts a single instance.
+
+const KEY = Symbol.for('@stacksjs/router:loaded-instances')
+const instances = (globalThis as Record<symbol, unknown>)[KEY] as Set<string>
+const FAKE = '/fake/node_modules/@stacksjs/router/dist/index.js'
+
+afterEach(() => {
+  instances.delete(FAKE)
+})
+
+describe('assertSingleRouterInstance (#1975)', () => {
+  test('registers this module as one loaded instance', () => {
+    // Importing the module recorded its own path; baseline is a single instance.
+    expect(instances.size).toBeGreaterThanOrEqual(1)
+    expect(() => assertSingleRouterInstance()).not.toThrow()
+  })
+
+  test('throws loudly when a second distinct instance is loaded', () => {
+    instances.add(FAKE)
+    expect(() => assertSingleRouterInstance()).toThrow(/distinct @stacksjs\/router instances/)
+  })
+
+  test('error names the offending file and points to the issue', () => {
+    instances.add(FAKE)
+    try {
+      assertSingleRouterInstance()
+      throw new Error('expected assertSingleRouterInstance to throw')
+    }
+    catch (err) {
+      const msg = (err as Error).message
+      expect(msg).toContain(FAKE)
+      expect(msg).toContain('#1975')
+    }
+  })
+})


### PR DESCRIPTION
Refs #1975.

## The bug
In an app that vendors `storage/framework/core` but installs the **published dist** `@stacksjs/*` packages, `core/tsconfig.json`'s `@stacksjs/* -> ./*/src` mapping (honored by Bun at runtime) splits module identity:

- files under `core/**` resolve `@stacksjs/router` → vendored `./router/src`
- root files (`routes/*.ts`, `app/**`) resolve → `node_modules/@stacksjs/router/dist`

Two `route` singletons: `importRoutes()` registers every user route on one, the server serves the other's empty table → **every route 404s, with nothing logged.** The silence is the worst part - there's no signal to debug from.

## What this PR does (the guardrail)
Makes the failure **loud**. Each loaded router module records its own path on a process-global set (keyed by a well-known `Symbol` so the src and dist copies share one set). `serve()` - the single choke point every boot path funnels through - asserts exactly one instance and otherwise throws an actionable error naming the offending files:

```
[router] 2 distinct @stacksjs/router instances loaded in one process. User routes
register on one instance while the server serves another, so every route 404s
silently. ... See stacksjs/stacks#1975.
Loaded instances:
    - .../storage/framework/core/router/src/stacks-router.ts
    - .../node_modules/@stacksjs/router/dist/index.js
```

By the time `serve()` runs, `importRoutes()` has already pulled in any second instance via the user route files, so the split is always visible at that point.

## Tests
New `split-instance-guard.test.ts` (3 cases): single instance passes, a second distinct instance throws, and the error names the file + issue. Verified no false positive - 43 existing router tests across 3 files pass in one process with `serve()` exercised. Lint clean.

## What's intentionally NOT here
The **resolution-level fix** - not shipping (or gating) the `@stacksjs/* -> ./*/src` mapping in dist-only app scaffolds, mirroring #1973's "only when packages actually ship src" gate. That's a scaffold/sync-tooling change and needs a reproducible dist-only app to validate safely; the mapping is a static file this repo copies verbatim, not something generated here. This PR ensures that until that lands, the failure can never again be silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)