### PR TITLE
fix(logging): stop rendering a stray "undefined" for missing log args (#2047)

### DIFF
--- a/storage/framework/core/logging/src/index.ts
+++ b/storage/framework/core/logging/src/index.ts
@@ -287,17 +287,24 @@ async function getLogger(): Promise<Logger> {
   return _logger!
 }
 
-// Helper function to format message for logging, including request context
-function formatMessage(...args: unknown[]): string {
+// Helper function to format message for logging, including request context.
+// Exported for direct unit testing of arg handling (stacksjs/stacks#2047).
+export function formatMessage(...args: unknown[]): string {
   // Errors (bare or nested in object args) need normalizing first —
   // `JSON.stringify(new Error())` is `{}` (stacksjs/stacks#1956).
-  const base = args.map((arg) => {
-    if (arg instanceof Error)
-      return renderNormalizedError(normalizeError(arg))
-    if (typeof arg === 'object' && arg !== null)
-      return JSON.stringify(normalizeContextValue(arg), null, 2)
-    return String(arg)
-  }).join(' ')
+  const base = args
+    // Drop `undefined` args so a call with a missing trailing context/format
+    // arg — e.g. `log.warn(`... database "${name}"`, ctx)` where `ctx` is
+    // undefined — doesn't leave a stray " undefined" at the end of the line
+    // (stacksjs/stacks#2047). `null` is kept: it's usually a deliberate value.
+    .filter(arg => arg !== undefined)
+    .map((arg) => {
+      if (arg instanceof Error)
+        return renderNormalizedError(normalizeError(arg))
+      if (typeof arg === 'object' && arg !== null)
+        return JSON.stringify(normalizeContextValue(arg), null, 2)
+      return String(arg)
+    }).join(' ')
 
   // Prepend request ID if available
   const ctx = logContextStorage.getStore()

--- a/storage/framework/core/logging/tests/logging.test.ts
+++ b/storage/framework/core/logging/tests/logging.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from 'bun:test'
-import { log, dump, dd, withLogContext, getLogContext } from '../src/index'
+import { log, dump, dd, withLogContext, getLogContext, formatMessage } from '../src/index'
+
+// A missing trailing context/format arg used to render as a stray
+// " undefined" at the end of a log line, e.g.
+//   WARN Could not auto-create database "bughq": ... create database undefined
+// (stacksjs/stacks#2047).
+describe('formatMessage - drops undefined args (stacksjs/stacks#2047)', () => {
+  it('drops a trailing undefined arg instead of appending " undefined"', () => {
+    expect(formatMessage('permission denied to create database', undefined)).toBe('permission denied to create database')
+  })
+
+  it('drops undefined regardless of position', () => {
+    expect(formatMessage('a', undefined, 'b')).toBe('a b')
+  })
+
+  it('renders a lone undefined as an empty string, not "undefined"', () => {
+    expect(formatMessage(undefined)).toBe('')
+  })
+
+  it('keeps a normal multi-arg message intact', () => {
+    expect(formatMessage('hello', 'world', 123)).toBe('hello world 123')
+  })
+
+  it('keeps null (a deliberate value) rather than dropping it', () => {
+    expect(formatMessage('value is', null)).toBe('value is null')
+  })
+})
 
 describe('@stacksjs/logging', () => {
   describe('log.info()', () => {


### PR DESCRIPTION
## Problem (#2047, Bug 2)

`formatMessage` mapped every arg through `String(arg)`, so a log call with a missing trailing context/format arg (`log.warn(msg, ctx)` where `ctx` is `undefined`) left a literal `" undefined"` at the end of the line:

```
WARN Could not auto-create database "bughq": permission denied to create database undefined
WARN This migration includes 7 potentially destructive changes: undefined
  • drop column "users"."two_factor_secret" (column data lost) undefined
```

## Fix

Filter `undefined` args before formatting. `null` is kept (usually a deliberate value). `formatMessage` is now exported so arg handling is unit-testable.

## Tests

5 new cases: trailing undefined dropped, undefined dropped regardless of position, lone undefined renders as empty string, normal multi-arg messages intact, null preserved. Logging suite: 81 pass / 0 fail. Pickier clean.

Part of #2047. The env half (silent ciphertext passthrough) was addressed by #2049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)