### PR TITLE
test(security): cover untested update-channel and envelope invariants (#2061, #2062)

### DIFF
--- a/storage/framework/core/desktop/tests/invites-updater.test.ts
+++ b/storage/framework/core/desktop/tests/invites-updater.test.ts
@@ -3,7 +3,7 @@ import { createHash, generateKeyPairSync, sign } from 'node:crypto'
 import { readFile, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
-import { checkForDesktopUpdate, compareVersions, sendDesktopInvites, stageDesktopUpdate, updateManifestPayload } from '../src/index'
+import { checkForDesktopUpdate, compareVersions, sendDesktopInvites, stageDesktopUpdate, updateManifestPayload, validateUpdateManifest } from '../src/index'
 
 const temporaryPaths: string[] = []
 const signingKeys = generateKeyPairSync('ed25519')
@@ -94,5 +94,71 @@ describe('desktop invites and updates', () => {
     const modifiedFetcher = async () => Response.json({ ...manifest, version: '9.0.0' })
     await expect(checkForDesktopUpdate({ currentVersion: '1.0.0', manifestUrl: 'https://releases.example.com/stable.json', fetcher: modifiedFetcher, trustedKeys }))
       .rejects.toThrow('signature verification failed')
+  })
+})
+
+// Security controls on the update path that had no coverage (stacksjs/stacks#2062):
+// transport, downgrade, integrity, and signing-key validation are what make an
+// update channel safe once real signing identities exist.
+describe('desktop update security controls', () => {
+  const stableUrl = 'https://releases.example.com/stable.json'
+
+  it('requires HTTPS for the manifest URL outside loopback', async () => {
+    await expect(checkForDesktopUpdate({
+      currentVersion: '1.0.0',
+      manifestUrl: 'http://releases.example.com/stable.json',
+      trustedKeys,
+      fetcher: async () => Response.json(signedManifest()),
+    })).rejects.toThrow('HTTPS')
+  })
+
+  it('requires HTTPS for the download URL outside loopback', async () => {
+    const manifest = signedManifest({ version: '2.0.0', url: 'http://releases.example.com/app.bin' })
+    await expect(stageDesktopUpdate(manifest, path.join(tmpdir(), 'never-written.bin'), async () => new Response(new Uint8Array()), trustedKeys))
+      .rejects.toThrow('HTTPS')
+  })
+
+  it('does not offer downgrades or equal versions', async () => {
+    const older = signedManifest({ version: '1.0.0' })
+    expect(await checkForDesktopUpdate({ currentVersion: '1.2.3', manifestUrl: stableUrl, trustedKeys, fetcher: async () => Response.json(older) })).toBeNull()
+    const equal = signedManifest({ version: '1.2.3' })
+    expect(await checkForDesktopUpdate({ currentVersion: '1.2.3', manifestUrl: stableUrl, trustedKeys, fetcher: async () => Response.json(equal) })).toBeNull()
+  })
+
+  it('rejects a size mismatch even when the checksum matches the delivered bytes', async () => {
+    const payload = new TextEncoder().encode('abc')
+    const sha256 = createHash('sha256').update(payload).digest('hex')
+    const manifest = signedManifest({ version: '2.0.0', url: 'https://releases.example.com/app.bin', sha256, size: payload.byteLength + 1 })
+    const directory = path.join(tmpdir(), `desktop-update-${crypto.randomUUID()}`)
+    temporaryPaths.push(directory)
+    await expect(stageDesktopUpdate(manifest, path.join(directory, 'u.bin'), async () => new Response(payload), trustedKeys))
+      .rejects.toThrow('size mismatch')
+  })
+
+  it('refuses to stage without trusted signing keys', async () => {
+    const manifest = signedManifest({ version: '2.0.0' })
+    await expect(stageDesktopUpdate(manifest, path.join(tmpdir(), 'never-written.bin'), async () => new Response(new Uint8Array())))
+      .rejects.toThrow('requires trusted signing keys')
+  })
+
+  it('rejects a signing key that is not ed25519-public: encoded', async () => {
+    const rawKey = signingKeys.publicKey.export({ format: 'der', type: 'spki' }).toString('base64url')
+    await expect(checkForDesktopUpdate({ currentVersion: '1.0.0', manifestUrl: stableUrl, trustedKeys: { release: rawKey }, fetcher: async () => Response.json(signedManifest()) }))
+      .rejects.toThrow('invalid encoding')
+  })
+
+  it('rejects a syntactically valid signature of the wrong length', async () => {
+    const manifest = signedManifest()
+    manifest.signature = Buffer.from(new Uint8Array(32)).toString('base64url') // canonical base64url, but not 64 bytes
+    await expect(checkForDesktopUpdate({ currentVersion: '1.0.0', manifestUrl: stableUrl, trustedKeys, fetcher: async () => Response.json(manifest) }))
+      .rejects.toThrow('signature verification failed')
+  })
+
+  it('enforces manifest schema before trusting any field', () => {
+    expect(() => validateUpdateManifest({ ...signedManifest(), sha256: 'not-a-hash' })).toThrow('SHA-256')
+    expect(() => validateUpdateManifest({ ...signedManifest(), size: -1 })).toThrow('non-negative')
+    expect(() => validateUpdateManifest({ ...signedManifest(), sourceRevision: 'short' })).toThrow('source revision')
+    expect(() => validateUpdateManifest({ ...signedManifest(), platform: 'solaris' })).toThrow('platform')
+    expect(() => validateUpdateManifest({ ...signedManifest(), architecture: 'x86 64' })).toThrow('architecture')
   })
 })

