### PR TITLE
feat(storage): add filebaseDisk preset for Filebase (#938)

### DIFF
--- a/storage/framework/core/storage/src/index.ts
+++ b/storage/framework/core/storage/src/index.ts
@@ -25,7 +25,7 @@ export type { FilenameStrategy, PutFileOptions, UploadedFileLike } from './put-f
 export { UploadedFile, uploadedFile, uploadedFiles } from './uploaded-file'
 
 // Filesystem type helpers
-export { configFromEnv, localDisk, s3Disk } from './types/filesystem'
+export { configFromEnv, filebaseDisk, localDisk, s3Disk } from './types/filesystem'
 // Disk-name autocomplete: userland augments `KnownDisks` to get
 // completion on `Storage.disk('…')` (stacksjs/stacks#1924).
 export type { DiskName, KnownDisks } from './types/filesystem'

--- a/storage/framework/core/storage/src/types/filesystem.ts
+++ b/storage/framework/core/storage/src/types/filesystem.ts
@@ -170,6 +170,27 @@ export function s3Disk(bucket: string, options?: Partial<Omit<S3DiskConfig, 'dri
 }
 
 /**
+ * Helper to create a Filebase disk config (stacksjs/stacks#938).
+ *
+ * Filebase (https://filebase.com) is an S3-compatible, IPFS-backed object
+ * store, so it reuses the `s3` adapter with the endpoint pinned to
+ * `https://s3.filebase.com` and the region to `us-east-1` (Filebase's single
+ * S3 region). Pass a Filebase bucket; supply Filebase credentials via
+ * `options.credentials` or the standard `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`
+ * env vars. Any field (prefix, visibility, credentials, ...) can be overridden.
+ */
+export function filebaseDisk(bucket: string, options?: Partial<Omit<S3DiskConfig, 'driver' | 'bucket'>>): S3DiskConfig {
+  return {
+    driver: 's3',
+    bucket,
+    region: 'us-east-1',
+    endpoint: 'https://s3.filebase.com',
+    visibility: 'private',
+    ...options,
+  }
+}
+
+/**
  * Create filesystem config from environment variables
  */
 export function configFromEnv(base: Partial<FilesystemConfig> = {}): FilesystemConfig {

--- a/storage/framework/core/storage/tests/filebase-disk.test.ts
+++ b/storage/framework/core/storage/tests/filebase-disk.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test'
+import { filebaseDisk } from '../src/types/filesystem'
+
+// Filebase is S3-compatible (IPFS-backed), so it reuses the s3 adapter with the
+// endpoint pinned. filebaseDisk makes it a first-class preset (stacksjs/stacks#938).
+describe('filebaseDisk', () => {
+  it('presets an s3 disk pointed at the Filebase endpoint', () => {
+    expect(filebaseDisk('my-bucket')).toEqual({
+      driver: 's3',
+      bucket: 'my-bucket',
+      region: 'us-east-1',
+      endpoint: 'https://s3.filebase.com',
+      visibility: 'private',
+    })
+  })
+
+  it('lets callers supply credentials and other overrides', () => {
+    const disk = filebaseDisk('assets', {
+      credentials: { key: 'FILEBASE_KEY', secret: 'FILEBASE_SECRET' },
+      prefix: 'uploads/',
+      visibility: 'public',
+    })
+    expect(disk.credentials).toEqual({ key: 'FILEBASE_KEY', secret: 'FILEBASE_SECRET' })
+    expect(disk.prefix).toBe('uploads/')
+    expect(disk.visibility).toBe('public')
+    // Endpoint stays pinned to Filebase unless explicitly overridden.
+    expect(disk.endpoint).toBe('https://s3.filebase.com')
+    expect(disk.driver).toBe('s3')
+  })
+
+  it('allows overriding the endpoint (e.g. a regional/gateway mirror)', () => {
+    expect(filebaseDisk('b', { endpoint: 'https://custom.filebase.example' }).endpoint)
+      .toBe('https://custom.filebase.example')
+  })
+})


### PR DESCRIPTION
Closes #938.

Filebase is an **S3-compatible**, IPFS-backed object store, so it needs no new adapter - it reuses the existing `s3` adapter with the endpoint pinned. `filebaseDisk(bucket, options?)` mirrors `s3Disk`, presetting `endpoint: https://s3.filebase.com` and `region: us-east-1` (Filebase's single S3 region), so a Filebase disk is a one-liner:

```ts
import { filebaseDisk } from '@stacksjs/storage'
// config/filesystems.ts
disks: { filebase: filebaseDisk('my-bucket') }
```

Credentials come from `options.credentials` or the standard `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars; any field (prefix, visibility, endpoint) is overridable. Exported from `@stacksjs/storage`. 3 unit tests, pickier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)