### PR TITLE
fix(queue): make setJobProgress a single percent contract (#1984)

### DIFF
--- a/storage/framework/core/queue/src/job-progress.ts
+++ b/storage/framework/core/queue/src/job-progress.ts
@@ -26,15 +26,29 @@ interface JobProgress {
 }
 
 /**
+ * Clamp a reported progress value to the `percent` contract (0-100).
+ * Non-finite input (NaN/Infinity) reports 0.
+ *
+ * `percent` is a percent, not a fraction: `50` is 50%, `12.5` is 12.5%.
+ * The previous implementation branched on the value (`v <= 1 ? v*100 : v`)
+ * to also accept fractions, which made `setJobProgress(id, 1)` — a caller
+ * meaning 1% — jump to 100%. Progress is single-contract now
+ * (stacksjs/stacks#1984).
+ */
+export function clampProgressPercent(percent: number): number {
+  return Number.isFinite(percent) ? Math.max(0, Math.min(100, percent)) : 0
+}
+
+/**
  * Update the progress of the running job. Workers call this from
  * inside their handler; the UI polls `getJobProgress(id)` to render
- * a progress bar.
+ * a progress bar. `percent` is 0-100 (a percent, not a 0-1 fraction).
  *
  * @example
  * ```ts
- * await job.progress(0.5, 'Halfway there')
+ * await setJobProgress(job.id, 50, 'Halfway there')
  * // … later
- * await job.progress(1.0, 'Done')
+ * await setJobProgress(job.id, 100, 'Done')
  * ```
  */
 export async function setJobProgress(
@@ -43,10 +57,9 @@ export async function setJobProgress(
   message?: string,
 ): Promise<void> {
   const { cache } = await import('@stacksjs/cache')
-  const clamped = Number.isFinite(percent) ? Math.max(0, Math.min(100, percent * (percent <= 1 ? 100 : 1))) : 0
   await cache.set(
     PROGRESS_KEY(jobId),
-    { percent: clamped, message, updatedAt: Date.now() } as JobProgress,
+    { percent: clampProgressPercent(percent), message, updatedAt: Date.now() } as JobProgress,
     TTL_SECONDS,
   )
 }

--- a/storage/framework/core/queue/tests/job-progress.test.ts
+++ b/storage/framework/core/queue/tests/job-progress.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test'
+import { clampProgressPercent } from '../src/job-progress'
+
+// stacksjs/stacks#1984: setJobProgress used a value-branching heuristic
+// (`v <= 1 ? v*100 : v`) to accept both fractions and percents, so a caller
+// meaning 1% — `setJobProgress(id, 1)` — jumped to 100%. Progress is now a
+// single contract: percent, 0-100.
+describe('setJobProgress percent contract (stacksjs/stacks#1984)', () => {
+  it('treats the value as a percent, not a fraction', () => {
+    expect(clampProgressPercent(1)).toBe(1) // the regression: was 100
+    expect(clampProgressPercent(50)).toBe(50)
+    expect(clampProgressPercent(12.5)).toBe(12.5) // sub-percent precision preserved
+    expect(clampProgressPercent(100)).toBe(100)
+  })
+
+  it('does not scale small values (no branching on the magnitude)', () => {
+    expect(clampProgressPercent(0)).toBe(0)
+    expect(clampProgressPercent(0.5)).toBe(0.5) // 0.5% under the percent contract, not 50%
+  })
+
+  it('clamps out-of-range values into [0, 100]', () => {
+    expect(clampProgressPercent(150)).toBe(100)
+    expect(clampProgressPercent(-5)).toBe(0)
+  })
+
+  it('reports 0 for non-finite input', () => {
+    expect(clampProgressPercent(Number.NaN)).toBe(0)
+    expect(clampProgressPercent(Number.POSITIVE_INFINITY)).toBe(0)
+    expect(clampProgressPercent(Number.NEGATIVE_INFINITY)).toBe(0)
+  })
+})


### PR DESCRIPTION
Addresses the `setJobProgress` item from #1984 (the last genuinely-open item in that tracker - most High/Medium items already landed in `fcd211023` / `0b34c3f09`).

## Problem

`setJobProgress` branched on the value to accept both fractions and percents:

```ts
percent * (percent <= 1 ? 100 : 1)
```

So a caller meaning **1%** - `setJobProgress(id, 1)` - reported **100%**.

## Contract decision (evidence-based)

The system is percent-based everywhere: the parameter is named `percent`, and the stored `JobProgress.percent` is documented *"0-100, float for sub-percent precision (e.g. 12.5%)"*. The only fraction signal was a JSDoc `@example` calling `job.progress(0.5)` - a method that **doesn't exist**. And `setJobProgress` has **zero callers**, so there's no back-compat risk.

So: percent (0-100), no branching.

## Fix

- Extracted `clampProgressPercent` (pure, unit-tested): clamp to `[0,100]`, non-finite → 0, no magnitude branching.
- `setJobProgress` uses it; corrected the JSDoc example to `setJobProgress(job.id, 50, …)`.

`1` → 1%, `12.5` → 12.5%, `0.5` → 0.5% (not 50%), `150` → 100, `NaN` → 0. 4 unit tests, pickier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)