--- a/storage/framework/core/env/tests/crypto.test.ts
+++ b/storage/framework/core/env/tests/crypto.test.ts
@@ -287,6 +287,26 @@ describe('Crypto - Versioned Envelope Security', () => {
     expect(() => decryptValue(value, keys.privateKey)).toThrow('authentication or format error')
   })
 
+  it('enforces canonical base64url and exact component lengths', () => {
+    const keys = generateKeypair()
+    const encrypted = encryptValue('secret', keys.publicKey)
+    const open = () => JSON.parse(Buffer.from(encrypted.slice('encrypted:v2:'.length), 'base64url').toString('utf8'))
+    const reseal = (envelope: Record<string, unknown>) => `encrypted:v2:${Buffer.from(JSON.stringify(envelope)).toString('base64url')}`
+
+    // Non-canonical (padded) base64url is rejected, closing malleability.
+    const padded = open()
+    padded.salt = `${padded.salt}=`
+    expect(() => decryptValue(reseal(padded), keys.privateKey)).toThrow('authentication or format error')
+
+    // Fixed-width components (salt=16, nonce=12, tag=16) reject a short but
+    // otherwise canonical value, so a truncated field can't slip through.
+    for (const field of ['salt', 'nonce', 'tag']) {
+      const short = open()
+      short[field] = Buffer.from('short').toString('base64url')
+      expect(() => decryptValue(reseal(short), keys.privateKey)).toThrow('authentication or format error')
+    }
+  })
+
   it('reads and migrates legacy ciphertext but never writes it', () => {
     const legacyPrivate = TEST_PRIVATE_KEY
     const legacyPublic = createHash('sha256').update(Buffer.from(legacyPrivate, 'hex')).digest()


### PR DESCRIPTION
Both features sit behind security gates (#2061 envelope v2 review, #2062 desktop signing provisioning), and both had real coverage holes in security-critical paths. Test-only; no runtime changes.

## Desktop updater (#2062)

The transport/integrity controls that make an update channel safe once real signing identities exist had **no** tests. Added:
- HTTPS enforcement on the **manifest URL** and the **download URL** (loopback still allowed)
- **Downgrade** and equal-version rejection (returns `null`)
- **Size mismatch** rejected independently of the checksum
- Staging **without trusted keys** is refused
- Signing key lacking the `ed25519-public:` encoding is rejected
- A canonical-but-**wrong-length signature** (32 bytes) fails verification
- `validateUpdateManifest` schema checks (sha256, size, sourceRevision, platform, architecture)

## Envelope v2 (#2061)

Locks the canonical-base64url and fixed-width invariants directly: a padded field and a short `salt`/`nonce`/`tag` are each rejected with the generic failure, closing malleability and truncation. Complements the existing per-field tamper / wrong-recipient / legacy-migration tests.

## Verification

Desktop suite 13 pass / 0 fail, env crypto suite 27 pass / 0 fail, pickier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)