### PR TITLE
feat(protocol): validate fixture-corpus integrity in CI (#2051)

### DIFF
--- a/scripts/protocol/sync-suite.test.ts
+++ b/scripts/protocol/sync-suite.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'bun:test'
-import { duplicateRequirementIds } from './sync-suite'
+import { danglingFixtureRequirements, duplicateRequirementIds } from './sync-suite'
 
 // Protocol 1.0 ratification requires requirement ids to be unique and validated
 // in CI (stacksjs/stacks#2050). `protocol:check` now enforces this on the
@@ -27,5 +27,44 @@ describe('protocol requirement-id uniqueness (stacksjs/stacks#2050)', () => {
     const ids = catalog.requirements.map(requirement => requirement.id)
     expect(ids.length).toBeGreaterThan(0)
     expect(duplicateRequirementIds(ids)).toEqual([])
+  })
+})
+
+// Fixtures must reference real catalog requirements and unblock formal conformance
+// reports (stacksjs/stacks#2051). `protocol:check` now enforces corpus integrity.
+describe('protocol fixture-corpus integrity (stacksjs/stacks#2051)', () => {
+  const catalogIds = new Set(['CORE-CONV-01', 'CORE-CONV-02', 'CORE-MVA-01'])
+
+  it('reports no dangling refs when every requirement resolves', () => {
+    const fixtures = [
+      { id: 'fixture.a', requirements: ['CORE-CONV-01', 'CORE-CONV-02'] },
+      { id: 'fixture.b', requirements: ['CORE-MVA-01'] },
+    ]
+    expect(danglingFixtureRequirements(fixtures, catalogIds)).toEqual([])
+  })
+
+  it('reports each unknown requirement ref as `fixture -> requirement`', () => {
+    const fixtures = [
+      { id: 'fixture.a', requirements: ['CORE-CONV-01', 'CORE-GONE-99'] },
+      { id: 'fixture.b', requirements: ['NOPE-01'] },
+    ]
+    expect(danglingFixtureRequirements(fixtures, catalogIds)).toEqual(['fixture.a -> CORE-GONE-99', 'fixture.b -> NOPE-01'])
+  })
+
+  it('tolerates fixtures with no requirements', () => {
+    expect(danglingFixtureRequirements([{ id: 'fixture.a' }], catalogIds)).toEqual([])
+  })
+
+  it('the vendored fixture corpus has unique ids and no dangling requirement refs', () => {
+    const base = resolve(import.meta.dir, '../../protocol/suite/1.0-draft')
+    const corpus = JSON.parse(readFileSync(resolve(base, 'fixtures/conformance.json'), 'utf8')) as {
+      fixtures: Array<{ id: string, requirements?: string[] }>
+    }
+    const catalog = JSON.parse(readFileSync(resolve(base, 'catalog.json'), 'utf8')) as { requirements: Array<{ id: string }> }
+    const realIds = new Set(catalog.requirements.map(requirement => requirement.id))
+
+    expect(corpus.fixtures.length).toBeGreaterThan(0)
+    expect(duplicateRequirementIds(corpus.fixtures.map(fixture => fixture.id))).toEqual([])
+    expect(danglingFixtureRequirements(corpus.fixtures, realIds)).toEqual([])
   })
 })

--- a/scripts/protocol/sync-suite.ts
+++ b/scripts/protocol/sync-suite.ts
@@ -131,6 +131,64 @@ function checkCatalog(): void {
   console.log(`Protocol catalog: ${ids.length} requirement ids, all unique`)
 }
 
