### PR TITLE
feat(ai): add compact project context

### DIFF
--- a/.claude/skills/stacks-ai/SKILL.md
+++ b/.claude/skills/stacks-ai/SKILL.md
@@ -196,6 +196,30 @@ for await (const chunk of buddyProcessStreaming('Refactor this function', 'opena
 }
 ```
 
+## Compact Project Context
+
+Use the native context contract instead of sending dependency internals, lockfiles,
+or an arbitrary repository dump to a coding model:
+
+```bash
+buddy ai:context
+buddy ai:context --json
+buddy ai:context --json --output .stacks/ai-context.json
+buddy ai:context --max-chars 4000 --model claude-sonnet-4
+```
+
+Programmatic callers use `buildProjectContext(projectRoot, options)`. Existing
+`getRepoContext(projectRoot)` calls return its compact text payload. The contract
+is deterministic, reports a heuristic token estimate, and describes canonical
+Model-View-Action roles, application overrides, instruction files, scripts,
+dependency names, and representative application files. It excludes
+`node_modules`, build output, caches, lockfiles, environment files, credentials,
+private keys, and secret files by default.
+
+The character budget applies to the prompt payload. JSON adds a versioned metadata
+envelope for tools. Token estimates are planning heuristics, not provider billing
+counts or evidence that model output is correct.
+
 ## Claude Agent
 
 ```typescript

--- a/.claude/skills/stacks-buddy/SKILL.md
+++ b/.claude/skills/stacks-buddy/SKILL.md
@@ -545,6 +545,11 @@ Uses `@stacksjs/server` module's `down()`, `up()`, `isDownForMaintenance()`, `ma
 
 ```bash
 buddy about                  # display Stacks version, Bun/Node versions, OS, environment
+buddy ai:context             # compact deterministic project context for coding models
+  -J/--json                  # versioned machine-readable contract
+  -o/--output [path]         # write to a file instead of stdout
+  --max-chars [characters]   # prompt payload character budget (default: 4000)
+  --model [model]            # model family for heuristic token estimates
 buddy doctor                 # health checks (Bun version, Node, package.json, .env, APP_KEY)
 buddy tinker                 # interactive REPL with Stacks preloaded
   -e/--eval [expr]           # evaluate expression and exit

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ _Focus on coding, not publishing._
 
 Convention over configuration, while staying wholly configurable. _No more boilerplate._
 
+- 🧠 **LLM-Friendly Authoring** _models generate compact application intent instead of repeating framework glue or reading `node_modules`_
 - 💎 **Automated Upgrades** _no need to worry about upgrading to the latest versions, Stacks upgrades you_
 - 🦋 **Pretty Dev URLs** _your-project.localhost instead of localhost:3000_
 - 💡 **IDE Integration** _auto-completions, inline docs & a powerful IDE setup_

--- a/bun.lock
+++ b/bun.lock
@@ -1095,7 +1095,7 @@
   "catalog": {
     "@stacksjs/clapp": "^0.2.12",
     "@stacksjs/components": "^0.2.82",
-    "@stacksjs/gitlint": "^0.1.5",
+    "@stacksjs/gitlint": "^0.1.7",
     "@stacksjs/stx": "^0.2.99",
     "@stacksjs/ts-cloud": "^0.7.56",
     "better-dx": "^0.2.17",
@@ -1366,7 +1366,7 @@
 
     "@stacksjs/gitit": ["@stacksjs/gitit@0.2.5", "", { "bin": { "gitit": "dist/bin/cli.js" } }, "sha512-HI9L1EsWTXG4JxqMlEjujDWovH5UnYqP6Uv9Pll74+vLGEH2OK6FRfarNQgRHBkMyzBx2fjutAHOXrPSCTN8eQ=="],
 
-    "@stacksjs/gitlint": ["@stacksjs/gitlint@0.1.6", "", { "bin": { "gitlint": "./dist/bin/cli.js" } }, "sha512-A4MTsddeWHEhz0mLKq+P/CqHxmWv4SWhrmWotP1UMtVbGlpYs/q+bwqrFyThT6L9xMR8iWKGVTV908oS6QDeNg=="],
+    "@stacksjs/gitlint": ["@stacksjs/gitlint@0.1.7", "", { "bin": { "gitlint": "./dist/bin/cli.js" } }, "sha512-7d43l2r5gSLXK8YKflvkwZvN/huoJqbUSmDN+OY3CGHjb4ItimV6GJ/8JyFJwGI7tDEc5VgNGL0JYyIbk2IQ6g=="],
 
     "@stacksjs/health": ["@stacksjs/health@workspace:storage/framework/core/health"],
 
@@ -2345,6 +2345,8 @@
     "@stacksjs/stx/@stacksjs/desktop": ["@stacksjs/desktop@0.2.99", "", { "peerDependencies": { "craft": "*" }, "optionalPeers": ["craft"] }, "sha512-CQwp77Y50Qbz3ih2KBGfIqUhmUm3U5wkPHDGtQM6hIlBYexbyxtdZMBp/uZkvD4wYrtojMtqnzb/TxBvxwQ9uA=="],
 
     "better-dx/@stacksjs/clarity": ["@stacksjs/clarity@0.3.29", "", { "dependencies": { "bunfig": "^0.15.6" }, "bin": { "clarity": "dist/bin/cli.js" } }, "sha512-EQzT6h1J17sZLsHEablV1KO+x4N5jLff3whzGbfZiy4xhnRVSw2eA3EbHXjbjQmv65PaUr3c8Kp3eTWRG0b7lQ=="],
+
+    "better-dx/@stacksjs/gitlint": ["@stacksjs/gitlint@0.1.6", "", { "bin": { "gitlint": "./dist/bin/cli.js" } }, "sha512-A4MTsddeWHEhz0mLKq+P/CqHxmWv4SWhrmWotP1UMtVbGlpYs/q+bwqrFyThT6L9xMR8iWKGVTV908oS6QDeNg=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/docs/guide/buddy/commands.md
+++ b/docs/guide/buddy/commands.md
@@ -6,12 +6,13 @@ description: Generated reference for every Buddy command, argument, option, alia
 
 # Buddy Command Reference
 
-This reference is generated from Buddy's runtime command registry and currently contains **243 commands**. Run `bun run docs:buddy` after changing the registry; CI rejects stale output.
+This reference is generated from Buddy's runtime command registry and currently contains **244 commands**. Run `bun run docs:buddy` after changing the registry; CI rejects stale output.
 
 ## Command groups
 
 | Group | Commands |
 | --- | ---: |
+| `ai` | 1 |
 | `auth` | 4 |
 | `build` | 11 |
 | `cloud` | 7 |
@@ -94,6 +95,30 @@ Examples:
 buddy add calendar
 buddy add table --dry-run
 buddy add calendar --conflict backup
+```
+
+### `ai:context`
+
+Generate compact deterministic project context for coding models
+
+- Usage: `$ buddy ai:context`
+- Namespace: `ai`
+- Aliases: none
+- Arguments: none
+
+| Option | Description | Contract | Default |
+| --- | --- | --- | --- |
+| `-J`, `--json` | Emit the versioned machine-readable context contract | boolean, optional | `false` |
+| `-o`, `--output` | Write output to a file instead of stdout | value, optional | — |
+| `--max-chars` | Maximum characters in the prompt context payload | value, optional | `4000` |
+| `--model` | Model family used for the heuristic token estimate | value, optional | `"gpt-4o"` |
+
+Examples:
+
+```bash
+buddy ai:context
+buddy ai:context --json
+buddy ai:context --json --output .stacks/ai-context.json
 ```
 
 ### `auth:client`
@@ -685,7 +710,7 @@ Configure the AWS connection
 | Option | Description | Contract | Default |
 | --- | --- | --- | --- |
 | `-p`, `--project` | Target a specific project | value, optional | `false` |
-| `--profile` | The AWS profile to use | boolean, optional | `"stacks"` |
+| `--profile` | The AWS profile to use | boolean, optional | — |
 | `--verbose` | Enable verbose output | boolean, optional | `false` |
 | `--access-key-id` | The AWS access key | boolean, optional | — |
 | `--secret-access-key` | The AWS secret access key | boolean, optional | — |
@@ -1193,7 +1218,7 @@ Examples:
 ```bash
 buddy env:decrypt
 buddy env:decrypt --file .env.production
-buddy env:decrypt -k "SECRET__"
+buddy env:decrypt -k "SECRET_*"
 ```
 
 ### `env:encrypt`
@@ -1217,7 +1242,7 @@ Examples:
 ```bash
 buddy env:encrypt
 buddy env:encrypt --file .env.production
-buddy env:encrypt -k "SECRET__"
+buddy env:encrypt -k "SECRET_*"
 ```
 
 ### `env:get`
@@ -1460,7 +1485,7 @@ Register Safari Bundle IDs and check the App Store Connect app record
 | --- | --- | --- | --- |
 | `--api-key-id` | App Store Connect API key ID | value, required | — |
 | `--api-issuer-id` | App Store Connect API issuer ID | value, required | — |
-| `--api-key-path` | Path to the App Store Connect AuthKey__.p8 file | value, required | — |
+| `--api-key-path` | Path to the App Store Connect AuthKey_*.p8 file | value, required | — |
 | `--check` | Report missing resources without creating Bundle IDs | boolean, optional | — |
 | `--version` | Create or align App Store versions (defaults to package.json) | value, required | — |
 | `--platform` | Provision macos, ios, or all (defaults to config safariPlatforms) | value, required | — |
@@ -1481,7 +1506,7 @@ Archive and validate or upload the Safari app to App Store Connect
 | `--team-id` | Apple Developer team (defaults to config safariTeamId) | value, required | — |
 | `--api-key-id` | App Store Connect API key ID | value, required | — |
 | `--api-issuer-id` | App Store Connect API issuer ID | value, required | — |
-| `--api-key-path` | Path to the App Store Connect AuthKey__.p8 file | value, required | — |
+| `--api-key-path` | Path to the App Store Connect AuthKey_*.p8 file | value, required | — |
 | `--validate-only` | Create and validate the archive without uploading it | boolean, optional | — |
 | `--platform` | Publish macos, ios, or all (defaults to config safariPlatforms) | value, required | — |
 
@@ -2627,7 +2652,7 @@ Check if the ports are available
 
 | Option | Description | Contract | Default |
 | --- | --- | --- | --- |
-| `-p`, `--project` | Target a specific project | value, optional | `"/Users/chris/Code/stacks"` |
+| `-p`, `--project` | Target a specific project | value, optional | `"/Users/chris/Code/stacks-ai-context"` |
 | `-q`, `--quiet` | Use minimal output | boolean, optional | `false` |
 | `--verbose` | Enable verbose output | boolean, optional | `false` |
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "catalog": {
     "@stacksjs/clapp": "^0.2.12",
     "@stacksjs/components": "^0.2.82",
-    "@stacksjs/gitlint": "^0.1.5",
+    "@stacksjs/gitlint": "^0.1.7",
     "@stacksjs/stx": "^0.2.99",
     "@stacksjs/ts-cloud": "^0.7.56",
     "better-dx": "^0.2.17",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
         "*.{js,ts,json,yaml,yml,md}": "bun x --bun pickier lint --fix"
       }
     },
