### PR TITLE
fix(migrate): surface pre-existing FK orphan rows at migrate time (#1951)

### DIFF
--- a/storage/framework/core/buddy/src/commands/migrate.ts
+++ b/storage/framework/core/buddy/src/commands/migrate.ts
@@ -155,6 +155,41 @@ async function reportMissingForeignKeys(): Promise<void> {
   }
 }
 
+/**
+ * Post-migrate orphan-row scan (stacksjs/stacks#1951, follow-up from #1957).
+ *
+ * SQLite now boots with `foreign_keys = ON`, so a database written under the
+ * old `foreign_keys = OFF` default can carry child rows pointing at parents
+ * that no longer exist. Those orphans turn previously-working deletes/inserts
+ * into runtime FK failures. `buddy doctor` already surfaces them, but migrate
+ * is the highest-context moment — it's the step that first flips enforcement on
+ * against the legacy data — so warn here too. Read-only (`PRAGMA
+ * foreign_key_check`) and non-fatal: a failed scan must never break migrate,
+ * and we never delete data (the operator cleans up manually).
+ */
+async function reportFkOrphans(): Promise<void> {
+  try {
+    const { findFkOrphans } = await import('@stacksjs/database')
+    const result = await findFkOrphans()
+    if (!result.supported || result.total === 0) return
+
+    const sample = result.orphans
+      .slice(0, 5)
+      .map(o => `  • ${o.table}.${o.column} → ${o.parent} (${o.count} row${o.count === 1 ? '' : 's'})`)
+      .join('\n')
+    const more = result.orphans.length > 5 ? `\n  + ${result.orphans.length - 5} more — run \`./buddy doctor\` for the full list.` : ''
+    const first = result.orphans[0]!
+    log.warn(
+      `${result.total} row${result.total === 1 ? '' : 's'} violate foreign keys (orphaned parents), now that SQLite enforces \`foreign_keys = ON\`:\n${sample}${more}\n`
+      + `These were written under the old \`foreign_keys = OFF\` default (#1951). Review and clean up manually — e.g. `
+      + `DELETE FROM ${first.table} WHERE ${first.column} IS NOT NULL AND ${first.column} NOT IN (SELECT id FROM ${first.parent}). migrate never deletes data.`,
+    )
+  }
+  catch (err) {
+    log.debug(`[migrate] FK orphan scan skipped: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
 interface MigrationOpLike {
   kind: string
   table: string
@@ -504,6 +539,13 @@ export function migrate(buddy: CLI): void {
       // follow" failure mode while the user is still at the migrate
       // command — the highest-context moment to warn.
       await reportMissingForeignKeys()
+
+      // Post-migrate orphan-row scan (stacksjs/stacks#1951). migrate is the
+      // step that flips `foreign_keys = ON` against legacy data, so it's the
+      // right place to surface pre-existing orphans (read-only, non-fatal).
+      // migrate:fresh rebuilds from scratch, so it can't have orphans — this
+      // scan is intentionally only on the plain `migrate` path.
+      await reportFkOrphans()
 
       const APP_ENV = process.env.APP_ENV || 'local'
 

--- a/storage/framework/core/buddy/tests/migrate-fk-orphan-scan.test.ts
+++ b/storage/framework/core/buddy/tests/migrate-fk-orphan-scan.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// stacksjs/stacks#1951 (follow-up from #1957) — SQLite now boots with
+// `foreign_keys = ON`, so `buddy migrate` should surface pre-existing orphan
+// rows (child rows pointing at missing parents) at the moment enforcement
+// first bites. The scan reuses the read-only `findFkOrphans()` already covered
+// by database/tests/fk-orphans.test.ts, so here we only pin the wiring:
+// it runs on the `migrate` path and NOT on `migrate:fresh` (which rebuilds
+// from scratch and therefore can't carry orphans). Source-shape check, matching
+// migrate-guarantees-ordering.test.ts — the command calls process.exit.
+
+describe('buddy migrate FK orphan scan (#1951)', () => {
+  const migratePath = resolve(__dirname, '../src/commands/migrate.ts')
+  const source = readFileSync(migratePath, 'utf-8')
+
+  const freshIdx = source.indexOf(`.command('migrate:fresh'`)
+  const dnsIdx = source.indexOf(`.command('migrate:dns'`)
+  const migrateSection = source.slice(0, freshIdx)
+  const freshSection = source.slice(freshIdx, dnsIdx)
+
+  it('defines a read-only, non-fatal reportFkOrphans helper', () => {
+    expect(source).toContain('async function reportFkOrphans()')
+    // reuses the existing read-only scanner rather than re-querying
+    expect(source).toContain('findFkOrphans')
+    // never deletes data
+    expect(source).toContain('migrate never deletes data')
+  })
+
+  it('runs the orphan scan on the migrate path', () => {
+    expect(migrateSection).toContain('await reportFkOrphans()')
+  })
+
+  it('does NOT run the orphan scan on migrate:fresh (rebuilt from scratch)', () => {
+    expect(freshSection).not.toContain('await reportFkOrphans()')
+  })
+})


### PR DESCRIPTION
Follow-up from the #1957 batch-verification sweep. Refs #1951.

## Context
The sweep of #1957 found most items already resolved. The one genuinely useful, low-risk gap left in **#1951**: SQLite now boots with `foreign_keys = ON`, but the read-only orphan scanner (`findFkOrphans()`, `PRAGMA foreign_key_check`) was only wired into `buddy doctor`. **`migrate` is the step that first flips enforcement on against legacy data**, so it's the highest-context moment to warn - today you only find out if you separately run `doctor`.

## Change
Adds a `reportFkOrphans()` sibling to the existing `reportMissingForeignKeys()`, called in the post-migrate block of the plain `migrate` path:
- **Reuses** the existing, already-tested `findFkOrphans()` - no new query logic.
- **Read-only** and **non-fatal** (a failed scan never breaks migrate; wrapped in try/catch → `log.debug`).
- **Never deletes data** - prints the manual `DELETE ... WHERE ... NOT IN (SELECT id ...)` remediation, same posture as `doctor`.
- **Not** on `migrate:fresh` (rebuilds from scratch, so it can't carry orphans).
- SQLite-only via `findFkOrphans()`'s own `supported` gate (MySQL/Postgres enforce FKs natively).

## Tests
New `migrate-fk-orphan-scan.test.ts` pins the wiring (helper exists, runs on `migrate`, absent on `migrate:fresh`); the scanner itself is already covered by `database/tests/fk-orphans.test.ts`. All pass; lint clean.

## Not included (documented in the sweep)
The rest of #1957 is either already fixed (#1947, #1949, #1952, and 2/3 of #1950) or needs a human decision: the #1953 registration enumeration-oracle (product/contract decision) and #1950's unmigrated-DB-on-deploy (touches live Hetzner deploy config + SQLite migrate-race, needs a staging deploy to validate). Those are left as findings, not blind edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)