### PR TITLE
feat(docs): add internal documentation link checker to CI (#2056)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
           bun run protocol:craft:check
           bun run docs:buddy:check
           bun run docs:artifacts:check
+          bun run docs:links:check
 
       - name: Run protocol adapter
         env:

--- a/docs/guide/components/popover.md
+++ b/docs/guide/components/popover.md
@@ -173,4 +173,4 @@ import { ref } from '@stacksjs/stx'
 const panelOpen = ref<boolean>(false)
 ```
 
-Still have questions relating this component's usage? Contact us and we will help you out. In the meantime, if you are curious about the [`<Tabs />`](./tabs.md) component read more on the next page.
+Still have questions relating this component's usage? Contact us and we will help you out.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "docs:buddy:check": "bun scripts/docs/buddy-commands.ts --check",
     "docs:artifacts": "bun scripts/docs/generated-artifacts.ts --write",
     "docs:artifacts:check": "bun scripts/docs/generated-artifacts.ts --check",
+    "docs:links": "bun scripts/docs/links.ts",
+    "docs:links:check": "bun scripts/docs/links.ts --check",
     "protocol:sync": "bun scripts/protocol/sync-suite.ts --write",
     "protocol:check": "bun scripts/protocol/sync-suite.ts --check",
     "protocol:conformance": "bun scripts/protocol/run-conformance.ts",

--- a/scripts/docs/links.test.ts
+++ b/scripts/docs/links.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test'
+import { extractLinks, isSkippableLink, resolveCandidates } from './links'
+
+describe('docs link checker (stacksjs/stacks#2056)', () => {
+  describe('isSkippableLink', () => {
+    it('skips external, mail/tel, anchors, protocol-relative, and templated links', () => {
+      for (const target of ['https://x.com', 'http://x.com', 'mailto:a@b.c', 'tel:123', '#section', '//cdn.example.com/x', '{{ url }}', 'data:image/png;base64,AAAA', ''])
+        expect(isSkippableLink(target)).toBe(true)
+    })
+
+    it('does not skip internal relative or absolute links', () => {
+      for (const target of ['./foo.md', '../bar/baz.md', '/guide/intro', 'sibling.md'])
+        expect(isSkippableLink(target)).toBe(false)
+    })
+  })
+
+  describe('extractLinks', () => {
+    it('extracts inline links with 1-based line numbers', () => {
+      const md = 'intro\n\nsee [a](./a.md) and [b](../b.md)\n'
+      expect(extractLinks(md)).toEqual([
+        { target: './a.md', line: 3 },
+        { target: '../b.md', line: 3 },
+      ])
+    })
+
+    it('strips an optional link title', () => {
+      expect(extractLinks('[x](/guide/x "The X page")')).toEqual([{ target: '/guide/x', line: 1 }])
+    })
+
+    it('ignores links inside fenced code blocks', () => {
+      const md = '```md\n[x](./nope.md)\n```\n[y](./yes.md)\n'
+      expect(extractLinks(md)).toEqual([{ target: './yes.md', line: 4 }])
+    })
+
+    it('ignores links inside inline code spans', () => {
+      expect(extractLinks('use `[x](./nope.md)` but link [y](./yes.md)')).toEqual([{ target: './yes.md', line: 1 }])
+    })
+
+    it('ignores links inside HTML comments while preserving line numbers', () => {
+      const md = 'line1\n<!-- ![x](./commented.png) -->\nreal [y](./y.md)\n'
+      expect(extractLinks(md)).toEqual([{ target: './y.md', line: 3 }])
+    })
+
+    it('handles a multi-line HTML comment', () => {
+      const md = '<!--\n[x](./a.md)\n-->\n[y](./b.md)\n'
+      expect(extractLinks(md)).toEqual([{ target: './b.md', line: 4 }])
+    })
+  })
+
+  describe('resolveCandidates', () => {
+    const docsRoot = '/docs'
+    const fileDir = '/docs/guide/components'
+
+    it('resolves a relative link against the file directory', () => {
+      expect(resolveCandidates('./tabs.md', fileDir, docsRoot)).toEqual(['/docs/guide/components/tabs.md'])
+    })
+
+    it('resolves an absolute link against the docs root', () => {
+      expect(resolveCandidates('/guide/intro.md', fileDir, docsRoot)).toEqual(['/docs/guide/intro.md'])
+    })
+
+    it('offers .md and index.md candidates for an extensionless (clean-URL) link', () => {
+      expect(resolveCandidates('../intro', fileDir, docsRoot)).toEqual([
+        '/docs/guide/intro',
+        '/docs/guide/intro.md',
+        '/docs/guide/intro/index.md',
+      ])
+    })
+
+    it('offers the .md source for an .html link', () => {
+      const candidates = resolveCandidates('./api.html', fileDir, docsRoot)
+      expect(candidates).toContain('/docs/guide/components/api.md')
+    })
+
+    it('strips the anchor before resolving', () => {
+      expect(resolveCandidates('./tabs.md#usage', fileDir, docsRoot)).toEqual(['/docs/guide/components/tabs.md'])
+    })
+
+    it('returns no candidates for a pure anchor', () => {
+      expect(resolveCandidates('#usage', fileDir, docsRoot)).toEqual([])
+    })
+  })
+})

--- a/scripts/docs/links.ts
+++ b/scripts/docs/links.ts
@@ -1,0 +1,142 @@
+/**
+ * Internal documentation link checker (stacksjs/stacks#2056).
+ *
+ * Docs links to other docs pages drift silently when a page is renamed or moved.
+ * This walks `docs/**` and verifies every internal markdown link resolves to a
+ * real target (handling VitePress clean-URL and `index.md` conventions), so CI
+ * can reject a broken cross-reference. External links, mail/tel, and same-page
+ * anchors are intentionally left alone.
+ *
+ * Usage: `bun scripts/docs/links.ts [--check]`
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+
+const root = resolve(import.meta.dir, '../..')
+const docsDir = resolve(root, 'docs')
+
+export interface BrokenDocLink {
+  file: string
+  line: number
+  target: string
+}
+
+const INLINE_LINK = /\[[^\]]*\]\(([^)]+)\)/g
+
+/** True for links this checker deliberately does not resolve on disk. */
+export function isSkippableLink(target: string): boolean {
+  return (
+    target === ''
+    || target.startsWith('#') // same-page anchor
+    || /^[a-z][\w+.-]*:/i.test(target) // http:, https:, mailto:, tel:, data:, etc.
+    || target.startsWith('//') // protocol-relative
+    || target.startsWith('{{') // template interpolation
+    || target.includes('<') // contains markup/placeholder
+  )
+}
+
+/** Extract inline-link targets with 1-based line numbers, skipping code. */
+export function extractLinks(content: string): Array<{ target: string, line: number }> {
+  const out: Array<{ target: string, line: number }> = []
+  // Blank out HTML comments (a commented-out `![](img)` is not a live link)
+  // while preserving newlines so reported line numbers stay accurate.
+  const withoutComments = content.replace(/<!--[\s\S]*?-->/g, match => match.replace(/[^\n]/g, ' '))
+  const lines = withoutComments.split('\n')
+  let inFence = false
+
+  for (let index = 0; index < lines.length; index++) {
+    const raw = lines[index]!
+    if (/^\s*(```|~~~)/.test(raw)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence)
+      continue
+
+    // Drop inline code spans so `[x](y)` inside backticks isn't treated as a link.
+    const line = raw.replace(/`[^`]*`/g, '')
+    for (const match of line.matchAll(INLINE_LINK)) {
+      let target = match[1]!.trim()
+      // Strip an optional link title: [text](/path "Title").
+      const space = target.search(/\s/)
+      if (space !== -1)
+        target = target.slice(0, space)
+      out.push({ target, line: index + 1 })
+    }
+  }
+
+  return out
+}
+
+/**
+ * On-disk paths a link could legitimately resolve to. Absolute (`/x`) links are
+ * rooted at `docsRoot`; relative links at the file's directory. Extensionless
+ * links also try `.md` and `index.md` (VitePress clean URLs), and `.html` links
+ * try their `.md` source.
+ */
+export function resolveCandidates(target: string, fileDir: string, docsRoot: string): string[] {
+  const clean = target.split('#')[0]!.split('?')[0]!
+  if (!clean)
+    return []
+
+  const base = clean.startsWith('/') ? join(docsRoot, clean.slice(1)) : resolve(fileDir, clean)
+  const candidates = [base]
+
+  if (!/\.\w+$/.test(clean))
+    candidates.push(`${base}.md`, join(base, 'index.md'))
+  else if (clean.endsWith('.html'))
+    candidates.push(base.replace(/\.html$/, '.md'), join(base.replace(/\.html$/, ''), 'index.md'))
+
+  return candidates
+}
+
+function walkMarkdown(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.'))
+        continue
+      files.push(...walkMarkdown(full))
+    }
+    else if (entry.name.endsWith('.md')) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+export function checkDocsLinks(docsRoot = docsDir): BrokenDocLink[] {
+  const broken: BrokenDocLink[] = []
+
+  for (const file of walkMarkdown(docsRoot)) {
+    const content = readFileSync(file, 'utf8')
+    for (const { target, line } of extractLinks(content)) {
+      if (isSkippableLink(target))
+        continue
+      const candidates = resolveCandidates(target, dirname(file), docsRoot)
+      if (candidates.length === 0)
+        continue
+      const resolvedOk = candidates.some(candidate => existsSync(candidate) && statSync(candidate).isFile())
+      if (!resolvedOk)
+        broken.push({ file: relative(docsRoot, file), line, target })
+    }
+  }
+
+  return broken
+}
+
+if (import.meta.main) {
+  const broken = checkDocsLinks()
+  if (broken.length === 0) {
+    console.log('✓ All internal documentation links resolve.')
+  }
+  else {
+    console.error(`✗ ${broken.length} broken internal documentation link(s):`)
+    for (const link of broken)
+      console.error(`  ${link.file}:${link.line} -> ${link.target}`)
+    if (process.argv.includes('--check'))
+      process.exit(1)
+  }
+}


### PR DESCRIPTION
Part of #2056 (generated-artifact / documentation freshness in CI) - specifically **criterion 4: "Internal links and selected snippets are tested."** The OpenAPI/declaration freshness (criterion 1) and command-drift (criterion 3, #2032) gates already exist; this adds the internal-link gate next to them.

## What

- **`scripts/docs/links.ts`** walks `docs/**`, extracts inline markdown links, and verifies each internal one resolves on disk. Handles VitePress clean-URL (`/guide/x` → `x.md`/`x/index.md`) and `.html`→`.md` conventions. Deliberately skips external / mail / tel links, same-page anchors, and links inside fenced code, inline code, and **HTML comments** (so a commented-out `![](img)` isn't a false positive). `--check` exits non-zero on any broken link.
- Wired as `docs:links` / `docs:links:check`; the check runs in the **protocol-conformance** CI job alongside `docs:buddy:check` and `docs:artifacts:check`.
- **14 unit tests** cover the pure parsing/resolution (code + comment skipping, titles, clean-URL and `.html` resolution, anchors).
- Fixed the one genuine broken link the checker surfaced: `popover.md` linked to a `./tabs.md` page that doesn't exist.

## Verification

`bun run docs:links:check` → `✓ All internal documentation links resolve.` (exit 0). Tests 14/0, pickier clean.

Pure filesystem-based, so it's unaffected by the local `@stacksjs/clapp` sibling-version quirk that stops `docs:buddy` from regenerating locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)