### PR TITLE
fix(browser-extension): make the scaffolded safari app compile and build on real toolchains

### DIFF
--- a/storage/framework/core/browser-extension/safari-template/__APP_NAME__ Extension/SafariWebExtensionHandler.swift
+++ b/storage/framework/core/browser-extension/safari-template/__APP_NAME__ Extension/SafariWebExtensionHandler.swift
@@ -21,7 +21,7 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
 
         let response = NSExtensionItem()
         if #available(macOS 15.4, *) {
-            response.userInfo = [SFExtensionResponseKey: ["Response to": message]]
+            response.userInfo = [SFExtensionMessageKey: ["Response to": message]]
         }
         else {
             response.userInfo = ["message": ["Response to": message]]

--- a/storage/framework/core/browser-extension/safari-template/__APP_NAME__/ContentView.swift
+++ b/storage/framework/core/browser-extension/safari-template/__APP_NAME__/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             Button("Open Safari Extension Settings…") {
-                SFSafariApplication.showPreferencesForExtension(with: extensionBundleIdentifier) { error in
+                SFSafariApplication.showPreferencesForExtension(withIdentifier: extensionBundleIdentifier) { error in
                     if let error {
                         NSLog("Failed to open Safari extension settings: \(error.localizedDescription)")
                     }

--- a/storage/framework/core/browser-extension/src/safari.ts
+++ b/storage/framework/core/browser-extension/src/safari.ts
@@ -257,16 +257,20 @@ export async function buildSafariApp(config: ExtensionConfig, options: SafariApp
   const configuration = options.release ? 'Release' : 'Debug'
   const derivedData = join(dir, 'build')
 
-  // xcodebuild needs full Xcode, not just the Command Line Tools.
-  const developerDir = (await Bun.$`xcode-select -p`.text()).trim()
-  if (!developerDir.includes('Xcode.app')) {
+  // xcodebuild needs full Xcode, not just the Command Line Tools. DEVELOPER_DIR
+  // overrides xcode-select (e.g. /Applications/Xcode-beta.app/Contents/Developer).
+  const developerDir = (process.env.DEVELOPER_DIR ?? (await Bun.$`xcode-select -p`.text()).trim()).replace(/\/$/, '')
+  if (!developerDir.includes('.app/Contents/Developer')) {
     console.error(`[browser-extension] full Xcode is required to build the app (active developer directory: ${developerDir}).`)
     console.error('Install Xcode, then: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer')
+    console.error('or point DEVELOPER_DIR at any Xcode toolchain (betas included) for this shell.')
     console.error(`The extension payload is built and synced at ${resources}`)
     return { resources }
   }
 
-  const signing = options.signed ? [] : ['CODE_SIGNING_ALLOWED=NO']
+  // Signed builds let Xcode fetch or create provisioning profiles and
+  // certificates for the Apple ID added in Xcode → Settings → Accounts.
+  const signing = options.signed ? ['-allowProvisioningUpdates'] : ['CODE_SIGNING_ALLOWED=NO']
   await Bun.$`xcodebuild -project ${join(dir, `${appName}.xcodeproj`)} -scheme ${appName} -configuration ${configuration} -derivedDataPath ${derivedData} ${signing} build`
 
   return { appPath: join(derivedData, 'Build', 'Products', configuration, `${appName}.app`), resources }


### PR DESCRIPTION
Follow-up to #2008 — the first real `xcodebuild` compile of a scaffolded app surfaced two invalid SafariServices references in the template, plus three toolchain issues in `buildSafariApp` (all verified against the very-good-adblock reference project, which had the same latent bugs since it had never been compiled):

**Template (tokenized copies of the reference project's Swift):**
- `SafariWebExtensionHandler.swift`: `SFExtensionResponseKey` does not exist in the SafariServices SDK — the response `userInfo` key is `SFExtensionMessageKey` (same key as the inbound message, per Apple's template).
- `ContentView.swift`: `SFSafariApplication.showPreferencesForExtension(with:)` → the Swift-imported selector is `showPreferencesForExtension(withIdentifier:completionHandler:)`.

**`buildSafariApp`:**
- Honors `DEVELOPER_DIR` (e.g. `/Applications/Xcode-beta.app/Contents/Developer`) instead of only `xcode-select -p`.
- The full-Xcode check accepts any `.app/Contents/Developer` toolchain path (beta app bundles are `Xcode-beta.app`, not `Xcode.app`).
- Signed builds pass `-allowProvisioningUpdates` so Xcode can create/fetch provisioning profiles and certificates on the first run.

Verified end-to-end with Xcode 27 beta + a paid developer team: `** BUILD SUCCEEDED **`, `codesign -dv` shows the team certificate on both the app and the appex. Safari tests (16) still pass; pickier clean.