### PR TITLE
fix(migrate): stop proposing to drop trait-managed columns (#2075)

### DIFF
--- a/storage/framework/core/database/src/auth-tables.ts
+++ b/storage/framework/core/database/src/auth-tables.ts
@@ -96,7 +96,9 @@ export function usersStripeIdSql(): string {
  * password_changed_at, two_factor_secret, two_factor_enabled,
  * stripe_id), each independently try/catch-swallowed so one
  * already-existing column (or a not-yet-existing `users` table) never
- * skips the others. Exported so `buddy migrate`/`migrate:fresh` can
+ * skips the others. The schema-diff guard mirrors this set in
+ * `managed-columns.ts` (`USERS_GUARANTEED_COLUMNS`) so the differ never
+ * proposes dropping them (stacksjs/stacks#2075) — keep the two in sync. Exported so `buddy migrate`/`migrate:fresh` can
  * call it a second time after the numbered model migrations run — see
  * the call site in {@link migrateAuthTables} for why a single call
  * isn't enough.

--- a/storage/framework/core/database/src/index.ts
+++ b/storage/framework/core/database/src/index.ts
@@ -109,6 +109,9 @@ export * from './auth-tables'
 // uuid column guarantee for `useUuid` models (stacksjs/status#1 Phase 9)
 export * from './uuid-columns'
 
+// Schema-diff guards so trait-managed columns aren't proposed for dropping (stacksjs/stacks#2075)
+export * from './managed-columns'
+
 // Notification tables migration (stacksjs/stacks#1937)
 export { migrateNotificationTables } from './notification-tables'
 

--- a/storage/framework/core/database/src/managed-columns.ts
+++ b/storage/framework/core/database/src/managed-columns.ts
@@ -1,0 +1,116 @@
+/**
+ * Schema-diff guards for framework-managed columns (stacksjs/stacks#2075).
+ *
+ * Some columns are added at runtime by the framework's guarantee-ALTERs
+ * (`ensureUsersAuthColumns` for `users.two_factor_*` / `email_verified_at` /
+ * `password_changed_at` / `stripe_id`, `ensureUuidColumns` for `uuid` on every
+ * `useUuid` table) rather than declared in a model's `attributes`. The
+ * model-first schema differ (bun-query-builder) builds each table's expected
+ * column set from `attributes` only, so those columns look like "in the DB but
+ * not in the model" and get proposed for dropping on EVERY `buddy migrate` —
+ * including the exact auth/billing columns the login (`getTwoFactorState`) and
+ * checkout flows read. That never converges to "nothing to migrate", and one
+ * careless `y` silently drops the columns and breaks auth.
+ *
+ * These helpers recognize framework-managed columns and drop the offending
+ * `drop_column` operations (and their generated SQL) from the destructive side
+ * of the diff, so the differ stops fighting the guarantee-ALTERs. Nothing else
+ * about the diff changes; adds, renames, and non-managed drops are untouched.
+ */
+
+import type { MigrationOperation } from '@stacksjs/query-builder'
+
+/**
+ * The `users` columns the framework guarantees via `ensureUsersAuthColumns`'s
+ * defensive ALTERs (auth-tables.ts) — created OUTSIDE any model's `attributes`.
+ * Kept here (a dependency-light module) so the differ guard doesn't drag in the
+ * ORM/query-builder graph. Keep in sync with `ensureUsersAuthColumns`.
+ */
+export const USERS_GUARANTEED_COLUMNS: readonly string[] = [
+  'email_verified_at',
+  'password_changed_at',
+  'two_factor_secret',
+  'two_factor_enabled',
+  'two_factor_last_used_step',
+  'stripe_id',
+]
+
+/** A minimal view of a migration operation — all these helpers need. */
+type ColumnOp = Pick<MigrationOperation, 'kind' | 'table' | 'column'>
+
+/**
+ * Resolve `table -> protected column names`: the `users` auth/billing columns
+ * plus `uuid` on every table backing a `useUuid` model. `findUuidTables` is
+ * lazy-imported so this module stays free of the model-walking ORM graph until
+ * actually resolving. Best-effort on the uuid side — if that walk fails we still
+ * guard the hardcoded `users` columns rather than losing the protection.
+ */
+export async function frameworkManagedColumns(): Promise<Map<string, Set<string>>> {
+  const managed = new Map<string, Set<string>>()
+  managed.set('users', new Set(USERS_GUARANTEED_COLUMNS))
+
+  try {
+    const { findUuidTables } = await import('./uuid-columns')
+    for (const table of await findUuidTables()) {
+      const columns = managed.get(table) ?? new Set<string>()
+      columns.add('uuid')
+      managed.set(table, columns)
+    }
+  }
+  catch {
+    // Model-file resolution failed; keep the users guard rather than none.
+  }
+
+  return managed
+}
+
+/** True when `op` would drop a column the framework guarantees at runtime. */
+export function isManagedColumnDrop(op: ColumnOp, managed: Map<string, Set<string>>): boolean {
+  return op.kind === 'drop_column' && op.column != null && (managed.get(op.table)?.has(op.column) ?? false)
+}
+
+/** Return `operations` without any drop of a framework-managed column. */
+export function withoutManagedColumnDrops<T extends ColumnOp>(operations: T[], managed: Map<string, Set<string>>): T[] {
+  return operations.filter(op => !isManagedColumnDrop(op, managed))
+}
+
+function normalizeSql(sql: string): string {
+  return sql.trim().replace(/\s+/g, ' ').replace(/;+\s*$/, '')
+}
+
+// `ALTER TABLE <t> DROP COLUMN [IF EXISTS] <c>` for postgres / mysql / sqlite>=3.35.
+const DROP_COLUMN_RE = /ALTER\s+TABLE\s+["'`]?(\w+)["'`]?\s+DROP\s+COLUMN\s+(?:IF\s+EXISTS\s+)?["'`]?(\w+)["'`]?/i
+
+/**
+ * Remove generated SQL statements that drop a framework-managed column, so the
+ * drop is never written to a migration file. Catches both the direct
+ * `ALTER TABLE ... DROP COLUMN` form and, by matching the structured
+ * operations' own `sql`, the SQLite table-rebuild form (which drops a column by
+ * recreating the table without it). Pass `operations` when available for the
+ * rebuild case; the regex alone still covers the common direct form.
+ */
+export function withoutManagedColumnDropSql(
+  statements: string[],
+  managed: Map<string, Set<string>>,
+  operations: MigrationOperation[] = [],
+): { statements: string[], removed: string[] } {
+  const protectedSql = new Set(
+    operations.filter(op => isManagedColumnDrop(op, managed)).map(op => normalizeSql(op.sql)),
+  )
+  const removed: string[] = []
+
+  const kept = statements.filter((statement) => {
+    if (protectedSql.has(normalizeSql(statement))) {
+      removed.push(statement)
+      return false
+    }
+    const match = statement.match(DROP_COLUMN_RE)
+    if (match?.[1] && match[2] && (managed.get(match[1])?.has(match[2]) ?? false)) {
+      removed.push(statement)
+      return false
+    }
+    return true
+  })
+
+  return { statements: kept, removed }
+}

--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -34,6 +34,7 @@ import {
   setConfig,
 } from '@stacksjs/query-builder'
 import { db } from './utils'
+import { frameworkManagedColumns, withoutManagedColumnDrops, withoutManagedColumnDropSql } from './managed-columns'
 import { acquireMigrationLock } from './migration-lock'
 
 // Use environment variables via @stacksjs/env for proper type coercion
@@ -954,7 +955,13 @@ export async function previewPendingMigrations(options: GenerateMigrationsOption
       return []
     const { applyRenames, fromDb } = resolveGenerateOptions(options)
     const result = await qbGenerateMigration(modelsDir, { dialect: getQbDialect(), dryRun: true, applyRenames, fromDb })
-    return result.operations ?? []
+    const operations = result.operations ?? []
+    // Framework-managed columns (trait ALTERs, not model `attributes`) are not
+    // real strays — don't surface them as destructive drops in the confirmation
+    // gate, or migrate never shows "nothing to migrate" (stacksjs/stacks#2075).
+    if (!operations.some((op: MigrationOperation) => op.kind === 'drop_column'))
+      return operations
+    return withoutManagedColumnDrops(operations, await frameworkManagedColumns())
   }
   catch (error) {
     // A preview must never block the migrate flow on its own failure — the
@@ -1045,8 +1052,20 @@ export async function generateMigrations(options: GenerateMigrationsOptions = {}
     // the single place that ever writes a migration file.
     const result = await qbGenerateMigration(modelsDir, { dialect: getQbDialect(), dryRun: true, applyRenames, fromDb })
 
+    // Never write a migration that drops a framework-managed column: those are
+    // guaranteed by runtime ALTERs (ensureUsersAuthColumns / ensureUuidColumns),
+    // not the model, so the differ re-proposes dropping them every run and a
+    // stray `y` destroys auth/billing data (stacksjs/stacks#2075).
+    let sqlStatements = result.sqlStatements ?? []
+    if (result.hasChanges && sqlStatements.length > 0) {
+      const filtered = withoutManagedColumnDropSql(sqlStatements, await frameworkManagedColumns(), result.operations ?? [])
+      if (filtered.removed.length > 0)
+        log.debug(`[migration] Skipped ${filtered.removed.length} generated drop(s) of framework-managed column(s) (stacksjs/stacks#2075)`)
+      sqlStatements = filtered.statements
+    }
+
     if (result.hasChanges) {
-      const written = persistGeneratedMigrations(result.sqlStatements ?? [])
+      const written = persistGeneratedMigrations(sqlStatements)
       // Only announce when we actually wrote files. `hasChanges` can be
       // true while `written === 0` if the qb diff restated statements
       // already covered by committed migrations — that's a no-op from

--- a/storage/framework/core/database/tests/managed-columns.test.ts
+++ b/storage/framework/core/database/tests/managed-columns.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test'
+import { USERS_GUARANTEED_COLUMNS, isManagedColumnDrop, withoutManagedColumnDropSql, withoutManagedColumnDrops } from '../src/managed-columns'
+
+// Regression coverage for stacksjs/stacks#2075: the model-first schema differ
+// proposes dropping trait-managed columns (useAuth 2FA, billable stripe_id,
+// useUuid) because they aren't in `attributes`. These guards keep those drops
+// out of both the destructive confirmation gate and the generated SQL.
+
+// `users` auth/billing columns + `uuid` on a useUuid-backed table, the same
+// shape frameworkManagedColumns() builds (without walking model files).
+const managed = new Map<string, Set<string>>([
+  ['users', new Set(USERS_GUARANTEED_COLUMNS)],
+  ['products', new Set(['uuid'])],
+])
+
+const op = (kind: string, table: string, column?: string, sql = ''): any => ({ kind, table, column, destructive: true, sql })
+
+describe('framework-managed column guards (#2075)', () => {
+  it('exposes the exact users columns the guarantee-ALTERs create', () => {
+    expect([...USERS_GUARANTEED_COLUMNS].sort()).toEqual([
+      'email_verified_at',
+      'password_changed_at',
+      'stripe_id',
+      'two_factor_enabled',
+      'two_factor_last_used_step',
+      'two_factor_secret',
+    ])
+  })
+
+  it('recognizes a managed column drop but not a user column drop', () => {
+    expect(isManagedColumnDrop(op('drop_column', 'users', 'two_factor_secret'), managed)).toBe(true)
+    expect(isManagedColumnDrop(op('drop_column', 'users', 'stripe_id'), managed)).toBe(true)
+    expect(isManagedColumnDrop(op('drop_column', 'products', 'uuid'), managed)).toBe(true)
+    // A genuine user column on a managed table is still droppable.
+    expect(isManagedColumnDrop(op('drop_column', 'users', 'nickname'), managed)).toBe(false)
+    // uuid on a table that doesn't declare useUuid is not protected.
+    expect(isManagedColumnDrop(op('drop_column', 'orders', 'uuid'), managed)).toBe(false)
+    // Non-drop operations are never touched.
+    expect(isManagedColumnDrop(op('add_column', 'users', 'two_factor_secret'), managed)).toBe(false)
+  })
+
+  it('strips managed drops from the operations list, keeping everything else', () => {
+    const operations = [
+      op('drop_column', 'users', 'two_factor_secret'),
+      op('drop_column', 'users', 'email_verified_at'),
+      op('drop_column', 'users', 'stripe_id'),
+      op('drop_column', 'products', 'uuid'),
+      op('drop_column', 'users', 'nickname'), // genuine drop — must survive
+      op('add_column', 'users', 'phone'),
+      op('rename_column', 'users', 'handle'),
+    ]
+    const kept = withoutManagedColumnDrops(operations, managed)
+    expect(kept.map(o => `${o.kind}:${o.table}.${o.column}`)).toEqual([
+      'drop_column:users.nickname',
+      'add_column:users.phone',
+      'rename_column:users.handle',
+    ])
+  })
+
+  it('strips the direct ALTER TABLE ... DROP COLUMN SQL across dialect quoting', () => {
+    const statements = [
+      'ALTER TABLE "users" DROP COLUMN "two_factor_secret"', // postgres
+      'ALTER TABLE `users` DROP COLUMN `stripe_id`', // mysql
+      'ALTER TABLE users DROP COLUMN IF EXISTS two_factor_enabled', // sqlite>=3.35
+      'ALTER TABLE users DROP COLUMN nickname', // genuine — keep
+      'ALTER TABLE "products" DROP COLUMN "uuid"',
+      'CREATE INDEX idx ON users (email)', // unrelated — keep
+    ]
+    const { statements: kept, removed } = withoutManagedColumnDropSql(statements, managed)
+    expect(removed).toHaveLength(4)
+    expect(kept).toEqual([
+      'ALTER TABLE users DROP COLUMN nickname',
+      'CREATE INDEX idx ON users (email)',
+    ])
+  })
+
+  it('strips the SQLite table-rebuild form by matching the operation sql', () => {
+    // SQLite drops a column by rebuilding the table without it; the statement
+    // has no "DROP COLUMN" to regex, so it's matched via the structured op sql.
+    const rebuild = 'CREATE TABLE users_new (id integer primary key, name text); INSERT INTO users_new SELECT id, name FROM users; DROP TABLE users; ALTER TABLE users_new RENAME TO users'
+    const statements = [rebuild, 'ALTER TABLE users DROP COLUMN nickname']
+    const operations = [op('drop_column', 'users', 'two_factor_secret', rebuild)]
+    const { statements: kept, removed } = withoutManagedColumnDropSql(statements, managed, operations)
+    expect(removed).toEqual([rebuild])
+    expect(kept).toEqual(['ALTER TABLE users DROP COLUMN nickname'])
+  })
+
+  it('is a no-op when nothing managed is being dropped', () => {
+    const statements = ['ALTER TABLE users DROP COLUMN nickname', 'ALTER TABLE users ADD COLUMN phone text']
+    const { statements: kept, removed } = withoutManagedColumnDropSql(statements, managed)
+    expect(removed).toEqual([])
+    expect(kept).toEqual(statements)
+  })
+})


### PR DESCRIPTION
## Problem

`buddy migrate`'s model-first diff builds each table's expected columns from the model's `attributes` only. Columns contributed by **traits** are created at runtime by guarantee-ALTERs, *outside* `attributes`:

- `ensureUsersAuthColumns` → `users.two_factor_secret`, `two_factor_enabled`, `two_factor_last_used_step`, `email_verified_at`, `password_changed_at`, `stripe_id`
- `ensureUuidColumns` → `uuid` on every `useUuid` table

So the differ sees them as "in the DB but not in the model" and proposes **dropping** them on every run - including the exact auth/billing columns login (`getTwoFactorState`) and checkout depend on. Migrate never converges to "nothing to migrate", and one careless `y` silently drops the columns and 500s the login flow. The differ actively fights the very guarantee-ALTERs that add them. Reproduces with the framework's own default `User` model.

## Fix

Exclude framework-managed columns from the **destructive side** of the diff (the issue's suggested alternative) - surgical, and leaves adds, renames, and genuine drops untouched.

- **`managed-columns.ts`** (new, dependency-light - `findUuidTables` lazy-imported so the guard doesn't drag in the ORM graph): `frameworkManagedColumns()` resolves `table -> guaranteed columns`, plus pure `withoutManagedColumnDrops` (operations) and `withoutManagedColumnDropSql` (generated SQL - matches both `ALTER TABLE ... DROP COLUMN` and the SQLite table-rebuild form via each operation's own `sql`).
- **`previewPendingMigrations`** filters managed drops so the confirmation gate stops showing phantom destructive changes (and migrate can reach a clean state).
- **`generateMigrations`** filters them from the written SQL, so a managed-column drop is never persisted to a migration file, on any dialect.

A genuine drop of a real user-declared attribute is unaffected - still gated and written as before.

## Tests

Hermetic unit coverage of the guards (6 cases): recognizes managed vs genuine drops, strips managed drops from the operations list, strips the direct `DROP COLUMN` SQL across postgres/mysql/sqlite quoting, strips the SQLite rebuild form via the operation `sql`, and no-ops when nothing managed is dropped.

Closes #2075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)