### PR TITLE
feat(protocol): wire CRUD and transaction rollback (DATA-01, DATA-03)

### DIFF
--- a/scripts/protocol/run-conformance.test.ts
+++ b/scripts/protocol/run-conformance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { buildReport, executeConfigEvidence, executeConventionsEvidence, executeLifecycleEvidence, executeQueryEvidence, executeSecurityEvidence, executeValidationEvidence } from './run-conformance'
+import { buildReport, executeConfigEvidence, executeConventionsEvidence, executeDatabaseEvidence, executeLifecycleEvidence, executeQueryEvidence, executeSecurityEvidence, executeValidationEvidence } from './run-conformance'
 
 const REVISION = '0'.repeat(40)
 
@@ -27,6 +27,12 @@ describe('protocol adapter evidence', () => {
     expect(evidence.get('CORE-SEC-01')?.status).toBe('pass')
   })
 
+  it('performs a CRUD round-trip and rolls back a failed transaction', async () => {
+    const evidence = await executeDatabaseEvidence(REVISION)
+    expect(evidence.get('CORE-DATA-01')?.status).toBe('pass')
+    expect(evidence.get('CORE-DATA-03')?.status).toBe('pass')
+  })
+
   it('produces field-keyed validation errors and a redacted 422 envelope', async () => {
     const evidence = await executeValidationEvidence(REVISION)
     expect(evidence.get('CORE-VAL-01')?.status).toBe('pass')
@@ -50,7 +56,7 @@ describe('protocol adapter evidence', () => {
   it('marks every passing requirement with a source evidence url', async () => {
     const report = await buildReport() as { results: Array<{ status: string, evidenceUrl: string | null }> }
     const passing = report.results.filter(result => result.status === 'pass')
-    expect(passing.length).toBeGreaterThanOrEqual(12)
+    expect(passing.length).toBeGreaterThanOrEqual(14)
     expect(passing.every(result => typeof result.evidenceUrl === 'string' && result.evidenceUrl.startsWith('https://'))).toBe(true)
   })
 })

--- a/scripts/protocol/run-conformance.ts
+++ b/scripts/protocol/run-conformance.ts
@@ -296,6 +296,68 @@ export async function executeQueryEvidence(revision: string): Promise<Evidence> 
   return evidence
 }
 
+export async function executeDatabaseEvidence(revision: string): Promise<Evidence> {
+  const evidence: Evidence = new Map()
+  const url = blob(revision, 'storage/framework/core/query-builder/src/index.ts')
+  const started = performance.now()
+  // Lazy-import + skip-on-failure for the same stale-pantry-link robustness as
+  // SEC-01. Runs a throwaway in-memory SQLite so there is no external service.
+  try {
+    const { createQueryBuilder, setConfig } = await import('../../storage/framework/core/query-builder/src/index')
+    setConfig({ dialect: 'sqlite', database: ':memory:' } as Parameters<typeof setConfig>[0])
+    const db = createQueryBuilder() as any
+    // The query builder reuses one global in-memory connection, so a prior run in
+    // the same process leaves the table behind. Drop first for idempotency.
+    await db.raw`DROP TABLE IF EXISTS conformance_widgets`.execute()
+    await db.raw`CREATE TABLE conformance_widgets (id INTEGER PRIMARY KEY, name TEXT)`.execute()
+
+    // CORE-DATA-01: create, read, update, delete round-trip.
+    await db.insertInto('conformance_widgets').values({ id: 1, name: 'a' }).execute()
+    const created = await db.selectFrom('conformance_widgets').selectAll().execute()
+    await db.updateTable('conformance_widgets').set({ name: 'b' }).where('id', '=', 1).execute()
+    const updated = await db.selectFrom('conformance_widgets').select(['name']).where('id', '=', 1).execute()
+    await db.deleteFrom('conformance_widgets').where('id', '=', 1).execute()
+    const afterDelete = await db.selectFrom('conformance_widgets').selectAll().execute()
+    const crudOk = created.length === 1 && created[0]?.name === 'a' && updated[0]?.name === 'b' && afterDelete.length === 0
+    evidence.set('CORE-DATA-01', {
+      status: crudOk ? 'pass' : 'fail',
+      evidenceUrl: url,
+      durationMs: Math.max(0, performance.now() - started),
+      notes: crudOk ? 'Create, read, update, and delete round-trip succeeded against SQLite.' : 'CRUD fixture failed.',
+    })
+
+    // CORE-DATA-03: a failing transaction rolls back its writes.
+    const txStarted = performance.now()
+    await db.insertInto('conformance_widgets').values({ id: 1, name: 'keep' }).execute()
+    let rolledBack = false
+    try {
+      await db.transaction(async (trx: any) => {
+        await trx.insertInto('conformance_widgets').values({ id: 2, name: 'temp' }).execute()
+        throw new Error('force rollback')
+      })
+    }
+    catch {
+      rolledBack = true
+    }
+    const rows = await db.selectFrom('conformance_widgets').selectAll().execute()
+    const txOk = rolledBack && rows.length === 1 && rows[0]?.id === 1
+    evidence.set('CORE-DATA-03', {
+      status: txOk ? 'pass' : 'fail',
+      evidenceUrl: url,
+      durationMs: Math.max(0, performance.now() - txStarted),
+      notes: txOk ? 'A failing transaction rolled back its writes, leaving prior state intact.' : 'Transaction-rollback fixture failed.',
+    })
+  }
+  catch (error) {
+    const note = `Query builder unavailable in this environment: ${error instanceof Error ? error.message.slice(0, 100) : String(error)}`
+    for (const id of ['CORE-DATA-01', 'CORE-DATA-03']) {
+      if (!evidence.has(id))
+        evidence.set(id, { status: 'skipped', evidenceUrl: null, durationMs: Math.max(0, performance.now() - started), notes: note })
+    }
+  }
+  return evidence
+}
+
 function validateSemantics(report: any, catalog: Catalog, fixtures: FixtureCorpus): string[] {
   const errors: string[] = []
   const expected = new Set(catalog.requirements.map(requirement => requirement.id))
@@ -349,6 +411,7 @@ export async function buildReport(): Promise<Record<string, unknown>> {
   for (const [id, value] of await executeValidationEvidence(revision)) evidence.set(id, value)
   for (const [id, value] of await executeLifecycleEvidence(revision)) evidence.set(id, value)
   for (const [id, value] of await executeQueryEvidence(revision)) evidence.set(id, value)
+  for (const [id, value] of await executeDatabaseEvidence(revision)) evidence.set(id, value)
   const fixtureByRequirement = new Map(fixtures.fixtures.flatMap(fixture => fixture.requirements.map(id => [id, fixture.id] as const)))
   const results: Result[] = catalog.requirements.map((requirement) => ({
     requirementId: requirement.id,


### PR DESCRIPTION
**12/37 → 14/37.** With the query builder resolving locally (after the pantry-link fix), a throwaway in-memory SQLite demonstrates two data behaviors against real SQL:

| Requirement | Behavior |
|---|---|
| CORE-DATA-01 | create / read / update / delete round-trip |
| CORE-DATA-03 | a failing transaction rolls back its writes; prior state intact |

**Robustness:** lazy-imported with the same skip-on-failure fallback as SEC-01, and drops its table first so repeated in-process runs stay idempotent (the builder reuses one global in-memory connection). No external service; `profileClaim` stays `null`.

Relations (DATA-02) and migration ordering (MIG-01) remain - DATA-02 needs the join-signature and MIG-01 the migration runner.

**Verification:** `protocol:conformance` → 14 pass / 33 skipped; `bun test` → 9 pass; lint + types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)