+/**
+ * Requirement ids referenced by a fixture that are absent from `catalogIds`,
+ * formatted `fixtureId -> requirementId`.
+ */
+export function danglingFixtureRequirements(
+  fixtures: Array<{ id: string, requirements?: string[] }>,
+  catalogIds: Set<string>,
+): string[] {
+  const dangling: string[] = []
+  for (const fixture of fixtures) {
+    for (const requirement of fixture.requirements ?? []) {
+      if (!catalogIds.has(requirement))
+        dangling.push(`${fixture.id} -> ${requirement}`)
+    }
+  }
+  return dangling
+}
+
+/**
+ * Validate the vendored fixture corpus: fixtures exist, each has a non-empty
+ * unique id, and every requirement a fixture claims to cover resolves to a real
+ * catalog id. The conformance runner validated *reports* against the catalog,
+ * but nothing checked the corpus's own integrity, so a duplicate fixture id or a
+ * fixture pointing at a renamed/removed requirement would go unnoticed
+ * (stacksjs/stacks#2051).
+ */
+function checkFixtures(): void {
+  const fixturesPath = resolve(suiteRoot, 'fixtures/conformance.json')
+  if (!existsSync(fixturesPath))
+    throw new Error(`protocol fixture corpus missing at ${relative(root, fixturesPath)}; run bun run protocol:sync`)
+
+  const corpus = JSON.parse(readFileSync(fixturesPath, 'utf8')) as { fixtures?: Array<{ id?: unknown, requirements?: unknown }> }
+  const fixtures = Array.isArray(corpus.fixtures) ? corpus.fixtures : []
+  if (fixtures.length === 0)
+    throw new Error('protocol fixture corpus has no fixtures')
+
+  const ids = fixtures.map(fixture => fixture?.id)
+  const missing = ids.filter(id => typeof id !== 'string' || id.length === 0).length
+  if (missing > 0)
+    throw new Error(`protocol fixture corpus has ${missing} fixture(s) without a string id`)
+
+  const duplicates = duplicateRequirementIds(ids as string[])
+  if (duplicates.length > 0)
+    throw new Error(`protocol fixture corpus has duplicate fixture id(s): ${duplicates.join(', ')}`)
+
+  const catalog = JSON.parse(readFileSync(resolve(suiteRoot, 'catalog.json'), 'utf8')) as { requirements?: Array<{ id?: unknown }> }
+  const catalogIds = new Set((catalog.requirements ?? []).map(requirement => requirement?.id).filter((id): id is string => typeof id === 'string'))
+  const normalized = fixtures.map(fixture => ({
+    id: String(fixture?.id),
+    requirements: Array.isArray(fixture?.requirements) ? fixture.requirements.filter((requirement): requirement is string => typeof requirement === 'string') : [],
+  }))
+  const dangling = danglingFixtureRequirements(normalized, catalogIds)
+  if (dangling.length > 0)
+    throw new Error(`protocol fixtures reference unknown requirement id(s): ${dangling.slice(0, 10).join(', ')}`)
+
+  console.log(`Protocol fixtures: ${ids.length} fixtures, ids unique, all requirement refs resolve`)
+}
+
 if (import.meta.main) {
   if (process.argv.includes('--write')) {
     const source = resolve(argument('--source') || process.env.STACKS_RFC_SOURCE || resolve(root, '../rfcs'))
@@ -139,6 +197,7 @@ if (import.meta.main) {
   else if (process.argv.includes('--check')) {
     checkSnapshot()
     checkCatalog()
+    checkFixtures()
   }
   else {
     console.error('usage: bun scripts/protocol/sync-suite.ts --write [--source ../rfcs] | --check')


### PR DESCRIPTION
Concrete code slice of #2051. The conformance runner validated *reports* against the catalog, but nothing checked the vendored **fixture corpus's own integrity** - a duplicate fixture id, or a fixture referencing a requirement that was renamed/removed from the catalog, would go unnoticed.

## Change
- `checkFixtures()` added to `protocol:check` (runs in protocol-conformance CI): fixtures exist, each has a non-empty unique id, and every requirement a fixture references resolves to a real catalog id.
- Pure, unit-tested `danglingFixtureRequirements` helper.

## Verify
`protocol:check` prints `Protocol fixtures: 16 fixtures, ids unique, all requirement refs resolve`; 8 unit tests; pickier clean.

Scope: the code-enforceable integrity slice. The fixture format spec, corpus authoring, and driver contract kit in #2051 live in the rfcs/whitepaper repos and remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)