### PR TITLE
fix(payments): align the stripe apiVersion literals with the vendored SDK

### DIFF
--- a/storage/framework/core/orm/src/traits/billable.ts
+++ b/storage/framework/core/orm/src/traits/billable.ts
@@ -328,5 +328,5 @@ async function getStripe(): Promise<Stripe> {
   const secret = (globalThis as { process?: { env?: { STRIPE_SECRET_KEY?: string } } }).process?.env?.STRIPE_SECRET_KEY
   if (!secret) throw new Error('Stripe Connect: STRIPE_SECRET_KEY not configured')
   const StripeCtor = (await import('stripe')).default
-  return new StripeCtor(secret, { apiVersion: '2026-03-25.dahlia' })
+  return new StripeCtor(secret, { apiVersion: '2026-06-24.dahlia' })
 }

--- a/storage/framework/core/payments/src/drivers/stripe.ts
+++ b/storage/framework/core/payments/src/drivers/stripe.ts
@@ -39,7 +39,7 @@ export const stripe: Stripe = new Proxy({} as Stripe, {
       // pantry-vendored Stripe SDK types are compiled against — bumping
       // it here without bumping the SDK would mean responses include
       // fields the SDK doesn't know about. Update both at once.
-      const apiVersion: Stripe.LatestApiVersion = '2026-03-25.dahlia'
+      const apiVersion: Stripe.LatestApiVersion = '2026-06-24.dahlia'
       const configuredVersion = services?.stripe?.apiVersion
       if (configuredVersion && configuredVersion !== apiVersion)
         throw new Error(`Stripe API version ${configuredVersion} does not match the installed SDK version ${apiVersion}`)


### PR DESCRIPTION
`bun run typecheck` (`tsc --build tsconfig.framework.json`) has been failing on main — including on every recent PR — with:

```
storage/framework/core/payments/src/drivers/stripe.ts(42,13): error TS2322: Type '"2026-03-25.dahlia"' is not assignable to type '"2026-06-24.dahlia"'.
storage/framework/core/orm/src/traits/billable.ts(331,35): error TS2322: Type '"2026-03-25.dahlia"' is not assignable to type '"2026-06-24.dahlia"'.
```

The vendored `stripe` package is 22.3.0, which pins API version `2026-06-24.dahlia` (`stripe/esm/apiVersion.js`), but the two hardcoded literals still said `2026-03-25.dahlia`. Per the code comment in `stripe.ts` ("Update both at once"), the SDK was already bumped — this completes the pair.

Side effect of the red typecheck: the `deploy` and `publish-commit` jobs (`needs: [lint, typecheck, test]`) have been getting skipped on main as well.

Left for review rather than auto-merged since this area is actively moving (workspace catalog adoption).