### PR TITLE
fix(upgrade): resolve stable channel to latest tag, not a nonexistent branch

### DIFF
--- a/storage/framework/core/actions/src/upgrade/framework-utils.ts
+++ b/storage/framework/core/actions/src/upgrade/framework-utils.ts
@@ -11,46 +11,65 @@ export interface UpgradeContext {
 }
 
 /**
+ * Resolve the latest published stable git tag (e.g. `v0.70.163`).
+ *
+ * The release pipeline (`.github/workflows/release.yml`) is triggered only by
+ * `push: tags: ['v*']`; it publishes `vX` tags and never pushes a `stable`
+ * branch. So the `stable` channel tracks the latest published tag, not a branch
+ * ref. We read npm's `latest` dist-tag (the same source `packages.ts` uses) and
+ * map it to its `vX` git tag, which the GitHub tarball endpoint resolves.
+ */
+export async function resolveLatestStableTag(): Promise<string> {
+  const res = await fetch('https://registry.npmjs.org/stacks').catch(() => null)
+  const meta = res?.ok
+    ? (await res.json().catch(() => null)) as { 'dist-tags'?: Record<string, string> } | null
+    : null
+  const latest = meta?.['dist-tags']?.latest
+  if (!latest)
+    throw new Error('Could not resolve the latest stable Stacks version from npm; retry, or pass `--version <tag>` or `--canary`.')
+  return latest.startsWith('v') ? latest : `v${latest}`
+}
+
+/**
  * Resolve the target channel and git ref from CLI options and persisted channel.
  * Priority: --version > --canary > --stable > persisted channel
  *
- * Branch model: `main` is the bleeding-edge "dump everything" branch; `stable`
- * is the vetted branch that PRs are merged into from `main` once main is proven.
- * So the `stable` channel tracks the `stable` branch (vetted) and the `canary`
- * channel tracks the `main` branch (bleeding edge). A pinned `--version` still
- * resolves to the matching `vX` tag.
+ * Channel model: `canary` tracks the `main` branch (bleeding edge). `stable`
+ * tracks the latest published `vX` tag, because the release process only ships
+ * tags and there is no `stable` branch (stacksjs/stacks#2117). A pinned
+ * `--version` resolves to the matching `vX` tag. The tag is resolved through
+ * `resolveLatestTag` (injectable for tests).
  */
