### PR TITLE
fix(ci): run redis as a Docker service container, not a pantry binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,15 @@ jobs:
         ports:
           - 8000:8000
 
+      # Redis via a Docker service container (bundles its own OpenSSL), matching
+      # the mysql/dynamodb services above. The pantry `services: redis@…` binary
+      # was linked against OpenSSL 1.1, which ubuntu-latest (OpenSSL 3) no longer
+      # ships, so `redis-server` died at setup with a missing libssl.so.1.1.
+      redis:
+        image: redis:8
+        ports:
+          - 6379:6379
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -117,7 +126,6 @@ jobs:
         with:
           version: '0.10.47'
           install: 'false'
-          services: redis@8.8.0
 
       - name: Use cached node_modules
         uses: actions/cache@v5
@@ -138,6 +146,15 @@ jobs:
   protocol-conformance:
     runs-on: ubuntu-latest
 
+    # Redis via a Docker service container (see the test job) instead of the
+    # pantry `services: redis@…` binary, which needs OpenSSL 1.1 that
+    # ubuntu-latest no longer ships.
+    services:
+      redis:
+        image: redis:8
+        ports:
+          - 6379:6379
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -149,7 +166,6 @@ jobs:
         with:
           version: '0.10.47'
           install: 'false'
-          services: redis@8.8.0
 
       - name: Use cached node_modules
         uses: actions/cache@v5


### PR DESCRIPTION
## Problem

Every CI run on `main` (and every PR) has been failing. The `test` and `protocol-conformance` jobs pass `services: redis@8.8.0` to the pantry action, which starts a `redis-server` linked against **OpenSSL 1.1**. `ubuntu-latest` moved to OpenSSL 3 and no longer ships `libssl.so.1.1`, so the binary dies at the **"Setup Pantry"** step:

```
pantry/.bin/redis-server: error while loading shared libraries:
libssl.so.1.1: cannot open shared object file: No such file or directory
```

Both jobs fail at setup, before any test or conformance logic runs. `lint`/`typecheck` don't request redis, so they pass - which is why the failure looks selective.

## Fix

Provision redis the same way `mysql` and `dynamodb` already are in the `test` job: a **Docker service container** (`redis:8` on `6379`). It bundles its own OpenSSL and is immune to the runner's system libraries. The framework connects to `127.0.0.1:6379` with `tls: false` (see `config/cache.ts`), so it's a drop-in - no test changes needed.

- `test` job: add `redis` to the existing `services:` block.
- `protocol-conformance` job: add a `services:` block with `redis`.
- Remove `services: redis@8.8.0` from both pantry steps.

## Verification

This PR's own CI run is the test: the `test` and `protocol-conformance` jobs should now get past "Setup Pantry" and run the actual suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)