### PR TITLE
fix(socials): resolve bluesky driver typecheck failures

### DIFF
--- a/storage/framework/core/socials/src/drivers/bluesky.ts
+++ b/storage/framework/core/socials/src/drivers/bluesky.ts
@@ -77,9 +77,11 @@ export function detectFacetCandidates(text: string): FacetCandidate[] {
 
   const tagPattern = /(^|\s)(#[A-Za-z0-9_]+)/g
   for (const match of text.matchAll(tagPattern)) {
+    const prefix = match[1]
     const tag = match[2]
+    if (prefix === undefined || tag === undefined) continue
     if (/^#\d+$/.test(tag)) continue
-    const charStart = (match.index ?? 0) + match[1].length
+    const charStart = (match.index ?? 0) + prefix.length
     const byteStart = byteLength(text.slice(0, charStart))
     const byteEnd = byteStart + byteLength(tag)
     if (insideLink(byteStart, byteEnd)) continue
@@ -89,8 +91,10 @@ export function detectFacetCandidates(text: string): FacetCandidate[] {
   // Handles are domain-shaped (user.bsky.social), so require a dot.
   const mentionPattern = /(^|\s)(@[a-z0-9][a-z0-9.-]*\.[a-z]{2,})/gi
   for (const match of text.matchAll(mentionPattern)) {
+    const prefix = match[1]
     const handle = match[2]
-    const charStart = (match.index ?? 0) + match[1].length
+    if (prefix === undefined || handle === undefined) continue
+    const charStart = (match.index ?? 0) + prefix.length
     const byteStart = byteLength(text.slice(0, charStart))
     const byteEnd = byteStart + byteLength(handle)
     if (insideLink(byteStart, byteEnd)) continue
@@ -361,7 +365,11 @@ export class BlueskyPublishingDriver implements SocialPublishingDriver {
           'content-type': mimeType,
           'authorization': `Bearer ${identity.accessToken}`,
         },
-        body: bytes,
+        // Copy into a fresh ArrayBuffer-backed array: the parameter is typed
+        // Uint8Array<ArrayBufferLike>, which the fetch body type (ArrayBuffer-
+        // backed views only) rejects; `new Uint8Array(bytes)` is Uint8Array<
+        // ArrayBuffer>. content-type is carried by the explicit header above.
+        body: new Uint8Array(bytes),
       },
     )
 


### PR DESCRIPTION
`bun run typecheck` (`tsc --build tsconfig.framework.json`) was red on `main` after #2072, all in the Bluesky driver:

- **Facet detection** read `match[1]` / `match[2]` from `matchAll` directly; under strict mode those capture groups are `string | undefined` (TS2345/TS2532/TS18048 on lines 81-97). Bind the prefix and tag/handle groups and narrow them before use.
- **`uploadBlob`** passed a bare `Uint8Array` as the fetch body (TS2322, line 364); it is now typed `Uint8Array<ArrayBufferLike>`, which the fetch body type (ArrayBuffer-backed views only) rejects. Copy into `new Uint8Array(bytes)` (`Uint8Array<ArrayBuffer>`); the explicit `content-type` header is unchanged.

Behavior-preserving. `bluesky.ts` typechecks clean; socials suite 29 pass; pickier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)