-export function resolveUpgradeContext(options: {
+export async function resolveUpgradeContext(options: {
   version?: string
   canary?: boolean
   stable?: boolean
-}, currentChannel: 'stable' | 'canary'): UpgradeContext {
+}, currentChannel: 'stable' | 'canary', resolveLatestTag: () => Promise<string> = resolveLatestStableTag): Promise<UpgradeContext> {
   const targetVersion = options.version
 
   if (targetVersion) {
-    // Specific version requested — use the git tag
-    // Support both "0.70.23" and "v0.70.23"
+    // Specific version requested. Use the git tag; support "0.70.23" and "v0.70.23".
     const ref = targetVersion.startsWith('v') ? targetVersion : `v${targetVersion}`
     return { channel: 'stable', ref, targetVersion }
   }
 
   if (options.canary) {
-    // canary tracks `main` — main IS the bleeding edge.
+    // canary tracks `main`, the bleeding edge.
     return { channel: 'canary', ref: 'main' }
   }
 
   if (options.stable) {
-    // stable tracks the vetted `stable` branch.
-    return { channel: 'stable', ref: 'stable' }
+    // stable tracks the latest published `vX` tag (no `stable` branch exists).
+    return { channel: 'stable', ref: await resolveLatestTag() }
   }
 
   if (currentChannel === 'canary') {
-    // Stay on canary if already on canary (like bun upgrade on canary stays on
-    // canary). canary tracks `main` — main IS the bleeding edge.
+    // Stay on canary if already on canary (like `bun upgrade` on canary).
     return { channel: 'canary', ref: 'main' }
   }
 
-  return { channel: 'stable', ref: 'stable' }
+  // Default: the latest published stable tag.
+  return { channel: 'stable', ref: await resolveLatestTag() }
 }
 
 /**

--- a/storage/framework/core/actions/src/upgrade/framework.ts
+++ b/storage/framework/core/actions/src/upgrade/framework.ts
@@ -79,7 +79,7 @@ if (!existsSync(p.projectPath('storage/framework/core'))) {
 const channelFile = join(projectRoot, '.stacks-channel')
 const versionFile = join(projectRoot, '.stacks-version')
 const currentChannel = readChannel(channelFile)
-const ctx = resolveUpgradeContext(options, currentChannel)
+const ctx = await resolveUpgradeContext(options, currentChannel)
 
 const corePkgPath = p.projectPath('storage/framework/core/buddy/package.json')
 const currentVersion = readVersion(corePkgPath)

--- a/storage/framework/core/actions/tests/upgrade-framework.test.ts
+++ b/storage/framework/core/actions/tests/upgrade-framework.test.ts
@@ -37,16 +37,21 @@ afterEach(() => {
 // ─── resolveUpgradeContext ───────────────────────────────────────────────────
 
 describe('resolveUpgradeContext', () => {
+  // The stable channel resolves the latest published tag (there is no `stable`
+  // branch - stacksjs/stacks#2117). Inject a fixed tag so these unit tests stay
+  // offline and deterministic.
+  const stableTag = async (): Promise<string> => 'v9.9.9'
+
   describe('default behavior', () => {
-    it('should default to the stable channel + stable branch when no options and channel is stable', () => {
-      const ctx = resolveUpgradeContext({}, 'stable')
+    it('defaults to the stable channel + latest tag when no options and channel is stable', async () => {
+      const ctx = await resolveUpgradeContext({}, 'stable', stableTag)
       expect(ctx.channel).toBe('stable')
-      expect(ctx.ref).toBe('stable')
+      expect(ctx.ref).toBe('v9.9.9')
       expect(ctx.targetVersion).toBeUndefined()
     })
 
-    it('should stay on canary (main branch) if current channel is canary and no flags', () => {
-      const ctx = resolveUpgradeContext({}, 'canary')
+    it('should stay on canary (main branch) if current channel is canary and no flags', async () => {
+      const ctx = await resolveUpgradeContext({}, 'canary')
       expect(ctx.channel).toBe('canary')
       expect(ctx.ref).toBe('main')
       expect(ctx.targetVersion).toBeUndefined()
@@ -54,90 +59,90 @@ describe('resolveUpgradeContext', () => {
   })
 
   describe('--canary flag', () => {
-    it('should switch to canary (main branch) when --canary is set', () => {
-      const ctx = resolveUpgradeContext({ canary: true }, 'stable')
+    it('should switch to canary (main branch) when --canary is set', async () => {
+      const ctx = await resolveUpgradeContext({ canary: true }, 'stable')
       expect(ctx.channel).toBe('canary')
       expect(ctx.ref).toBe('main')
     })
 
-    it('should stay on canary (main branch) when already on canary and --canary is set', () => {
-      const ctx = resolveUpgradeContext({ canary: true }, 'canary')
+    it('should stay on canary (main branch) when already on canary and --canary is set', async () => {
+      const ctx = await resolveUpgradeContext({ canary: true }, 'canary')
       expect(ctx.channel).toBe('canary')
       expect(ctx.ref).toBe('main')
     })
   })
 
   describe('--stable flag', () => {
-    it('should switch to the stable branch when --stable is set from canary', () => {
-      const ctx = resolveUpgradeContext({ stable: true }, 'canary')
+    it('switches to the stable channel + latest tag when --stable is set from canary', async () => {
+      const ctx = await resolveUpgradeContext({ stable: true }, 'canary', stableTag)
       expect(ctx.channel).toBe('stable')
-      expect(ctx.ref).toBe('stable')
+      expect(ctx.ref).toBe('v9.9.9')
     })
 
-    it('should stay on the stable branch when already stable and --stable is set', () => {
-      const ctx = resolveUpgradeContext({ stable: true }, 'stable')
+    it('stays on the stable channel + latest tag when already stable and --stable is set', async () => {
+      const ctx = await resolveUpgradeContext({ stable: true }, 'stable', stableTag)
       expect(ctx.channel).toBe('stable')
-      expect(ctx.ref).toBe('stable')
+      expect(ctx.ref).toBe('v9.9.9')
     })
   })
 
   describe('--version flag', () => {
-    it('should use version tag without v prefix', () => {
-      const ctx = resolveUpgradeContext({ version: '0.70.23' }, 'stable')
+    it('should use version tag without v prefix', async () => {
+      const ctx = await resolveUpgradeContext({ version: '0.70.23' }, 'stable')
       expect(ctx.channel).toBe('stable')
       expect(ctx.ref).toBe('v0.70.23')
       expect(ctx.targetVersion).toBe('0.70.23')
     })
 
-    it('should use version tag with v prefix as-is', () => {
-      const ctx = resolveUpgradeContext({ version: 'v0.70.23' }, 'stable')
+    it('should use version tag with v prefix as-is', async () => {
+      const ctx = await resolveUpgradeContext({ version: 'v0.70.23' }, 'stable')
       expect(ctx.channel).toBe('stable')
       expect(ctx.ref).toBe('v0.70.23')
       expect(ctx.targetVersion).toBe('v0.70.23')
     })
 
-    it('should take priority over --canary', () => {
-      const ctx = resolveUpgradeContext({ version: '0.70.23', canary: true }, 'stable')
+    it('should take priority over --canary', async () => {
+      const ctx = await resolveUpgradeContext({ version: '0.70.23', canary: true }, 'stable')
       expect(ctx.channel).toBe('stable')
       expect(ctx.ref).toBe('v0.70.23')
       expect(ctx.targetVersion).toBe('0.70.23')
     })
 
-    it('should take priority over --stable', () => {
-      const ctx = resolveUpgradeContext({ version: '0.70.23', stable: true }, 'canary')
+    it('should take priority over --stable', async () => {
+      const ctx = await resolveUpgradeContext({ version: '0.70.23', stable: true }, 'canary')
       expect(ctx.channel).toBe('stable')
       expect(ctx.ref).toBe('v0.70.23')
     })
 
-    it('should take priority over persisted canary channel', () => {
-      const ctx = resolveUpgradeContext({ version: '0.70.23' }, 'canary')
+    it('should take priority over persisted canary channel', async () => {
+      const ctx = await resolveUpgradeContext({ version: '0.70.23' }, 'canary')
       expect(ctx.channel).toBe('stable')
       expect(ctx.ref).toBe('v0.70.23')
     })
 
-    it('should handle semver-only strings', () => {
-      const ctx = resolveUpgradeContext({ version: '1.0.0' }, 'stable')
+    it('should handle semver-only strings', async () => {
+      const ctx = await resolveUpgradeContext({ version: '1.0.0' }, 'stable')
       expect(ctx.ref).toBe('v1.0.0')
     })
 
-    it('should handle pre-release version strings', () => {
-      const ctx = resolveUpgradeContext({ version: '1.0.0-beta.1' }, 'stable')
+    it('should handle pre-release version strings', async () => {
+      const ctx = await resolveUpgradeContext({ version: '1.0.0-beta.1' }, 'stable')
       expect(ctx.ref).toBe('v1.0.0-beta.1')
     })
   })
 
   describe('flag priority', () => {
-    it('--version beats --canary beats --stable beats persisted channel', () => {
+    it('--version beats --canary beats --stable beats persisted channel', async () => {
       // version > canary
-      const v = resolveUpgradeContext({ version: '1.0.0', canary: true, stable: true }, 'canary')
+      const v = await resolveUpgradeContext({ version: '1.0.0', canary: true, stable: true }, 'canary')
       expect(v.ref).toBe('v1.0.0')
 
       // canary > stable (when no version)
-      const c = resolveUpgradeContext({ canary: true, stable: true }, 'stable')
+      const c = await resolveUpgradeContext({ canary: true, stable: true }, 'stable')
       expect(c.channel).toBe('canary')
 
       // stable > persisted canary (when no version/canary)
-      const s = resolveUpgradeContext({ stable: true }, 'canary')
+      const s = await resolveUpgradeContext({ stable: true }, 'canary', stableTag)
       expect(s.channel).toBe('stable')
     })
   })


### PR DESCRIPTION
Fixes #2117.

## The bug
`buddy upgrade` (default channel, and `--stable`) resolved to a git ref literally named `stable`, but the release pipeline (`release.yml`, triggered only by `push: tags: ['v*']`) publishes `vX` tags and **never creates a `stable` branch**. So every `./buddy upgrade` 404'd:

```
source: github:stacksjs/stacks#stable
✘ Failed to download …/tarball/stable: 404 Not Found
```

The default upgrade path has been dead since `04bfbc38e` introduced the branch assumption. Only `--version <tag>` and `--from <checkout>` worked.

## The fix
Resolve the stable/default channel to the **latest published tag** (via npm's `latest` dist-tag, mapped to its `vX` git tag - the tag the release pipeline guarantees exists). `resolveUpgradeContext` is now async with an **injectable** tag resolver so the unit tests stay offline. `canary` still tracks `main`; a pinned `--version` still resolves to its `vX` tag.

## Verification
- `resolveLatestStableTag()` resolves `v0.70.163` (a real, downloadable tag) instead of `stable`.
- Upgrade tests: 91 pass / 0 fail; lint + types clean.

(The issue also flags a separate `@stacksjs/bun-router@0.0.19` orphan-export bundle bug, fixed in `0.0.20` - out of scope here; worth deprecating `0.0.19` on npm.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)