### PR TITLE
fix(ci): regenerate bun.lock as v1 and stop releases reintroducing v2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {

--- a/storage/framework/core/actions/src/bump.ts
+++ b/storage/framework/core/actions/src/bump.ts
@@ -258,6 +258,25 @@ if (!isDryRun && existsSync(p.projectPath('bun.lock'))) {
     writeFileSync(lockPath, previousLock)
     throw error
   }
+
+  // CI runs Bun 1.3.x, which only parses lockfileVersion 1. A maintainer
+  // releasing with Bun 1.4.x regenerates v2 here, which then fails every
+  // post-release `bun install --frozen-lockfile` job before lint/typecheck/test
+  // can run (see scripts/check-lockfile-version.ts, the PR-side guard that
+  // release commits bypass). Refuse to ship a lockfile CI cannot read: restore
+  // the previous one and abort with an actionable message.
+  const expectedLockfileVersion = 1
+  const regeneratedLock = readFileSync(lockPath, 'utf8')
+  const versionMatch = regeneratedLock.match(/"lockfileVersion"\s*:\s*(\d+)/)
+  const producedVersion = versionMatch ? Number(versionMatch[1]) : null
+  if (producedVersion !== expectedLockfileVersion) {
+    writeFileSync(lockPath, previousLock)
+    throw new Error(
+      `Release aborted: regenerating bun.lock produced lockfileVersion ${producedVersion ?? 'unknown'}, `
+      + `but CI's Bun (1.3.x) requires v${expectedLockfileVersion}. You are releasing with a newer Bun `
+      + `(1.4.x writes v2). Re-run the release with Bun 1.3.x (e.g. via \`bunx bun@1.3.14\`) so CI can parse the lockfile.`,
+    )
+  }
 }
 
 function pinMetaCoreDeps(version: string): void {

--- a/storage/framework/core/buddy/src/commands/mail.ts
+++ b/storage/framework/core/buddy/src/commands/mail.ts
@@ -21,7 +21,7 @@ export function sanitizeLineCount(value?: string): string {
   return String(Number.isFinite(count) ? Math.min(5000, Math.max(1, count)) : 50)
 }
 
-function shellQuote(_value: string): string {
+function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 

--- a/storage/framework/core/database/src/types.ts
+++ b/storage/framework/core/database/src/types.ts
@@ -267,7 +267,7 @@ const SAFE_FILTER_OPERATORS = new Set([
  * text), so filtered aggregates inline values instead - safely, with
  * strict typing and standard `''` quote escaping.
  */
-function inlineSqlLiteral(_value: unknown): string {
+function inlineSqlLiteral(value: unknown): string {
   if (value === null || value === undefined)
     return 'NULL'
   if (typeof value === 'number') {


### PR DESCRIPTION
**Main is red for every PR**, it keeps recurring, and it was masking a second bug. This is the complete fix.

## The break
The `v0.70.162`/`v0.70.163` `chore: release` commits regenerated `bun.lock` with Bun 1.4.x (`lockfileVersion: 2`). CI's Bun 1.3.x can't parse v2, so `bun install --frozen-lockfile` dies with `Unknown lockfile version` on every job. Because install never succeeded, **CI never reached typecheck** - hiding a latent TS error too.

## Three commits
1. **`fix(ci)`** - regenerated `bun.lock` with `bunx bun@1.3.14 install` to restore v1 and unbreak install now.
2. **`fix(release)`** - the durable fix. `buddy release` (`actions/src/bump.ts`) regenerates the lockfile with the maintainer's local Bun; on 1.4.x that silently writes v2, and release commits bypass the #2113 PR guard by pushing straight to main. `bump.ts` now verifies the regenerated lockfile is CI-compatible and **aborts the release** (restoring the previous lock) if a newer Bun produced v2.
3. **`fix(types)`** - with install fixed, typecheck ran again and surfaced a latent TS2552: `shellQuote` (mail.ts) and `inlineSqlLiteral` (database/types.ts) declared a `_value` param but reference `value` in the body. Renamed to match.

Ends the cycle (commit 2) and clears everything CI was blind to (commits 1 + 3).