### PR TITLE
ci: guard against a bun.lock version CI's Bun can't read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
           restore-keys: |
             node-modules-
 
+      - name: Check lockfile version
+        run: bun scripts/check-lockfile-version.ts
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "docs:artifacts:check": "bun scripts/docs/generated-artifacts.ts --check",
     "docs:links": "bun scripts/docs/links.ts",
     "docs:links:check": "bun scripts/docs/links.ts --check",
+    "deps:lockfile:check": "bun scripts/check-lockfile-version.ts",
     "protocol:sync": "bun scripts/protocol/sync-suite.ts --write",
     "protocol:check": "bun scripts/protocol/sync-suite.ts --check",
     "protocol:conformance": "bun scripts/protocol/run-conformance.ts",

--- a/scripts/check-lockfile-version.test.ts
+++ b/scripts/check-lockfile-version.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import { EXPECTED_LOCKFILE_VERSION, lockfileVersion } from './check-lockfile-version'
+
+describe('bun.lock version guard', () => {
+  it('parses the lockfileVersion field', () => {
+    expect(lockfileVersion('{\n  "lockfileVersion": 1,\n')).toBe(1)
+    expect(lockfileVersion('{\n  "lockfileVersion": 2,\n  "configVersion": 1,\n')).toBe(2)
+  })
+
+  it('returns null when the field is absent', () => {
+    expect(lockfileVersion('{}')).toBeNull()
+  })
+
+  it('the committed bun.lock is the CI-compatible version', () => {
+    const contents = readFileSync(resolve(import.meta.dir, '..', 'bun.lock'), 'utf8')
+    expect(lockfileVersion(contents)).toBe(EXPECTED_LOCKFILE_VERSION)
+  })
+})

--- a/scripts/check-lockfile-version.ts
+++ b/scripts/check-lockfile-version.ts
@@ -1,0 +1,44 @@
+/**
+ * Guard against a `bun.lock` written by a newer Bun than CI runs.
+ *
+ * CI provisions Bun 1.3.x (the repo's `engines: bun ^1.3.0`), which reads
+ * `lockfileVersion: 1`. Bun 1.4.x writes `lockfileVersion: 2`, which 1.3.x
+ * cannot parse — every job then dies at `bun install --frozen-lockfile` with a
+ * cryptic `Unknown lockfile version`. This runs before install and fails fast
+ * with an actionable message so the fix is obvious.
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/** The lockfile format CI's Bun understands. Bump if the toolchain moves to 1.4.x. */
+export const EXPECTED_LOCKFILE_VERSION = 1
+
+/** Parse the `lockfileVersion` from bun.lock text, or null if absent. */
+export function lockfileVersion(contents: string): number | null {
+  const match = contents.match(/"lockfileVersion"\s*:\s*(\d+)/)
+  return match ? Number(match[1]) : null
+}
+
+if (import.meta.main) {
+  const path = resolve(import.meta.dir, '..', 'bun.lock')
+  const version = lockfileVersion(readFileSync(path, 'utf8'))
+
+  if (version === EXPECTED_LOCKFILE_VERSION) {
+    console.log(`✓ bun.lock is lockfileVersion ${version}`)
+  }
+  else {
+    console.error(
+      `✗ bun.lock is lockfileVersion ${version ?? 'unknown'}, but CI's Bun (1.3.x — the repo's \`engines\`) reads v${EXPECTED_LOCKFILE_VERSION}.\n`
+      + `\n`
+      + `  This happens when \`bun install\` runs on Bun 1.4.x, which writes v2 that 1.3.x can't parse\n`
+      + `  ("Unknown lockfile version" at install). Regenerate the lockfile with stable Bun:\n`
+      + `\n`
+      + `    bunx bun@1.3.14 install\n`
+      + `\n`
+      + `  ...then commit bun.lock. (Or, to move the whole toolchain to 1.4.x, bump CI's Bun +\n`
+      + `  \`engines\` and set EXPECTED_LOCKFILE_VERSION here to 2.)`,
+    )
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
Fast pre-install guard: `scripts/check-lockfile-version.ts` asserts `bun.lock` is `lockfileVersion 1` (what CI's Bun 1.3.x reads) and fails with an actionable message before the cryptic `Unknown lockfile version` install error. Wired into the lint job; exposed as `deps:lockfile:check`; pure parser unit-tested. Prevents the recurring CI break from a 1.4.x-written v2 lockfile. 🤖 Generated with [Claude Code](https://claude.com/claude-code)