### PR TITLE
feat(protocol): wire relation join (DATA-02)

### DIFF
--- a/scripts/protocol/run-conformance.test.ts
+++ b/scripts/protocol/run-conformance.test.ts
@@ -27,9 +27,10 @@ describe('protocol adapter evidence', () => {
     expect(evidence.get('CORE-SEC-01')?.status).toBe('pass')
   })
 
-  it('performs a CRUD round-trip and rolls back a failed transaction', async () => {
+  it('performs a CRUD round-trip, a relation join, and rolls back a failed transaction', async () => {
     const evidence = await executeDatabaseEvidence(REVISION)
     expect(evidence.get('CORE-DATA-01')?.status).toBe('pass')
+    expect(evidence.get('CORE-DATA-02')?.status).toBe('pass')
     expect(evidence.get('CORE-DATA-03')?.status).toBe('pass')
   })
 
@@ -56,7 +57,7 @@ describe('protocol adapter evidence', () => {
   it('marks every passing requirement with a source evidence url', async () => {
     const report = await buildReport() as { results: Array<{ status: string, evidenceUrl: string | null }> }
     const passing = report.results.filter(result => result.status === 'pass')
-    expect(passing.length).toBeGreaterThanOrEqual(14)
+    expect(passing.length).toBeGreaterThanOrEqual(15)
     expect(passing.every(result => typeof result.evidenceUrl === 'string' && result.evidenceUrl.startsWith('https://'))).toBe(true)
   })
 })

--- a/scripts/protocol/run-conformance.ts
+++ b/scripts/protocol/run-conformance.ts
@@ -347,10 +347,31 @@ export async function executeDatabaseEvidence(revision: string): Promise<Evidenc
       durationMs: Math.max(0, performance.now() - txStarted),
       notes: txOk ? 'A failing transaction rolled back its writes, leaving prior state intact.' : 'Transaction-rollback fixture failed.',
     })
+
+    // CORE-DATA-02: a relation query joins related rows across two tables.
+    const relStarted = performance.now()
+    await db.raw`DROP TABLE IF EXISTS conformance_books`.execute()
+    await db.raw`DROP TABLE IF EXISTS conformance_authors`.execute()
+    await db.raw`CREATE TABLE conformance_authors (id INTEGER PRIMARY KEY, name TEXT)`.execute()
+    await db.raw`CREATE TABLE conformance_books (id INTEGER PRIMARY KEY, author_id INTEGER, title TEXT)`.execute()
+    await db.insertInto('conformance_authors').values({ id: 1, name: 'Ada' }).execute()
+    await db.insertInto('conformance_books').values([{ id: 1, author_id: 1, title: 'B1' }, { id: 2, author_id: 1, title: 'B2' }]).execute()
+    const related = await db.selectFrom('conformance_books')
+      .innerJoin('conformance_authors', 'conformance_authors.id', '=', 'conformance_books.author_id')
+      .select(['conformance_books.title', 'conformance_authors.name'])
+      .where('conformance_authors.id', '=', 1)
+      .execute()
+    const relationOk = related.length === 2 && related.every((row: any) => row.name === 'Ada')
+    evidence.set('CORE-DATA-02', {
+      status: relationOk ? 'pass' : 'fail',
+      evidenceUrl: url,
+      durationMs: Math.max(0, performance.now() - relStarted),
+      notes: relationOk ? 'A relation query joined related rows across two tables.' : 'Relation fixture failed.',
+    })
   }
   catch (error) {
     const note = `Query builder unavailable in this environment: ${error instanceof Error ? error.message.slice(0, 100) : String(error)}`
-    for (const id of ['CORE-DATA-01', 'CORE-DATA-03']) {
+    for (const id of ['CORE-DATA-01', 'CORE-DATA-02', 'CORE-DATA-03']) {
       if (!evidence.has(id))
         evidence.set(id, { status: 'skipped', evidenceUrl: null, durationMs: Math.max(0, performance.now() - started), notes: note })
     }


### PR DESCRIPTION
**14/37 → 15/37.** Extends the in-memory SQLite database evidence with a relation query: two books `innerJoin` their author across tables and resolve correctly. Completes the CRUD (DATA-01), relation (DATA-02), and transaction (DATA-03) requirements of the data-persistence fixture; only migration ordering (MIG-01) remains there.

Same lazy-import + skip-on-failure robustness; `profileClaim` stays `null`.

**Verification:** `protocol:conformance` → 15 pass / 32 skipped; `bun test` → 9 pass; lint + types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)