-    "commit-msg": "bun x gitlint --edit .git/COMMIT_EDITMSG"
+    "commit-msg": "bun x gitlint --edit \"$1\""
   },
   "devDependencies": {
     "ajv": "^8.20.0",

--- a/storage/framework/core/ai/README.md
+++ b/storage/framework/core/ai/README.md
@@ -35,6 +35,36 @@ const client = useAI()
 // client...
 ```
 
+## Compact project context
+
+Stacks conventions reduce the amount of application-owned code a coding model
+must generate. A model can describe domain shape once, use known Model-View-Action
+locations, and rely on framework traits and generators for migrations, validation,
+routes, API artifacts, and types where those paths are supported. Installed
+dependencies still exist, but their `node_modules` implementation is package-manager
+state, not application context an LLM should ingest or reproduce.
+
+Generate a deterministic context payload for any coding model or agent:
+
+```bash
+buddy ai:context
+buddy ai:context --json
+buddy ai:context --json --output .stacks/ai-context.json
+buddy ai:context --max-chars 4000 --model claude-sonnet-4
+```
+
+The versioned JSON contract identifies canonical source roles, instruction files,
+available application surfaces, safe package metadata, and representative source
+paths. It excludes dependency, build, cache, lock, environment, credential, key,
+and secret paths by default. Existing Buddy AI calls consume the same compact text
+representation.
+
+Output metrics include the enforced character budget and a heuristic token estimate.
+They also compare the payload with the previous unstructured context shape. This is
+evidence about prompt size only. It is not evidence that a particular model will
+write correct code, and exact billing tokens require the selected provider's
+tokenizer.
+
 Learn more in the docs.
 
 ## 🧪 Testing

--- a/storage/framework/core/ai/src/buddy.ts
+++ b/storage/framework/core/ai/src/buddy.ts
@@ -16,11 +16,12 @@ import type {
   RepoState,
   StreamingResult,
 } from './types'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { claudeAgent } from './agents'
 import { createAnthropicDriver, createClaudeAgentSDKDriver, createOllamaDriver, createOpenAIDriver } from './drivers'
+import { buildProjectContext } from './context'
 
 // =============================================================================
 // Configuration
@@ -250,29 +251,7 @@ export function getAvailableDrivers(): string[] {
  * Get repository structure for context
  */
 export async function getRepoContext(repoPath: string): Promise<string> {
-  const { $: _$ } = await import('bun')
-  const treeResult = await _$`cd ${repoPath} && find . -type f -not -path "*/node_modules/*" -not -path "*/.git/*" -not -name "*.lock" | head -50`.quiet()
-  const files = treeResult.text().trim()
-
-  let readme = ''
-  const readmePath = join(repoPath, 'README.md')
-  if (existsSync(readmePath)) {
-    readme = readFileSync(readmePath, 'utf-8').slice(0, 2000)
-  }
-
-  let packageJson = ''
-  const packagePath = join(repoPath, 'package.json')
-  if (existsSync(packagePath)) {
-    packageJson = readFileSync(packagePath, 'utf-8')
-  }
-
-  return `
-Repository Structure:
-${files}
-
-${readme ? `README.md (excerpt):\n${readme}\n` : ''}
-${packageJson ? `package.json:\n${packageJson}\n` : ''}
-`.trim()
+  return buildProjectContext(repoPath).text
 }
 
 /**

--- a/storage/framework/core/ai/src/context.ts
+++ b/storage/framework/core/ai/src/context.ts
@@ -1,0 +1,300 @@
+import { existsSync, lstatSync, readFileSync, readdirSync } from 'node:fs'
+import { basename, relative, resolve, sep } from 'node:path'
+import { estimateTokens } from './utils/tokens'
+
+export const STACKS_PROJECT_CONTEXT_SCHEMA = 'https://stacksjs.org/schemas/ai-project-context/v1'
+
+const DEFAULT_MAX_CHARS = 4000
+const DEFAULT_MAX_FILES = 30
+
+const excludedSegments = new Set([
+  '.git',
+  '.bun',
+  '.cache',
+  '.next',
+  '.output',
+  '.turbo',
+  '.vite',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'tmp',
+  'vendor',
+])
+
+const sensitiveNames = /^(?:\.env(?:\..*)?|\.npmrc|\.pypirc|credentials(?:\..*)?|id_(?:rsa|ed25519)(?:\.pub)?|secrets?(?:\..*)?)$/i
+const lockNames = /(?:^|\.)(?:bun|package-lock|pnpm-lock|yarn|pantry)\.?(?:lock|yaml)?$/i
+
+export interface ProjectContextOptions {
+  maxChars?: number
+  maxFiles?: number
+  model?: string
+}
+
+export interface ProjectContextSurface {
+  id: string
+  purpose: string
+  paths: string[]
+}
+
+export interface StacksProjectContext {
+  schema: typeof STACKS_PROJECT_CONTEXT_SCHEMA
+  schemaVersion: '1.0.0'
+  framework: 'stacks'
+  architecture: {
+    pattern: 'Model-View-Action'
+    overrideRule: string
+    authoringOrder: string[]
+    principles: string[]
+  }
+  project: {
+    name: string | null
+    version: string | null
+    scripts: string[]
+    dependencies: string[]
+  }
+  instructionFiles: string[]
+  surfaces: ProjectContextSurface[]
+  representativeFiles: string[]
+  exclusions: string[]
+}
+
+export interface ProjectContextMetrics {
+  candidateFiles: number
+  includedFiles: number
+  maxCharacters: number
+  outputCharacters: number
+  estimatedTokens: number
+  model: string
+  truncated: boolean
+  baselineMethod: 'sorted-first-50-paths+readme-2000+package-json'
+  baselineCharacters: number
+  baselineEstimatedTokens: number
+  estimatedTokenReductionPercent: number | null
+  tokenEstimateIsHeuristic: true
+}
+
+export interface ProjectContextResult {
+  context: StacksProjectContext
+  text: string
+  metrics: ProjectContextMetrics
+}
+
+interface SurfaceDefinition {
+  id: string
+  purpose: string
+  prefixes: string[]
+}
+
+const surfaceDefinitions: SurfaceDefinition[] = [
+  { id: 'models', purpose: 'Domain schema, validation, relationships, factories, and traits.', prefixes: ['app/Models/', 'storage/framework/defaults/app/Models/'] },
+  { id: 'actions', purpose: 'Transport-independent application behavior.', prefixes: ['app/Actions/', 'storage/framework/defaults/app/Actions/'] },
+  { id: 'routes', purpose: 'HTTP and API route registration.', prefixes: ['routes/', 'app/Routes.ts'] },
+  { id: 'jobs', purpose: 'Background and inline work.', prefixes: ['app/Jobs/', 'storage/framework/defaults/app/Jobs/'] },
+  { id: 'configuration', purpose: 'Typed application and provider configuration.', prefixes: ['config/'] },
+  { id: 'views', purpose: 'STX views, layouts, components, and client functions.', prefixes: ['resources/'] },
+  { id: 'database', purpose: 'Reviewable migrations and seed data.', prefixes: ['database/'] },
+  { id: 'tests', purpose: 'Unit, feature, contract, and end-to-end evidence.', prefixes: ['tests/', 'storage/framework/core/'] },
+]
+
+function normalizePath(path: string): string {
+  return path.split(sep).join('/')
+}
+
+function isExcluded(path: string): boolean {
+  const segments = path.split('/')
+  const name = basename(path)
+  return segments.some(segment => excludedSegments.has(segment))
+    || sensitiveNames.test(name)
+    || lockNames.test(name)
+    || name.endsWith('.lock')
+}
+
+function collectFiles(root: string): string[] {
+  const files: string[] = []
+
+  function visit(directory: string): void {
+    const entries = readdirSync(directory, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    for (const entry of entries) {
+      const fullPath = resolve(directory, entry.name)
+      const projectPath = normalizePath(relative(root, fullPath))
+      if (isExcluded(projectPath)) continue
+      if (entry.isDirectory()) visit(fullPath)
+      else if (entry.isFile() && !lstatSync(fullPath).isSymbolicLink()) files.push(projectPath)
+    }
+  }
+
+  visit(root)
+  return files.sort((a, b) => a.localeCompare(b))
+}
+
+function readPackageSummary(root: string): StacksProjectContext['project'] {
+  const packagePath = resolve(root, 'package.json')
+  if (!existsSync(packagePath)) return { name: null, version: null, scripts: [], dependencies: [] }
+
+  try {
+    const manifest = JSON.parse(readFileSync(packagePath, 'utf8')) as Record<string, unknown>
+    const dependencies = [
+      ...Object.keys((manifest.dependencies || {}) as Record<string, unknown>),
+      ...Object.keys((manifest.devDependencies || {}) as Record<string, unknown>),
+      ...Object.keys((manifest.peerDependencies || {}) as Record<string, unknown>),
+    ]
+    return {
+      name: typeof manifest.name === 'string' ? manifest.name : null,
+      version: typeof manifest.version === 'string' ? manifest.version : null,
+      scripts: Object.keys((manifest.scripts || {}) as Record<string, unknown>).sort().slice(0, 25),
+      dependencies: [...new Set(dependencies)].sort().slice(0, 30),
+    }
+  }
+  catch {
+    return { name: null, version: null, scripts: [], dependencies: [] }
+  }
+}
+
+function filePriority(path: string): number {
+  if (/^(?:AGENTS|CLAUDE)\.md$|^\.github\/copilot-instructions\.md$/.test(path)) return 0
+  if (path === 'package.json' || path === 'app/Routes.ts' || path === 'app/Commands.ts') return 1
+  if (/^(?:app|routes|config)\//.test(path)) return 2
+  if (/^(?:resources|database|tests)\//.test(path)) return 3
+  if (/^docs\//.test(path)) return 4
+  if (/^storage\/framework\/defaults\//.test(path)) return 5
+  return 6
+}
+
+function representativeFiles(files: string[], maxFiles: number): string[] {
+  return [...files]
+    .sort((a, b) => filePriority(a) - filePriority(b) || a.localeCompare(b))
+    .slice(0, maxFiles)
+    .sort((a, b) => a.localeCompare(b))
+}
+
+function surfacePaths(files: string[], prefixes: string[]): string[] {
+  return files
+    .filter(file => prefixes.some(prefix => prefix.endsWith('/') ? file.startsWith(prefix) : file === prefix))
+    .slice(0, 4)
+}
+
+function renderContext(context: StacksProjectContext): string {
+  const lines = [
+    'Stacks AI Project Context v1',
+    '',
+    `Project: ${context.project.name || 'unnamed'}${context.project.version ? `@${context.project.version}` : ''}`,
+    'Architecture: Model-View-Action',
+    `Override rule: ${context.architecture.overrideRule}`,
+    `Authoring order: ${context.architecture.authoringOrder.join(' -> ')}`,
+    '',
+    'Authoring principles:',
+    ...context.architecture.principles.map(principle => `- ${principle}`),
+    '',
+    'Instruction files:',
+    ...(context.instructionFiles.length ? context.instructionFiles.map(file => `- ${file}`) : ['- none detected']),
+    '',
+    'Available surfaces:',
+    ...context.surfaces.flatMap(surface => [
+      `- ${surface.id}: ${surface.purpose}`,
+      ...surface.paths.map(path => `  - ${path}`),
+    ]),
+    '',
+    `Scripts: ${context.project.scripts.join(', ') || 'none detected'}`,
+    `Dependencies: ${context.project.dependencies.join(', ') || 'none detected'}`,
+    '',
+    'Representative files:',
+    ...context.representativeFiles.map(file => `- ${file}`),
+  ]
+  return lines.join('\n')
+}
+
+function fitToBudget(text: string, maxChars: number): { text: string, truncated: boolean } {
+  if (text.length <= maxChars) return { text, truncated: false }
+  const marker = '\n[context truncated by character budget]'
+  if (maxChars <= marker.length) return { text: marker.slice(0, maxChars), truncated: true }
+  const available = maxChars - marker.length
+  const prefix = text.slice(0, available)
+  const lastLine = prefix.lastIndexOf('\n')
+  return {
+    text: `${prefix.slice(0, lastLine > 0 ? lastLine : available)}${marker}`,
+    truncated: true,
+  }
+}
+
+function unstructuredBaseline(root: string, files: string[]): string {
+  const readmePath = resolve(root, 'README.md')
+  const packagePath = resolve(root, 'package.json')
+  const readme = existsSync(readmePath) ? readFileSync(readmePath, 'utf8').slice(0, 2000) : ''
+  const packageJson = existsSync(packagePath) ? readFileSync(packagePath, 'utf8') : ''
+  return [
+    'Repository Structure:',
+    files.slice(0, 50).join('\n'),
+    readme ? `README.md (excerpt):\n${readme}` : '',
+    packageJson ? `package.json:\n${packageJson}` : '',
+  ].filter(Boolean).join('\n\n')
+}
+
+export function buildProjectContext(repoPath: string, options: ProjectContextOptions = {}): ProjectContextResult {
+  const root = resolve(repoPath)
+  const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS
+  const maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES
+  const model = options.model || 'gpt-4o'
+  if (!Number.isInteger(maxChars) || maxChars < 256) throw new Error('maxChars must be an integer of at least 256')
+  if (!Number.isInteger(maxFiles) || maxFiles < 1) throw new Error('maxFiles must be a positive integer')
+
+  const files = collectFiles(root)
+  const included = representativeFiles(files, maxFiles)
+  const context: StacksProjectContext = {
+    schema: STACKS_PROJECT_CONTEXT_SCHEMA,
+    schemaVersion: '1.0.0',
+    framework: 'stacks',
+    architecture: {
+      pattern: 'Model-View-Action',
+      overrideRule: 'Application files under app/ override matching framework defaults; do not edit defaults for application customization.',
+      authoringOrder: ['model', 'migration', 'action', 'route', 'test'],
+      principles: [
+        'Prefer conventional paths and framework generators over bespoke glue code.',
+        'Declare domain shape once and derive validation, migrations, API surfaces, and types where supported.',
+        'Keep Actions transport-independent and make unsupported drivers fail loudly.',
+        'Read repository instruction files before changing source.',
+      ],
+    },
+    project: readPackageSummary(root),
+    instructionFiles: files.filter(file => /(?:^|\/)(?:AGENTS|CLAUDE)\.md$|^\.github\/copilot-instructions\.md$/.test(file)),
+    surfaces: surfaceDefinitions
+      .map(surface => ({ id: surface.id, purpose: surface.purpose, paths: surfacePaths(files, surface.prefixes) }))
+      .filter(surface => surface.paths.length > 0),
+    representativeFiles: included,
+    exclusions: [
+      'dependency, build, cache, coverage, temporary, and vendor directories',
+      'lockfiles',
+      'environment, credential, private-key, and secret files',
+    ],
+  }
+
+  const fitted = fitToBudget(renderContext(context), maxChars)
+  const baseline = unstructuredBaseline(root, files)
+  const outputTokens = estimateTokens(fitted.text, model)
+  const baselineTokens = estimateTokens(baseline, model)
+  const reduction = baselineTokens > 0
+    ? Math.round((1 - outputTokens / baselineTokens) * 1000) / 10
+    : null
+
+  return {
+    context,
+    text: fitted.text,
+    metrics: {
+      candidateFiles: files.length,
+      includedFiles: included.length,
+      maxCharacters: maxChars,
+      outputCharacters: fitted.text.length,
+      estimatedTokens: outputTokens,
+      model,
+      truncated: fitted.truncated,
+      baselineMethod: 'sorted-first-50-paths+readme-2000+package-json',
+      baselineCharacters: baseline.length,
+      baselineEstimatedTokens: baselineTokens,
+      estimatedTokenReductionPercent: reduction,
+      tokenEstimateIsHeuristic: true,
+    },
+  }
+}

--- a/storage/framework/core/ai/src/index.ts
+++ b/storage/framework/core/ai/src/index.ts
@@ -13,6 +13,9 @@ export * from './agents'
 // Buddy - Voice AI Code Assistant
 export * from './buddy'
 
+// Deterministic, budgeted project context for coding models and agents
+export * from './context'
+
 // Text utilities
 export * from './text'
 

--- a/storage/framework/core/ai/tests/context.test.ts
+++ b/storage/framework/core/ai/tests/context.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildProjectContext } from '../src/context'
+import { getRepoContext } from '../src/buddy'
+
+const temporaryRoots: string[] = []
+
+function fixture(): string {
+  const root = mkdtempSync(join(tmpdir(), 'stacks-ai-context-'))
+  temporaryRoots.push(root)
+  for (const directory of ['app/Actions', 'app/Models', 'config', 'node_modules/noisy', 'routes', 'tests'])
+    mkdirSync(join(root, directory), { recursive: true })
+
+  writeFileSync(join(root, 'package.json'), JSON.stringify({
+    name: 'example-stacks-app',
+    version: '1.2.3',
+    scripts: { build: 'SECRET_TOKEN=do-not-copy bun build', test: 'bun test' },
+    dependencies: { '@stacksjs/actions': '1.0.0', '@stacksjs/orm': '1.0.0' },
+  }, null, 2))
+  writeFileSync(join(root, 'AGENTS.md'), 'Use the Stacks conventions.')
+  writeFileSync(join(root, '.env'), 'SECRET_TOKEN=visible-nowhere')
+  writeFileSync(join(root, 'bun.lock'), 'large lock')
+  writeFileSync(join(root, 'node_modules/noisy/index.ts'), 'ignore me')
+  writeFileSync(join(root, 'app/Actions/CreatePost.ts'), 'export default {}')
+  writeFileSync(join(root, 'app/Models/Post.ts'), 'export default {}')
+  writeFileSync(join(root, 'config/app.ts'), 'export default {}')
+  writeFileSync(join(root, 'routes/api.ts'), 'export default {}')
+  writeFileSync(join(root, 'tests/post.test.ts'), 'export default {}')
+  writeFileSync(join(root, 'README.md'), 'A'.repeat(2000))
+  return root
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('Stacks AI project context', () => {
+  it('builds deterministic high-signal context without secret or dependency paths', () => {
+    const root = fixture()
+    const first = buildProjectContext(root)
+    const second = buildProjectContext(root)
+
+    expect(first).toEqual(second)
+    expect(first.context.schemaVersion).toBe('1.0.0')
+    expect(first.context.architecture.pattern).toBe('Model-View-Action')
+    expect(first.context.instructionFiles).toEqual(['AGENTS.md'])
+    expect(first.context.project.scripts).toEqual(['build', 'test'])
+    expect(first.context.project.dependencies).toEqual(['@stacksjs/actions', '@stacksjs/orm'])
+    expect(first.text).toContain('app/Models/Post.ts')
+    expect(first.text).not.toContain('SECRET_TOKEN')
+    expect(first.text).not.toContain('.env')
+    expect(first.text).not.toContain('node_modules')
+    expect(first.text).not.toContain('bun.lock')
+  })
+
+  it('enforces the prompt character budget and reports heuristic savings', () => {
+    const result = buildProjectContext(fixture(), { maxChars: 512, model: 'claude-sonnet-4' })
+
+    expect(result.text.length).toBeLessThanOrEqual(512)
+    expect(result.metrics.outputCharacters).toBe(result.text.length)
+    expect(result.metrics.truncated).toBeTrue()
+    expect(result.metrics.estimatedTokens).toBeGreaterThan(0)
+    expect(result.metrics.baselineEstimatedTokens).toBeGreaterThan(result.metrics.estimatedTokens)
+    expect(result.metrics.estimatedTokenReductionPercent).toBeGreaterThan(0)
+    expect(result.metrics.tokenEstimateIsHeuristic).toBeTrue()
+  })
+
+  it('keeps the existing Buddy API on the compact representation', async () => {
+    const root = fixture()
+    expect(await getRepoContext(root)).toBe(buildProjectContext(root).text)
+  })
+
+  it('rejects unusable budgets', () => {
+    expect(() => buildProjectContext(fixture(), { maxChars: 255 })).toThrow('at least 256')
+  })
+})

--- a/storage/framework/core/buddy/src/commands/ai-context.ts
+++ b/storage/framework/core/buddy/src/commands/ai-context.ts
@@ -1,0 +1,54 @@
+import type { CLI, CliOptions } from '@stacksjs/types'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+import { buildProjectContext } from '@stacksjs/ai'
+import { onUnknownSubcommand } from '@stacksjs/cli'
+
+export interface AiContextCommandOptions extends CliOptions {
+  json?: boolean
+  output?: string
+  maxChars?: string | number
+  model?: string
+}
+
+export interface AiContextCommandResult {
+  output: string
+  outputPath: string | null
+}
+
+export function generateAiContextOutput(
+  options: AiContextCommandOptions = {},
+  projectRoot: string = process.cwd(),
+): AiContextCommandResult {
+  const maxChars = options.maxChars === undefined ? undefined : Number(options.maxChars)
+  const result = buildProjectContext(projectRoot, { maxChars, model: options.model })
+  const output = options.json
+    ? `${JSON.stringify(result, null, 2)}\n`
+    : `${result.text}\n\nContext metrics:\n${JSON.stringify(result.metrics, null, 2)}\n`
+
+  if (!options.output) return { output, outputPath: null }
+  const outputPath = resolve(projectRoot, String(options.output))
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, output)
+  return { output, outputPath }
+}
+
+export function aiContext(buddy: CLI): void {
+  buddy
+    .command('ai:context', 'Generate compact deterministic project context for coding models')
+    .option('-J, --json', 'Emit the versioned machine-readable context contract', { default: false })
+    .option('-o, --output [path]', 'Write output to a file instead of stdout')
+    .option('--max-chars [characters]', 'Maximum characters in the prompt context payload', { default: 4000 })
+    .option('--model [model]', 'Model family used for the heuristic token estimate', { default: 'gpt-4o' })
+    .example('buddy ai:context')
+    .example('buddy ai:context --json')
+    .example('buddy ai:context --json --output .stacks/ai-context.json')
+    .action((options: AiContextCommandOptions) => {
+      const generated = generateAiContextOutput(options)
+      if (generated.outputPath) console.log(`Wrote AI project context to ${generated.outputPath}`)
+      else process.stdout.write(generated.output)
+    })
+
+  onUnknownSubcommand(buddy, 'ai:context')
+}

--- a/storage/framework/core/buddy/src/lazy-commands.ts
+++ b/storage/framework/core/buddy/src/lazy-commands.ts
@@ -16,6 +16,7 @@ interface CommandLoader {
 const commandRegistry: Record<string, CommandLoader> = {
   'about': { path: './commands/about.ts', exportName: 'about' },
   'add': { path: './commands/add.ts', exportName: 'add' },
+  'ai:context': { path: './commands/ai-context.ts', exportName: 'aiContext' },
   'auth': { path: './commands/auth.ts', exportName: 'auth' },
   'build': { path: './commands/build.ts', exportName: 'build' },
   'cd': { path: './commands/cd.ts', exportName: 'cd' },

--- a/storage/framework/core/buddy/src/project-setup.ts
+++ b/storage/framework/core/buddy/src/project-setup.ts
@@ -12,6 +12,7 @@ const APP_KEY_OPTIONAL_COMMANDS = [
   'clean',
   'fresh',
   'about',
+  'ai:context',
   'doctor',
   'list',
   'setup',

--- a/storage/framework/core/buddy/tests/ai-context.test.ts
+++ b/storage/framework/core/buddy/tests/ai-context.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { cli } from '@stacksjs/cli'
+import { aiContext, generateAiContextOutput } from '../src/commands/ai-context'
+import { commandInventoryEntry } from '../src/commands/list'
+import { shouldSkipAppKeyCheck } from '../src/project-setup'
+
+const temporaryRoots: string[] = []
+
+function project(): string {
+  const root = mkdtempSync(join(tmpdir(), 'buddy-ai-context-'))
+  temporaryRoots.push(root)
+  mkdirSync(join(root, 'app/Models'), { recursive: true })
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'buddy-context-test' }))
+  writeFileSync(join(root, 'app/Models/User.ts'), 'export default {}')
+  return root
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('buddy ai:context', () => {
+  it('registers JSON, output, budget, and model controls', () => {
+    const buddy = cli('buddy')
+    aiContext(buddy)
+    const command = buddy.commands.find(candidate => candidate.namespace === 'ai' && candidate.name === 'context')
+    const optionNames = command?.options.flatMap(option => option.names)
+
+    expect(command && commandInventoryEntry(command).name).toBe('ai:context')
+    expect(optionNames).toContain('json')
+    expect(optionNames).toContain('output')
+    expect(optionNames).toContain('maxChars')
+    expect(optionNames).toContain('model')
+  })
+
+  it('emits the versioned JSON contract and writes it explicitly', () => {
+    const root = project()
+    const target = '.stacks/ai-context.json'
+    const generated = generateAiContextOutput({ json: true, output: target, maxChars: 1000 }, root)
+    const outputPath = join(root, target)
+
+    expect(generated.outputPath).toBe(outputPath)
+    expect(existsSync(outputPath)).toBeTrue()
+    expect(JSON.parse(readFileSync(outputPath, 'utf8')).context.schemaVersion).toBe('1.0.0')
+  })
+
+  it('does not require an application key', () => {
+    expect(shouldSkipAppKeyCheck('ai:context')).toBeTrue()
+  })
+})


### PR DESCRIPTION
## Summary

- add deterministic, secret-aware `buddy ai:context` output with explicit budgets and metrics
- replace broad repository dumps in Buddy with compact application-authoring context
- document how Stacks conventions reduce app-owned boilerplate and LLM prompt/code tokens without claiming dependencies disappear
- make commit hooks work in linked Git worktrees and consume @stacksjs/gitlint 0.1.7

## Verification

- `bun test storage/framework/core/ai/tests/context.test.ts storage/framework/core/buddy/tests/ai-context.test.ts`
- `bun run docs:buddy:check`
- changed-file Pickier checks via commit hooks

Closes #2096
Supports #2056