### PR TITLE
feat(storage): S3-compatible presets + endpoint plumbing (Backblaze/R2/Hetzner/Filebase) (#1897, #1896, #938)

### DIFF
--- a/storage/framework/core/storage/src/adapters/s3.ts
+++ b/storage/framework/core/storage/src/adapters/s3.ts
@@ -93,6 +93,40 @@ async function isSettled(p: Promise<unknown>): Promise<boolean> {
 }
 
 /**
+ * Options for the ts-cloud S3 client. Mirrors ts-cloud's internal
+ * `S3ClientOptions` (declared but not re-exported from its package root);
+ * structural typing lets this satisfy the `S3Client` constructor's 3rd argument.
+ */
+interface S3ClientOptions {
+  endpoint?: string
+  forcePathStyle?: boolean
+  credentials?: { accessKeyId: string, secretAccessKey: string, sessionToken?: string }
+}
+
+/**
+ * Build ts-cloud `S3ClientOptions` from adapter config, or `undefined` for a
+ * plain AWS S3 client. The config endpoint may carry a scheme
+ * (`https://s3.filebase.com`); ts-cloud wants a scheme-less host, so it's
+ * stripped here. This is what routes the adapter to S3-compatible providers -
+ * Filebase, Backblaze B2, Cloudflare R2, Hetzner Object Storage
+ * (stacksjs/stacks#938, #1897, #1896).
+ */
+export function resolveS3ClientOptions(config: {
+  endpoint?: string
+  usePathStyleEndpoint?: boolean
+  credentials?: { accessKeyId: string, secretAccessKey: string, sessionToken?: string }
+}): S3ClientOptions | undefined {
+  const options: S3ClientOptions = {}
+  if (config.endpoint)
+    options.endpoint = config.endpoint.replace(/^https?:\/\//i, '').replace(/\/+$/, '')
+  if (config.usePathStyleEndpoint)
+    options.forcePathStyle = true
+  if (config.credentials)
+    options.credentials = config.credentials
+  return Object.keys(options).length > 0 ? options : undefined
+}
+
+/**
  * AWS S3 storage adapter using ts-cloud S3Client
  */
 export class S3StorageAdapter implements StorageAdapter {
@@ -101,6 +135,8 @@ export class S3StorageAdapter implements StorageAdapter {
   private bucket: string
   private prefix: string
   private region: string
+  private endpoint?: string
+  private usePathStyleEndpoint?: boolean
   /**
    * Caller-supplied credentials, kept so we can issue presigned POST
    * policies (which need access to the signing key — ts-cloud's
@@ -120,6 +156,8 @@ export class S3StorageAdapter implements StorageAdapter {
     this.prefix = config.prefix || ''
     this.region = config.region || 'us-east-1'
     this.credentials = config.credentials
+    this.endpoint = config.endpoint
+    this.usePathStyleEndpoint = config.usePathStyleEndpoint
 
     if (!this.bucket) {
       throw new Error('S3 bucket name is required')
@@ -131,7 +169,11 @@ export class S3StorageAdapter implements StorageAdapter {
       return this._client
     if (!this._clientPromise) {
       this._clientPromise = import('@stacksjs/ts-cloud').then((cloud) => {
-        this._client = new cloud.S3Client(this.region)
+        this._client = new cloud.S3Client(
+          this.region,
+          undefined,
+          resolveS3ClientOptions({ endpoint: this.endpoint, usePathStyleEndpoint: this.usePathStyleEndpoint, credentials: this.credentials }),
+        )
         return this._client
       })
     }

--- a/storage/framework/core/storage/src/facade.ts
+++ b/storage/framework/core/storage/src/facade.ts
@@ -176,6 +176,14 @@ class StorageManager {
       bucket: config.bucket,
       region: config.region,
       prefix: config.prefix,
+      endpoint: config.endpoint,
+      usePathStyleEndpoint: config.usePathStyleEndpoint,
+      // S3DiskConfig uses { key, secret }; the adapter/ts-cloud client use
+      // { accessKeyId, secretAccessKey }. Map so S3-compatible providers whose
+      // keys aren't in the AWS env chain still authenticate (stacksjs/stacks#1897).
+      credentials: config.credentials
+        ? { accessKeyId: config.credentials.key, secretAccessKey: config.credentials.secret }
+        : undefined,
     })
   }
 

--- a/storage/framework/core/storage/src/index.ts
+++ b/storage/framework/core/storage/src/index.ts
@@ -25,7 +25,7 @@ export type { FilenameStrategy, PutFileOptions, UploadedFileLike } from './put-f
 export { UploadedFile, uploadedFile, uploadedFiles } from './uploaded-file'
 
 // Filesystem type helpers
-export { configFromEnv, filebaseDisk, localDisk, s3Disk } from './types/filesystem'
+export { backblazeDisk, configFromEnv, filebaseDisk, hetznerDisk, localDisk, r2Disk, s3Disk } from './types/filesystem'
 // Disk-name autocomplete: userland augments `KnownDisks` to get
 // completion on `Storage.disk('…')` (stacksjs/stacks#1924).
 export type { DiskName, KnownDisks } from './types/filesystem'

--- a/storage/framework/core/storage/src/types.ts
+++ b/storage/framework/core/storage/src/types.ts
@@ -335,6 +335,15 @@ export interface StorageAdapterConfig {
   /** S3 key prefix */
   prefix?: string
   /**
+   * Endpoint URL for S3-compatible providers (Filebase, Backblaze B2,
+   * Cloudflare R2, Hetzner Object Storage, MinIO, ...). May include the
+   * scheme (`https://...`); the adapter passes the host on to the S3 client.
+   * Omit for AWS S3.
+   */
+  endpoint?: string
+  /** Force path-style addressing instead of virtual-hosted-style. */
+  usePathStyleEndpoint?: boolean
+  /**
    * AWS credentials. When omitted the adapter falls back to the
    * standard env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
    * `AWS_SESSION_TOKEN`) — same source as the S3Client itself.

--- a/storage/framework/core/storage/src/types/filesystem.ts
+++ b/storage/framework/core/storage/src/types/filesystem.ts
@@ -191,6 +191,63 @@ export function filebaseDisk(bucket: string, options?: Partial<Omit<S3DiskConfig
 }
 
 /**
+ * Helper to create a Backblaze B2 disk config (stacksjs/stacks#1897).
+ *
+ * Backblaze B2 exposes an S3-compatible API, so it reuses the `s3` adapter.
+ * `region` is the B2 region embedded in the endpoint (e.g. `us-west-004`,
+ * `eu-central-003`); the endpoint resolves to `https://s3.<region>.backblazeb2.com`.
+ * Supply B2 application key credentials via `options.credentials` or the AWS_* env vars.
+ */
+export function backblazeDisk(bucket: string, region: string, options?: Partial<Omit<S3DiskConfig, 'driver' | 'bucket'>>): S3DiskConfig {
+  return {
+    driver: 's3',
+    bucket,
+    region,
+    endpoint: `https://s3.${region}.backblazeb2.com`,
+    visibility: 'private',
+    ...options,
+  }
+}
+
+/**
+ * Helper to create a Cloudflare R2 disk config (stacksjs/stacks#1896).
+ *
+ * R2 exposes an S3-compatible API, so it reuses the `s3` adapter. R2 has a
+ * single logical region (`auto`) and a per-account endpoint
+ * `https://<accountId>.r2.cloudflarestorage.com`. Supply R2 token credentials
+ * via `options.credentials` or the AWS_* env vars.
+ */
+export function r2Disk(bucket: string, accountId: string, options?: Partial<Omit<S3DiskConfig, 'driver' | 'bucket'>>): S3DiskConfig {
+  return {
+    driver: 's3',
+    bucket,
+    region: 'auto',
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    visibility: 'private',
+    ...options,
+  }
+}
+
+/**
+ * Helper to create a Hetzner Object Storage disk config (stacksjs/stacks#1897).
+ *
+ * Hetzner Object Storage exposes an S3-compatible API, so it reuses the `s3`
+ * adapter. `location` is the datacenter (e.g. `fsn1`, `nbg1`, `hel1`), used as
+ * both the region and the endpoint host `https://<location>.your-objectstorage.com`.
+ * Supply Hetzner S3 credentials via `options.credentials` or the AWS_* env vars.
+ */
+export function hetznerDisk(bucket: string, location: string, options?: Partial<Omit<S3DiskConfig, 'driver' | 'bucket'>>): S3DiskConfig {
+  return {
+    driver: 's3',
+    bucket,
+    region: location,
+    endpoint: `https://${location}.your-objectstorage.com`,
+    visibility: 'private',
+    ...options,
+  }
+}
+
+/**
  * Create filesystem config from environment variables
  */
 export function configFromEnv(base: Partial<FilesystemConfig> = {}): FilesystemConfig {

--- a/storage/framework/core/storage/tests/s3-compatible-disks.test.ts
+++ b/storage/framework/core/storage/tests/s3-compatible-disks.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test'
+import { backblazeDisk, hetznerDisk, r2Disk } from '../src/types/filesystem'
+
+// Backblaze B2, Cloudflare R2 and Hetzner Object Storage are all S3-compatible,
+// so they reuse the s3 adapter with the endpoint pinned to the service
+// (stacksjs/stacks#1897, #1896). These presets make each a first-class disk.
+describe('S3-compatible storage presets', () => {
+  it('backblazeDisk pins the region into the endpoint', () => {
+    expect(backblazeDisk('bucket', 'us-west-004')).toEqual({
+      driver: 's3',
+      bucket: 'bucket',
+      region: 'us-west-004',
+      endpoint: 'https://s3.us-west-004.backblazeb2.com',
+      visibility: 'private',
+    })
+  })
+
+  it('r2Disk uses the auto region and the per-account endpoint', () => {
+    expect(r2Disk('bucket', 'abc123account')).toEqual({
+      driver: 's3',
+      bucket: 'bucket',
+      region: 'auto',
+      endpoint: 'https://abc123account.r2.cloudflarestorage.com',
+      visibility: 'private',
+    })
+  })
+
+  it('hetznerDisk uses the location as both region and endpoint host', () => {
+    expect(hetznerDisk('bucket', 'fsn1')).toEqual({
+      driver: 's3',
+      bucket: 'bucket',
+      region: 'fsn1',
+      endpoint: 'https://fsn1.your-objectstorage.com',
+      visibility: 'private',
+    })
+  })
+
+  it('each accepts credentials and overrides', () => {
+    const disk = r2Disk('assets', 'acct', {
+      credentials: { key: 'R2_KEY', secret: 'R2_SECRET' },
+      prefix: 'uploads/',
+      visibility: 'public',
+    })
+    expect(disk.credentials).toEqual({ key: 'R2_KEY', secret: 'R2_SECRET' })
+    expect(disk.prefix).toBe('uploads/')
+    expect(disk.visibility).toBe('public')
+    expect(disk.endpoint).toBe('https://acct.r2.cloudflarestorage.com')
+  })
+})

--- a/storage/framework/core/storage/tests/s3-endpoint-options.test.ts
+++ b/storage/framework/core/storage/tests/s3-endpoint-options.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test'
+import { resolveS3ClientOptions } from '../src/adapters/s3'
+
+// This helper is what actually routes the S3 adapter to S3-compatible providers
+// (Filebase/B2/R2/Hetzner). Without it the endpoint from the disk presets was
+// dropped and every request hit AWS (stacksjs/stacks#938, #1897, #1896).
+describe('resolveS3ClientOptions', () => {
+  it('returns undefined for a plain AWS config (no endpoint/creds)', () => {
+    expect(resolveS3ClientOptions({})).toBeUndefined()
+  })
+
+  it('strips the scheme and trailing slash (ts-cloud wants a bare host)', () => {
+    expect(resolveS3ClientOptions({ endpoint: 'https://s3.filebase.com' })).toEqual({ endpoint: 's3.filebase.com' })
+    expect(resolveS3ClientOptions({ endpoint: 'https://s3.us-west-004.backblazeb2.com/' }))
+      .toEqual({ endpoint: 's3.us-west-004.backblazeb2.com' })
+    expect(resolveS3ClientOptions({ endpoint: 'http://localhost:9000' })).toEqual({ endpoint: 'localhost:9000' })
+  })
+
+  it('passes forcePathStyle when requested', () => {
+    expect(resolveS3ClientOptions({ endpoint: 'https://x.example', usePathStyleEndpoint: true }))
+      .toEqual({ endpoint: 'x.example', forcePathStyle: true })
+  })
+
+  it('passes credentials through unchanged', () => {
+    expect(resolveS3ClientOptions({ credentials: { accessKeyId: 'A', secretAccessKey: 'S' } }))
+      .toEqual({ credentials: { accessKeyId: 'A', secretAccessKey: 'S' } })
+  })
+
+  it('combines endpoint + credentials (the real R2 shape)', () => {
+    expect(resolveS3ClientOptions({
+      endpoint: 'https://acct.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'A', secretAccessKey: 'S' },
+    })).toEqual({
+      endpoint: 'acct.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'A', secretAccessKey: 'S' },
+    })
+  })
+})


### PR DESCRIPTION
Adds first-class presets for the S3-compatible object stores **and** the plumbing that makes them actually route to the provider.

### The plumbing bug this also fixes
The already-merged `filebaseDisk` (#938) - and these new presets - set `endpoint`, but it was **dropped at every layer**: `facade.createS3Adapter` passed only bucket/region/prefix, `StorageAdapterConfig` had no `endpoint` field, and the adapter built `new S3Client(region)` with no options. So every request silently hit **AWS** instead of the provider. ts-cloud's `S3Client` now accepts `S3ClientOptions` (endpoint/forcePathStyle/credentials), so this PR passes them through:
- `StorageAdapterConfig`: `endpoint` + `usePathStyleEndpoint`
- adapter: `resolveS3ClientOptions` (pure, unit-tested) builds the options, strips the URL scheme ts-cloud doesn't want; passed to `new S3Client(region, undefined, options)`. **AWS default path unchanged.**
- facade: passes endpoint/path-style and maps `{key,secret}` → `{accessKeyId,secretAccessKey}`

### Presets
```ts
import { backblazeDisk, r2Disk, hetznerDisk } from '@stacksjs/storage'
disks: {
  b2:      backblazeDisk('bucket', 'us-west-004'),
  r2:      r2Disk('bucket', '<accountId>'),
  hetzner: hetznerDisk('bucket', 'fsn1'),
}
```

12 unit tests (plumbing helper + all four presets), pickier clean, typecheck clean. Note: the live provider round-trip still needs a real bucket to validate; the config→client plumbing is what's unit-tested.

**Closes #1897.** Advances #1896 (R2 done; GCS semi-S3 and Azure non-S3 remain). Makes #938's `filebaseDisk` functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)