### PR TITLE
feat(protocol): wire query parameterization (SEC-01)

### DIFF
--- a/scripts/protocol/run-conformance.test.ts
+++ b/scripts/protocol/run-conformance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { buildReport, executeConfigEvidence, executeConventionsEvidence, executeLifecycleEvidence, executeSecurityEvidence, executeValidationEvidence } from './run-conformance'
+import { buildReport, executeConfigEvidence, executeConventionsEvidence, executeLifecycleEvidence, executeQueryEvidence, executeSecurityEvidence, executeValidationEvidence } from './run-conformance'
 
 const REVISION = '0'.repeat(40)
 
@@ -20,6 +20,11 @@ describe('protocol adapter evidence', () => {
   it('invokes an Action directly, independent of any HTTP transport', async () => {
     const evidence = await executeLifecycleEvidence(REVISION)
     expect(evidence.get('CORE-MVA-01')?.status).toBe('pass')
+  })
+
+  it('parameterizes untrusted values instead of inlining them into SQL', async () => {
+    const evidence = await executeQueryEvidence(REVISION)
+    expect(evidence.get('CORE-SEC-01')?.status).toBe('pass')
   })
 
   it('produces field-keyed validation errors and a redacted 422 envelope', async () => {
@@ -45,7 +50,7 @@ describe('protocol adapter evidence', () => {
   it('marks every passing requirement with a source evidence url', async () => {
     const report = await buildReport() as { results: Array<{ status: string, evidenceUrl: string | null }> }
     const passing = report.results.filter(result => result.status === 'pass')
-    expect(passing.length).toBeGreaterThanOrEqual(11)
+    expect(passing.length).toBeGreaterThanOrEqual(12)
     expect(passing.every(result => typeof result.evidenceUrl === 'string' && result.evidenceUrl.startsWith('https://'))).toBe(true)
   })
 })

--- a/scripts/protocol/run-conformance.ts
+++ b/scripts/protocol/run-conformance.ts
@@ -262,6 +262,40 @@ export async function executeLifecycleEvidence(revision: string): Promise<Eviden
   return evidence
 }
 
+export async function executeQueryEvidence(revision: string): Promise<Evidence> {
+  const evidence: Evidence = new Map()
+  const url = blob(revision, 'storage/framework/core/database/src/types.ts')
+  const started = performance.now()
+  // CORE-SEC-01: database operations parameterize untrusted values by default.
+  // Lazy-import so a stale local pantry link (see the sibling-resolution note)
+  // degrades this one check to skipped instead of crashing the whole adapter;
+  // CI and a healthy checkout resolve it and run the check for real.
+  try {
+    const { sql } = await import('../../storage/framework/core/database/src/types')
+    const attack = '\' OR 1=1 --'
+    const query = sql`SELECT * FROM users WHERE email = ${attack}` as unknown as { sql: string, parameters: unknown[] }
+    const parameterized = query.sql === 'SELECT * FROM users WHERE email = ?'
+      && Array.isArray(query.parameters)
+      && query.parameters.length === 1
+      && query.parameters[0] === attack
+    evidence.set('CORE-SEC-01', {
+      status: parameterized ? 'pass' : 'fail',
+      evidenceUrl: url,
+      durationMs: Math.max(0, performance.now() - started),
+      notes: parameterized ? 'Untrusted input is bound as a positional parameter and never inlined into the SQL text.' : 'Query-parameterization fixture failed.',
+    })
+  }
+  catch (error) {
+    evidence.set('CORE-SEC-01', {
+      status: 'skipped',
+      evidenceUrl: null,
+      durationMs: Math.max(0, performance.now() - started),
+      notes: `Query builder unavailable in this environment: ${error instanceof Error ? error.message.slice(0, 100) : String(error)}`,
+    })
+  }
+  return evidence
+}
+
 function validateSemantics(report: any, catalog: Catalog, fixtures: FixtureCorpus): string[] {
   const errors: string[] = []
   const expected = new Set(catalog.requirements.map(requirement => requirement.id))
@@ -314,6 +348,7 @@ export async function buildReport(): Promise<Record<string, unknown>> {
   for (const [id, value] of executeConventionsEvidence(revision)) evidence.set(id, value)
   for (const [id, value] of await executeValidationEvidence(revision)) evidence.set(id, value)
   for (const [id, value] of await executeLifecycleEvidence(revision)) evidence.set(id, value)
+  for (const [id, value] of await executeQueryEvidence(revision)) evidence.set(id, value)
   const fixtureByRequirement = new Map(fixtures.fixtures.flatMap(fixture => fixture.requirements.map(id => [id, fixture.id] as const)))
   const results: Result[] = catalog.requirements.map((requirement) => ({
     requirementId: requirement.id,


### PR DESCRIPTION
**11/37 → 12/37.** The `sql` tagged template parameterizes untrusted input rather than inlining it:

```
sql`SELECT * FROM users WHERE email = ${"' OR 1=1 --"}`
→ { sql: "SELECT * FROM users WHERE email = ?", parameters: ["' OR 1=1 --"] }
```

Exactly the SEC-01 fixture expectation. Adds query-parameterization to the security baseline (now SEC-01/-02/-05/-07 green there; only the pipeline-embedded CSRF check SEC-03 remains).

**Robustness:** lazy-imported with a skip-on-failure fallback, so a stale local pantry link to a sibling `bun-query-builder` degrades *this one check* to skipped rather than crashing the adapter. CI and a healthy checkout resolve the query builder and run it for real. `profileClaim` stays `null`.

**Verification:** `protocol:conformance` → 12 pass / 35 skipped; `bun test` → 8 pass; lint + types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)