### PR TITLE
Revert "fix(ci): run redis as a Docker service container" (#2197)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,15 +108,6 @@ jobs:
         ports:
           - 8000:8000
 
-      # Redis via a Docker service container (bundles its own OpenSSL), matching
-      # the mysql/dynamodb services above. The pantry `services: redis@…` binary
-      # was linked against OpenSSL 1.1, which ubuntu-latest (OpenSSL 3) no longer
-      # ships, so `redis-server` died at setup with a missing libssl.so.1.1.
-      redis:
-        image: redis:8
-        ports:
-          - 6379:6379
-
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -126,6 +117,7 @@ jobs:
         with:
           version: '0.10.47'
           install: 'false'
+          services: redis@8.8.0
 
       - name: Use cached node_modules
         uses: actions/cache@v5
@@ -146,15 +138,6 @@ jobs:
   protocol-conformance:
     runs-on: ubuntu-latest
 
-    # Redis via a Docker service container (see the test job) instead of the
-    # pantry `services: redis@…` binary, which needs OpenSSL 1.1 that
-    # ubuntu-latest no longer ships.
-    services:
-      redis:
-        image: redis:8
-        ports:
-          - 6379:6379
-
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -166,6 +149,7 @@ jobs:
         with:
           version: '0.10.47'
           install: 'false'
+          services: redis@8.8.0
 
       - name: Use cached node_modules
         uses: actions/cache@v5


### PR DESCRIPTION
Reverts #2197.

The Docker service container sidestepped pantry instead of fixing why pantry's redis is broken - a workaround, not a root-cause fix. `redis@8.8.0` was intentionally moved onto pantry in `ccd35db3` (`chore(ci): pin Pantry and ts-cloud deployment contracts`), so provisioning redis a different way undoes that intent.

**Root cause to fix instead (pantry-side):** pantry's `redis@8.8.0` ships a `redis-server` dynamically linked against OpenSSL 1.1, which `ubuntu-latest` (OpenSSL 3) no longer provides. The fix belongs in the pantry redis package (build/link against OpenSSL 3, or statically), or by pinning a pantry redis version that already does - not in `ci.yml`.

CI returns to red at "Setup Pantry" until the pantry package is fixed. That's the honest state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)