### PR TITLE
chore: remove stale ts-collect workaround comment

### DIFF
--- a/storage/framework/core/collections/src/index.ts
+++ b/storage/framework/core/collections/src/index.ts
@@ -1,3 +1,1 @@
-// Avoid ts-collect 0.4.1 and 0.4.2: their published dist is unparseable, so an
-// import here took the whole test suite down. Fixed in 0.4.3.
 export { collect } from 'ts-collect'


### PR DESCRIPTION
ts-collect 0.4.3 is published and verified working — its dist imports cleanly and `collect()` behaves (the 0.4.1/0.4.2 dists were tree-shaken to an empty export stub by a `sideEffects: false` + Bun bundler interaction, fixed in stacksjs/ts-collect@a1e4f94). We already depend on `^0.4.3` since ef73a02, so the warning comment no longer applies.

ts-collect also gained a prepublish smoke test (stacksjs/ts-collect@750c4cd) that imports the built dist and exercises it before publishing, so an unimportable dist can't reach npm again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)