### PR TITLE
fix(dashboard): native window uses HTTPS now that Craft trusts local dev TLS

### DIFF
--- a/storage/framework/core/actions/src/dev/dashboard.ts
+++ b/storage/framework/core/actions/src/dev/dashboard.ts
@@ -571,15 +571,6 @@ const initialUrl = dashboardHttpsUrl && proxyStarted
   ? `${dashboardHttpsUrl}/`
   : `${dashboardLocalUrl}/`
 
-// The native Craft window loads over http://localhost, NOT the pretty HTTPS URL
-// shown above. Craft's WKWebView rejects the tlsx local-CA cert ("The
-// certificate for this server is invalid") because Craft installs no
-// didReceiveAuthenticationChallenge handler to trust it, so the HTTPS URL fails
-// to load and the window goes blank / flashes then clears. Plain http on
-// loopback needs no cert and renders identically in the webview. The browser
-// "Local" URL above stays HTTPS for anyone opening it in a real browser.
-const nativeWindowUrl = `${dashboardLocalUrl}/`
-
 // Print vite-style output
 const elapsedMs = (Bun.nanoseconds() - startTime) / 1_000_000
 
@@ -738,7 +729,11 @@ if (createApp) {
   }
 
   const app = createApp!({
-    url: nativeWindowUrl,
+    // Same pretty HTTPS URL as the browser. Craft's WKWebView trusts the tlsx
+    // local-dev CA via its didReceiveAuthenticationChallenge handler (scoped to
+    // loopback / *.localhost), so the native window loads it directly instead of
+    // failing the cert and going blank.
+    url: initialUrl,
     quiet: !verbose,
     ...(craftBinaryPath && { craftPath: craftBinaryPath }),
     window: {


### PR DESCRIPTION
Removes the http://localhost **workaround** from #2191 that @chrisbreuer flagged. The proper fix landed in Craft: its WKWebView now trusts the tlsx local-CA cert via a scoped `didReceiveAuthenticationChallenge` handler (loopback / `*.localhost` only) - **home-lang/craft#17**.

With that, the native dashboard window loads the **same pretty HTTPS URL as the browser** (`initialUrl`) instead of a special-cased http origin. No consumer-side cert logic; Craft owns it.

```diff
-  // http://localhost workaround because Craft's WKWebView rejects the cert...
-  const nativeWindowUrl = `${dashboardLocalUrl}/`
   ...
-    url: nativeWindowUrl,
+    url: initialUrl,   // same HTTPS URL as the browser; Craft trusts the local dev CA
```

## ⚠️ Merge order

**This depends on Craft shipping the handler (home-lang/craft#17).** Merge order:
1. Merge home-lang/craft#17, cut a Craft build/release with the handler.
2. Then merge this.

Merging this before Craft has the handler would white-screen `buddy dev --dashboard` for anyone on an older Craft binary. My local Craft is already rebuilt from #17, so the real https flow can be verified on this branch now.

Verified: Craft's `--debug` shows the handler firing (`[Nav] trusting local dev TLS cert`) and WKWebView loads the local HTTPS URL; lint clean.