### PR TITLE
fix(database): detect and repair migration ledger drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,8 @@ jobs:
           bun test storage/framework/core/database/tests/committed-migrations-dialect.test.ts
           bun test storage/framework/core/database/tests/model-sources.test.ts
           bun test storage/framework/core/database/tests/emitted-migration-execution.test.ts
+          bun test storage/framework/core/database/tests/migration-ledger.test.ts
+          bun test storage/framework/core/database/tests/migration-ledger-reconcile.test.ts
 
       - name: Core tests (buddy)
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}

--- a/docs/guide/buddy/commands.md
+++ b/docs/guide/buddy/commands.md
@@ -6,7 +6,7 @@ description: Generated reference for every Buddy command, argument, option, alia
 
 # Buddy Command Reference
 
-This reference is generated from Buddy's runtime command registry and currently contains **303 commands**. Run `bun run docs:buddy` after changing the registry; CI rejects stale output.
+This reference is generated from Buddy's runtime command registry and currently contains **304 commands**. Run `bun run docs:buddy` after changing the registry; CI rejects stale output.
 
 ## Command groups
 
@@ -41,7 +41,7 @@ This reference is generated from Buddy's runtime command registry and currently 
 | `mail` | 30 |
 | `make` | 18 |
 | `marketing` | 2 |
-| `migrate` | 5 |
+| `migrate` | 6 |
 | `monitoring` | 2 |
 | `package` | 1 |
 | `phone` | 4 |
@@ -3094,6 +3094,21 @@ Rebuild database/migrations from your models for a given dialect
 | --- | --- | --- | --- |
 | `--dry-run` | Show what would change without writing anything | boolean, optional | `false` |
 | `-f`, `--force` | Regenerate even though the database already has migrations recorded | boolean, optional | `false` |
+
+### `migrate:status`
+
+Compare database/migrations, the migrations ledger, and the live schema
+
+- Usage: `$ buddy migrate:status`
+- Namespace: `migrate`
+- Aliases: none
+- Arguments: none
+
+| Option | Description | Contract | Default |
+| --- | --- | --- | --- |
+| `--reconcile` | Repair the ledger where the schema proves what happened | boolean, optional | `false` |
+| `--include-partial` | With --reconcile, also record half-applied migrations | boolean, optional | `false` |
+| `--json` | Emit the audit as JSON | boolean, optional | `false` |
 
 ### `migrate:switch`
 

--- a/storage/framework/core/buddy/src/commands/doctor.ts
+++ b/storage/framework/core/buddy/src/commands/doctor.ts
@@ -300,6 +300,32 @@ export function doctor(buddy: CLI): void {
         throw new Error(`${result.missing.length}/${result.declared.length} declared unique constraints have no UNIQUE index: ${sample}${more}. Run \`buddy migrate\` (re-queues missing unique-index migrations, #1952) — dedupe duplicate rows first or migrate hard-fails; if no migration file exists run \`buddy generate:migrations\`, or create manually: ${example}`)
       }, 10000)
 
+      // Migration ledger drift (stacksjs/stacks#2203). The `migrations`
+      // table keys on the FILENAME, and regenerating the corpus from
+      // the models renumbers every file — so an already-applied
+      // migration reads as pending and everything after it queues
+      // behind. The reported case ran that way for weeks and first
+      // surfaced as a 500 in an unrelated feature panel. Nothing
+      // compared the ledger to the schema, so nothing caught it; this
+      // is that comparison. Read-only. 10s budget — it reads every
+      // migration file and introspects the live schema.
+      await probe(checks, 'Migration ledger', async () => {
+        const { auditMigrationLedger } = await import('@stacksjs/database')
+        const result = await auditMigrationLedger()
+        if (!result.supported) return 'Dialect not audited (skipped)'
+        if (result.entries.length === 0) return 'No migration files'
+        const { counts, orphans } = result
+        if (!result.drift)
+          return `${result.entries.length} migrations, ledger consistent with the schema`
+
+        const parts: string[] = []
+        if (counts.stranded > 0) parts.push(`${counts.stranded} applied but unrecorded (would re-run)`)
+        if (counts.partial > 0) parts.push(`${counts.partial} half-applied`)
+        if (counts.reverted > 0) parts.push(`${counts.reverted} recorded but missing from the schema`)
+        if (orphans.length > 0) parts.push(`${orphans.length} ledger row(s) with no file on disk`)
+        throw new Error(`Migration ledger has drifted: ${parts.join(', ')}. Inspect with \`buddy migrate:status\`, repair with \`buddy migrate:status --reconcile\`.`)
+      }, 10000)
+
       // FK orphans (stacksjs/stacks#1951). FK enforcement flipped ON
       // against databases written under `foreign_keys = OFF`, so legacy
       // rows can reference parents that no longer exist. READ-ONLY scan

--- a/storage/framework/core/buddy/src/commands/migrate.ts
+++ b/storage/framework/core/buddy/src/commands/migrate.ts
@@ -1110,8 +1110,138 @@ export function migrate(buddy: CLI): void {
       }
 
       log.success(`Wrote ${result.value.files.length} ${target} migration file(s) to database/migrations.`)
+
+      // Regeneration just renumbered every file, and the ledger keys on the
+      // filename — so without this, every migration this database had already
+      // applied now reads as pending and re-runs on the next `migrate`
+      // (stacksjs/stacks#2203). Reconciling is only reachable here after the
+      // guard above, i.e. an empty ledger or an explicit --force, and it is
+      // strictly safer than leaving the rows pointing at files that no longer
+      // exist.
+      if (applied > 0) {
+        const { reconcileMigrationLedger } = await import('@stacksjs/database')
+        const fixed = await reconcileMigrationLedger()
+        if (fixed.remapped.length > 0)
+          log.info(`Repointed ${fixed.remapped.length} ledger row(s) at their renumbered file.`)
+        if (fixed.recorded.length > 0)
+          log.info(`Recorded ${fixed.recorded.length} migration(s) already present in the schema.`)
+        if (fixed.skipped.length > 0) {
+          log.warn(`${fixed.skipped.length} ledger entr(ies) need a look — run \`./buddy migrate:status\`.`)
+        }
+      }
+
       log.info('Review the change with `git diff`, then run `./buddy migrate`.')
       await outro('Regenerated.', { startTime: perf, useSeconds: true })
+      process.exit(ExitCode.Success)
+    })
+
+  // `buddy migrate:status` — compare the corpus on disk, the `migrations`
+  // ledger, and the live schema.
+  //
+  // The ledger alone cannot be trusted to describe itself: it keys on the
+  // filename, regeneration renumbers files, and a renumbered migration then
+  // reads as pending forever. In the reported case (stacksjs/stacks#2203) the
+  // ledger claimed 6 applied while the schema reflected 22, and the first
+  // symptom was a 500 from an unrelated feature weeks later. Reading the schema
+  // is what tells "applied, row lost" apart from "genuinely never ran".
+  buddy
+    .command('migrate:status', 'Compare database/migrations, the migrations ledger, and the live schema')
+    .option('--reconcile', 'Repair the ledger where the schema proves what happened', { default: false })
+    .option('--include-partial', 'With --reconcile, also record half-applied migrations', { default: false })
+    .option('--json', 'Emit the audit as JSON', { default: false })
+    .action(async (options: { reconcile?: boolean, includePartial?: boolean, json?: boolean }) => {
+      const perf = options.json ? undefined : await intro('buddy migrate:status')
+
+      const { auditMigrationLedger, reconcileMigrationLedger } = await import('@stacksjs/database')
+      const audit = await auditMigrationLedger()
+
+      if (options.json) {
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(audit, (_k, v) => (v instanceof Set ? [...v] : v), 2))
+        process.exit(audit.drift ? ExitCode.FatalError : ExitCode.Success)
+      }
+
+      if (!audit.supported) {
+        log.info(`Dialect "${audit.dialect}" is not audited. Nothing to compare.`)
+        await outro('Skipped.', { startTime: perf!, useSeconds: true })
+        process.exit(ExitCode.Success)
+      }
+
+      const { counts, entries, orphans } = audit
+      const list = (status: string): string[] => entries.filter(e => e.status === status).map(e => e.file)
+
+      // One buffer, one write. `log.*` is async and `console.log` is not, so
+      // interleaving them detaches every heading from the list it introduces.
+      const report: string[] = []
+      const section = (heading: string, files: string[]): void => {
+        if (files.length === 0) return
+        if (heading) report.push(`  ${heading}`)
+        for (const file of files.slice(0, 8)) report.push(`      ${file}`)
+        if (files.length > 8) report.push(`      … +${files.length - 8} more`)
+        report.push('')
+      }
+
+      report.push('')
+      report.push(`  Migration status: ${audit.dialect}`)
+      report.push('  ─────────────────────────────────────────────')
+      report.push(`  ${entries.length} file(s) on disk · ${audit.recordedCount} recorded in the ledger`)
+      report.push('')
+
+      if (counts.applied > 0)
+        report.push(`  ${counts.applied} applied - recorded, and present in the schema.`, '')
+      if (counts.unverifiable > 0)
+        report.push(`  ${counts.unverifiable} unverifiable - data migrations with no schema trace to check.`, '')
+
+      section(`${counts.pending} pending - not applied yet, will run on the next \`buddy migrate\`:`, list('pending'))
+      if (counts.stranded > 0) {
+        report.push(`  ${counts.stranded} STRANDED - already applied to the schema, but missing from the ledger.`)
+        report.push('  These re-run on the next `buddy migrate`, which is unsafe for anything not idempotent.')
+        section('', list('stranded'))
+      }
+      section(`${counts.partial} PARTIAL - some effects present, some missing. Needs a human:`, list('partial'))
+      section(`${counts.reverted} REVERTED - recorded as applied, but the effects are gone from the schema:`, list('reverted'))
+
+      if (orphans.length > 0) {
+        section(
+          `${orphans.length} orphaned ledger row(s) - recorded, but no such file on disk:`,
+          orphans.map(o => `${o.migration}${o.renamedTo ? `  -> renumbered to ${o.renamedTo}` : '  (no counterpart; migration deleted?)'}`),
+        )
+      }
+
+      // eslint-disable-next-line no-console
+      console.log(report.join('\n'))
+
+      if (!audit.drift) {
+        await outro('Ledger matches the corpus and the schema.', { startTime: perf!, useSeconds: true })
+        process.exit(ExitCode.Success)
+      }
+
+      if (!options.reconcile) {
+        // eslint-disable-next-line no-console
+        console.log(`
+  Repair with:  ./buddy migrate:status --reconcile
+  That repoints renumbered ledger rows and records migrations the schema
+  already proves. It never runs SQL from a migration file.
+`)
+        await outro('Drift detected.', { startTime: perf!, useSeconds: true })
+        process.exit(ExitCode.FatalError)
+      }
+
+      const fixed = await reconcileMigrationLedger({ includePartial: options.includePartial })
+      if (fixed.remapped.length > 0)
+        log.success(`Repointed ${fixed.remapped.length} ledger row(s) at their renumbered file.`)
+      if (fixed.recorded.length > 0)
+        log.success(`Recorded ${fixed.recorded.length} migration(s) the schema already reflects.`)
+      if (fixed.skipped.length > 0) {
+        log.warn(`Left ${fixed.skipped.length} entr(ies) alone:`)
+        // eslint-disable-next-line no-console
+        console.log(fixed.skipped.slice(0, 8).map(s => `      ${s.file} — ${s.reason}`).join('\n')
+          + (fixed.skipped.length > 8 ? `\n      … +${fixed.skipped.length - 8} more` : ''))
+      }
+      if (fixed.remapped.length === 0 && fixed.recorded.length === 0)
+        log.info('Nothing could be repaired automatically.')
+
+      await outro('Reconciled.', { startTime: perf!, useSeconds: true })
       process.exit(ExitCode.Success)
     })
 

--- a/storage/framework/core/database/src/index.ts
+++ b/storage/framework/core/database/src/index.ts
@@ -112,6 +112,11 @@ export * from './defaults'
 // emitted for one database fails loudly before a single statement runs.
 export * from './migration-dialect'
 
+// Ledger drift audit (stacksjs/stacks#2203) — compare the corpus on disk, the
+// `migrations` table, and the live schema, because regeneration renumbers files
+// and the ledger keys on the filename.
+export * from './migration-ledger'
+
 // Model resolution for the generator: userland + framework defaults, flattened
 // because bun-query-builder's loadModels reads only the top level of a dir.
 export * from './model-sources'

--- a/storage/framework/core/database/src/migration-ledger.ts
+++ b/storage/framework/core/database/src/migration-ledger.ts
@@ -1,0 +1,783 @@
+/**
+ * Migration ledger drift audit (stacksjs/stacks#2203).
+ *
+ * The `migrations` table keys on the FILENAME. That filename carries an
+ * ordinal prefix, and regenerating the corpus from `app/Models`
+ * ({@link regenerateMigrationCorpus}) renumbers the whole sequence. Same
+ * logical migrations, different numbers — so every migration whose number
+ * shifted reads as never-applied, and genuinely-new migrations queue behind it.
+ *
+ * The reported failure was silent for weeks: the ledger claimed 6 applied, the
+ * schema reflected ~22, and the first symptom was a 500 from an unrelated
+ * feature panel (`column p.repository does not exist`). Nothing compared the
+ * two, because nothing ever had.
+ *
+ * This module supplies that comparison, across three sources rather than two:
+ *
+ *   1. `database/migrations/*.sql` — what the corpus says should exist
+ *   2. the `migrations` table      — what the runner believes it has applied
+ *   3. the live schema             — what is actually there
+ *
+ * The third is what makes the audit trustworthy. The ledger is precisely the
+ * thing under suspicion, so a disk-vs-ledger diff alone cannot tell a
+ * renumbered-but-applied migration (harmless once the row is rewritten) from a
+ * genuinely pending one (must actually run). Only the schema can, and it is
+ * what a human recovering by hand ends up reading anyway.
+ *
+ * Deliberately NOT automatic. Recording a migration that never ran, or
+ * re-running one that did, are both worse than the drift. Everything here is
+ * read-only until a caller opts in, and the reconciler refuses every case it
+ * cannot prove.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import process from 'node:process'
+import { join } from 'node:path'
+
+export type LedgerDialect = 'sqlite' | 'mysql' | 'postgres'
+
+/**
+ * A schema change a migration makes that can be confirmed by looking at the
+ * live database. Deliberately narrow: only effects whose presence is
+ * unambiguous. An `ALTER COLUMN ... TYPE`, an `UPDATE`, or a `DELETE` leaves no
+ * such trace, and guessing at those is how you end up recording a data
+ * migration that never ran.
+ */
+export interface MigrationEffect {
+  kind: 'table' | 'column' | 'index' | 'constraint' | 'enum'
+  /** Owning table, for `column` and `constraint` effects. */
+  table?: string
+  /** Table / column / index / constraint / enum type name. */
+  name: string
+}
+
+export type MigrationStatus =
+  /** Recorded in the ledger, and every verifiable effect is present. */
+  | 'applied'
+  /** Not recorded, but every effect is already present — a renumber victim. */
+  | 'stranded'
+  /** Not recorded, and no effect is present — genuinely queued to run. */
+  | 'pending'
+  /** Not recorded, and only some effects are present — needs a human. */
+  | 'partial'
+  /** Nothing schema-visible to check (pure DML). Status cannot be inferred. */
+  | 'unverifiable'
+  /** Recorded, but effects are missing — the schema drifted away from history. */
+  | 'reverted'
+
+export interface MigrationLedgerEntry {
+  file: string
+  /** Filename minus its ordinal prefix and extension. Stable across renumbers. */
+  logical: string
+  recorded: boolean
+  status: MigrationStatus
+  effects: MigrationEffect[]
+  present: MigrationEffect[]
+  absent: MigrationEffect[]
+}
+
+export interface LedgerOrphan {
+  /** The ledger row. */
+  migration: string
+  /**
+   * The disk file carrying the same logical name, when exactly one does —
+   * i.e. this row was renumbered rather than deleted.
+   */
+  renamedTo?: string
+}
+
+export interface MigrationLedgerAudit {
+  /** False when the dialect has no introspection support here. */
+  supported: boolean
+  dialect: LedgerDialect | 'other'
+  dir: string
+  entries: MigrationLedgerEntry[]
+  orphans: LedgerOrphan[]
+  counts: Record<MigrationStatus, number>
+  /** Ledger rows read, for reporting "N files on disk, M recorded". */
+  recordedCount: number
+  /**
+   * How ledger rows map onto the renumbered corpus. Carried on the result so
+   * the reconciler acts on the same plan the report showed, rather than
+   * recomputing one from a slightly different file list.
+   */
+  remapPlan: LedgerRemapPlan
+  /** True when anything needs attention. */
+  drift: boolean
+}
+
+export interface LedgerRemap {
+  from: string
+  to: string
+}
+
+export interface LedgerRemapPlan {
+  /** Ledger rows to rewrite in place, matched by logical name. */
+  remap: LedgerRemap[]
+  /** Rows whose logical name matches more than one disk file — refused. */
+  ambiguous: string[]
+  /** Rows with no disk counterpart at all — the migration is simply gone. */
+  dropped: string[]
+}
+
+/**
+ * Filenames the ledger writers will accept.
+ *
+ * Every write below inlines the filename as a SQL literal rather than binding
+ * it, because the parameter placeholder differs by dialect and the ledger is
+ * touched on all three. That is only safe because this pattern admits no quote,
+ * backslash, or semicolon — so validate first, and refuse anything else rather
+ * than trying to escape it.
+ */
+const SAFE_MIGRATION_FILE = /^[\w.-]+\.sql$/
+
+/** `["`[]?ident["`\]]?` — accepts every identifier quoting style in play. */
+const IDENT = String.raw`["\`\[]?([A-Za-z_]\w*)["\`\]]?`
+
+/**
+ * Strip a migration's SQL down to something safe to pattern-match.
+ *
+ * Blanks comments and single-quoted string literals while PRESERVING
+ * double-quoted identifiers, which is the opposite of what
+ * {@link stripSqlNoise} in `migration-dialect.ts` wants — that one is matching
+ * dialect markers and has no use for names, whereas every effect here IS a
+ * name. Blanking the literals still matters: without it a data migration whose
+ * payload happens to contain `CREATE TABLE "x"` would register as creating a
+ * table, and then be silently recorded as applied.
+ *
+ * Blanking preserves offsets and line count, so nothing downstream has to care.
+ */
+export function stripForEffects(sql: string): string {
+  let out = ''
+  let i = 0
+  const blank = (text: string): string => text.replace(/[^\n]/g, ' ')
+
+  while (i < sql.length) {
+    const rest = sql.slice(i)
+
+    const line = rest.match(/^--[^\n]*/)
+    if (line) {
+      out += blank(line[0])
+      i += line[0].length
+      continue
+    }
+
+    if (rest.startsWith('/*')) {
+      const end = rest.indexOf('*/')
+      const chunk = end === -1 ? rest : rest.slice(0, end + 2)
+      out += blank(chunk)
+      i += chunk.length
+      continue
+    }
+
+    if (rest[0] === '\'') {
+      let j = 1
+      while (j < rest.length && rest[j] !== '\'') j++
+      const chunk = rest.slice(0, Math.min(j + 1, rest.length))
+      out += blank(chunk)
+      i += chunk.length
+      continue
+    }
+
+    out += sql[i]
+    i += 1
+  }
+
+  return out
+}
+
+/** Split cleaned SQL into statements. */
+function statementsOf(sql: string): string[] {
+  return stripForEffects(sql)
+    .split(';')
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+}
+
+/**
+ * The migration's identity, independent of where it sits in the sequence.
+ *
+ * This is the whole basis for reconciliation: `0000000003-create-issues-table`
+ * and `0000000002-create-issues-table` are the same migration, and the ledger
+ * only failed to see that because it stored the ordinal.
+ */
+export function logicalName(file: string): string {
+  return file.replace(/^\d+[-_]/, '').replace(/\.sql$/i, '')
+}
+
+/** Schema changes a migration file makes that the live database can confirm. */
+export function migrationEffects(sql: string): MigrationEffect[] {
+  const effects: MigrationEffect[] = []
+  const seen = new Set<string>()
+  // Tables this file renames away. bun-query-builder rebuilds a table by
+  // creating `_qb_tmp_<name>`, copying into it, and renaming it into place, so
+  // the scaffold is GONE once the migration succeeds. Counting its CREATE as an
+  // effect makes every rebuild look permanently half-applied — which would
+  // report the exact migrations #2203 is about as `partial` instead of
+  // `stranded`, and put them beyond the reconciler's reach. Tracked by rename
+  // rather than by the `_qb_tmp_` prefix so any naming scheme is covered.
+  const renamedAway = new Set<string>()
+
+  const push = (effect: MigrationEffect): void => {
+    const key = effectKey(effect)
+    if (seen.has(key)) return
+    seen.add(key)
+    effects.push(effect)
+  }
+
+  for (const statement of statementsOf(sql)) {
+    const create = new RegExp(String.raw`^CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?${IDENT}`, 'i').exec(statement)
+    if (create?.[1]) {
+      push({ kind: 'table', name: create[1] })
+      continue
+    }
+
+    // SQLite rebuilds a table by creating `_qb_tmp_<name>` and renaming it into
+    // place, so the rename is what actually leaves the final table behind.
+    const rename = new RegExp(String.raw`^ALTER\s+TABLE\s+${IDENT}\s+RENAME\s+TO\s+${IDENT}`, 'i').exec(statement)
+    if (rename?.[2]) {
+      if (rename[1]) renamedAway.add(rename[1].toLowerCase())
+      push({ kind: 'table', name: rename[2] })
+      continue
+    }
+
+    const index = new RegExp(String.raw`^CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?${IDENT}`, 'i').exec(statement)
+    if (index?.[1]) {
+      push({ kind: 'index', name: index[1] })
+      continue
+    }
+
+    const enumType = new RegExp(String.raw`^CREATE\s+TYPE\s+${IDENT}\s+AS\s+ENUM`, 'i').exec(statement)
+    if (enumType?.[1]) {
+      push({ kind: 'enum', name: enumType[1] })
+      continue
+    }
+
+    const alter = new RegExp(String.raw`^ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?${IDENT}\s+(.*)$`, 'is').exec(statement)
+    if (!alter?.[1] || !alter[2]) continue
+    const table = alter[1]
+
+    // One ALTER may carry several comma-separated actions. Matching globally
+    // over the remainder catches all of them; anchoring would find only the
+    // first and quietly under-report what the file does.
+    const addColumn = new RegExp(String.raw`\bADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?${IDENT}`, 'gi')
+    for (const m of alter[2].matchAll(addColumn)) {
+      if (m[1]) push({ kind: 'column', table, name: m[1] })
+    }
+
+    const addConstraint = new RegExp(String.raw`\bADD\s+CONSTRAINT\s+(?:IF\s+NOT\s+EXISTS\s+)?${IDENT}`, 'gi')
+    for (const m of alter[2].matchAll(addConstraint)) {
+      if (m[1]) push({ kind: 'constraint', table, name: m[1] })
+    }
+
+    // MySQL's short form: `ADD <column> <type>`, no COLUMN keyword. Excluded
+    // above by the explicit keyword; match it here, taking care not to re-read
+    // CONSTRAINT / INDEX / KEY / PRIMARY / UNIQUE / FOREIGN as a column name.
+    const addBare = new RegExp(
+      String.raw`\bADD\s+(?!COLUMN\b|CONSTRAINT\b|INDEX\b|KEY\b|PRIMARY\b|UNIQUE\b|FOREIGN\b|FULLTEXT\b|SPATIAL\b|CHECK\b)${IDENT}\s+\w`,
+      'gi',
+    )
+    for (const m of alter[2].matchAll(addBare)) {
+      if (m[1]) push({ kind: 'column', table, name: m[1] })
+    }
+  }
+
+  // A rename can appear before or after the CREATE that built the scaffold, so
+  // the filter has to run once the whole file has been read.
+  if (renamedAway.size === 0)
+    return effects
+
+  return effects.filter((effect) => {
+    const owner = (effect.kind === 'table' ? effect.name : effect.table ?? '').toLowerCase()
+    return !renamedAway.has(owner)
+  })
+}
+
+function effectKey(effect: MigrationEffect): string {
+  return `${effect.kind}:${(effect.table ?? '').toLowerCase()}.${effect.name.toLowerCase()}`
+}
+
+/**
+ * Effects this dialect can actually confirm.
+ *
+ * SQLite has no named constraints reachable by introspection (foreign keys are
+ * inline on CREATE TABLE) and no user-defined types, and the runner
+ * deliberately records ADD CONSTRAINT / CREATE TYPE files as executed WITHOUT
+ * running them so a later `DB_CONNECTION` flip can replay the file
+ * (stacksjs/stacks#1916). Checking for those effects on SQLite would therefore
+ * report every such file as `reverted`, which is both wrong and loud. MySQL has
+ * no standalone enum type either.
+ */
+export function verifiableEffects(effects: MigrationEffect[], dialect: LedgerDialect): MigrationEffect[] {
+  if (dialect === 'postgres') return effects
+  if (dialect === 'mysql') return effects.filter(e => e.kind !== 'enum')
+  return effects.filter(e => e.kind !== 'constraint' && e.kind !== 'enum')
+}
+
+export interface LiveSchema {
+  tables: Set<string>
+  /** table (lower) → set of column names (lower). */
+  columns: Map<string, Set<string>>
+  indexes: Set<string>
+  constraints: Set<string>
+  enums: Set<string>
+}
+
+function emptySchema(): LiveSchema {
+  return { tables: new Set(), columns: new Map(), indexes: new Set(), constraints: new Set(), enums: new Set() }
+}
+
+function rowsOf(result: unknown): any[] {
+  return Array.isArray(result) ? result : []
+}
+
+/**
+ * Runs one SQL string and returns its rows.
+ *
+ * Injectable for the same reason `ensure-database.ts` takes its own `connect`:
+ * everything here has to be exercisable against a database the caller controls.
+ * The default binds to the process-wide `db`, which is a single shared handle —
+ * fine in production, useless for a test that needs to build a specific
+ * drift state, and unable to audit a database other than the configured one.
+ */
+export type SqlRunner = (sql: string) => Promise<any[]>
+
+async function defaultRunner(): Promise<SqlRunner> {
+  const { db } = await import('./utils')
+  return async (sql: string) => rowsOf(await (db as any).unsafe(sql).execute())
+}
+
+function pick(row: any, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = row?.[key] ?? row?.[key.toLowerCase()] ?? row?.[key.toUpperCase()]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return ''
+}
+
+/** Read the parts of the live schema an effect can be checked against. */
+export async function readLiveSchema(dialect: LedgerDialect, runner?: SqlRunner): Promise<LiveSchema> {
+  const schema = emptySchema()
+  const run = runner ?? await defaultRunner()
+
+  if (dialect === 'sqlite') {
+    for (const row of await run(`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`)) {
+      const name = pick(row, 'name')
+      if (name) schema.tables.add(name.toLowerCase())
+    }
+    for (const row of await run(`SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'`)) {
+      const name = pick(row, 'name')
+      if (name) schema.indexes.add(name.toLowerCase())
+    }
+    for (const table of schema.tables) {
+      // Identifier interpolation — bounded by the charset check, same guard the
+      // unique-index audit uses for its own PRAGMA calls.
+      if (!/^[a-z_]\w*$/i.test(table)) continue
+      const cols = new Set<string>()
+      for (const row of await run(`PRAGMA table_info("${table}")`)) {
+        const name = pick(row, 'name')
+        if (name) cols.add(name.toLowerCase())
+      }
+      schema.columns.set(table, cols)
+    }
+    return schema
+  }
+
+  if (dialect === 'mysql') {
+    for (const row of await run(`SELECT TABLE_NAME AS name FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE()`)) {
+      const name = pick(row, 'name', 'TABLE_NAME')
+      if (name) schema.tables.add(name.toLowerCase())
+    }
+    for (const row of await run(`SELECT TABLE_NAME, COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE()`)) {
+      const table = pick(row, 'TABLE_NAME').toLowerCase()
+      const column = pick(row, 'COLUMN_NAME').toLowerCase()
+      if (!table || !column) continue
+      if (!schema.columns.has(table)) schema.columns.set(table, new Set())
+      schema.columns.get(table)!.add(column)
+    }
+    for (const row of await run(`SELECT DISTINCT INDEX_NAME AS name FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE()`)) {
+      const name = pick(row, 'name', 'INDEX_NAME')
+      if (name) schema.indexes.add(name.toLowerCase())
+    }
+    for (const row of await run(`SELECT CONSTRAINT_NAME AS name FROM information_schema.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE()`)) {
+      const name = pick(row, 'name', 'CONSTRAINT_NAME')
+      if (name) schema.constraints.add(name.toLowerCase())
+    }
+    return schema
+  }
+
+  for (const row of await run(`SELECT tablename AS name FROM pg_tables WHERE schemaname = 'public'`)) {
+    const name = pick(row, 'name', 'tablename')
+    if (name) schema.tables.add(name.toLowerCase())
+  }
+  for (const row of await run(`SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public'`)) {
+    const table = pick(row, 'table_name').toLowerCase()
+    const column = pick(row, 'column_name').toLowerCase()
+    if (!table || !column) continue
+    if (!schema.columns.has(table)) schema.columns.set(table, new Set())
+    schema.columns.get(table)!.add(column)
+  }
+  for (const row of await run(`SELECT indexname AS name FROM pg_indexes WHERE schemaname = 'public'`)) {
+    const name = pick(row, 'name', 'indexname')
+    if (name) schema.indexes.add(name.toLowerCase())
+  }
+  for (const row of await run(`SELECT c.conname AS name FROM pg_constraint c JOIN pg_namespace n ON n.oid = c.connamespace WHERE n.nspname = 'public'`)) {
+    const name = pick(row, 'name', 'conname')
+    if (name) schema.constraints.add(name.toLowerCase())
+  }
+  for (const row of await run(`SELECT t.typname AS name FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace WHERE t.typtype = 'e' AND n.nspname = 'public'`)) {
+    const name = pick(row, 'name', 'typname')
+    if (name) schema.enums.add(name.toLowerCase())
+  }
+  return schema
+}
+
+/** Whether a single effect can be found in the live schema. */
+export function effectPresent(effect: MigrationEffect, schema: LiveSchema): boolean {
+  const name = effect.name.toLowerCase()
+  switch (effect.kind) {
+    case 'table':
+      return schema.tables.has(name)
+    case 'column':
+      return schema.columns.get((effect.table ?? '').toLowerCase())?.has(name) ?? false
+    case 'index':
+      return schema.indexes.has(name)
+    case 'constraint':
+      return schema.constraints.has(name)
+    case 'enum':
+      return schema.enums.has(name)
+  }
+}
+
+/**
+ * Decide what a single migration file's state actually is.
+ *
+ * Pure, so the interesting cases are testable without a database. The order
+ * matters: "no verifiable effects" has to be answered before "all present",
+ * because vacuously-all-present is exactly the wrong answer for a data
+ * migration — it is how a `DELETE FROM oauth_access_tokens` gets recorded as
+ * applied on the strength of having nothing to check.
+ */
+export function classifyMigration(
+  recorded: boolean,
+  present: MigrationEffect[],
+  absent: MigrationEffect[],
+): MigrationStatus {
+  const verifiable = present.length + absent.length
+  if (recorded) {
+    if (verifiable === 0 || absent.length === 0) return 'applied'
+    return 'reverted'
+  }
+  if (verifiable === 0) return 'unverifiable'
+  if (absent.length === 0) return 'stranded'
+  if (present.length === 0) return 'pending'
+  return 'partial'
+}
+
+function migrationsDir(dir?: string): string {
+  return dir ?? join(process.cwd(), 'database', 'migrations')
+}
+
+function listMigrationFiles(dir: string): string[] {
+  if (!existsSync(dir)) return []
+  try {
+    return readdirSync(dir).filter(f => f.toLowerCase().endsWith('.sql')).sort()
+  }
+  catch {
+    return []
+  }
+}
+
+async function currentDialect(): Promise<LedgerDialect | 'other'> {
+  const env = await import('@stacksjs/env')
+  const driver = ((env as { env?: { DB_CONNECTION?: string } }).env?.DB_CONNECTION ?? 'sqlite').toLowerCase()
+  if (driver === 'sqlite' || driver === 'mysql' || driver === 'postgres') return driver
+  return 'other'
+}
+
+/**
+ * Every filename the `migrations` table has recorded.
+ *
+ * An absent table is a legitimate state (nothing has ever migrated), so it
+ * reads as an empty ledger rather than an error.
+ */
+export async function readLedger(runner?: SqlRunner): Promise<string[]> {
+  try {
+    const run = runner ?? await defaultRunner()
+    const rows = await run('SELECT migration FROM migrations')
+    return rows
+      .map(row => pick(row, 'migration'))
+      .filter(name => name.length > 0)
+      .sort()
+  }
+  catch {
+    return []
+  }
+}
+
+/**
+ * Match ledger rows to disk files by logical name, so a renumbered corpus can
+ * have its bookkeeping rewritten instead of being re-run.
+ *
+ * Pure — takes the two lists and returns a plan. Refuses anything it cannot
+ * prove: a logical name appearing on more than one disk file, or two ledger
+ * rows converging on one file, are both reported as ambiguous rather than
+ * guessed at. A wrong remap silently un-applies a migration, which is the very
+ * failure this exists to fix.
+ */
+export function planLedgerRemap(ledger: string[], diskFiles: string[]): LedgerRemapPlan {
+  const onDisk = new Set(diskFiles)
+  const byLogical = new Map<string, string[]>()
+  for (const file of diskFiles) {
+    const key = logicalName(file)
+    if (!byLogical.has(key)) byLogical.set(key, [])
+    byLogical.get(key)!.push(file)
+  }
+
+  // A row that already names a file on disk is correct and claims that file,
+  // so no other row may remap onto it.
+  const claimed = new Set(ledger.filter(row => onDisk.has(row)))
+
+  const remap: LedgerRemap[] = []
+  const ambiguous: string[] = []
+  const dropped: string[] = []
+  const targets = new Map<string, string[]>()
+
+  for (const row of ledger) {
+    if (onDisk.has(row)) continue
+    const candidates = (byLogical.get(logicalName(row)) ?? []).filter(f => !claimed.has(f))
+    if (candidates.length === 0) {
+      dropped.push(row)
+      continue
+    }
+    if (candidates.length > 1) {
+      ambiguous.push(row)
+      continue
+    }
+    const to = candidates[0]!
+    if (!targets.has(to)) targets.set(to, [])
+    targets.get(to)!.push(row)
+    remap.push({ from: row, to })
+  }
+
+  // Two rows resolving to one file means the logical names collided; neither
+  // can be trusted.
+  const contested = new Set([...targets.entries()].filter(([, rows]) => rows.length > 1).flatMap(([, rows]) => rows))
+  if (contested.size === 0)
+    return { remap, ambiguous, dropped }
+
+  return {
+    remap: remap.filter(r => !contested.has(r.from)),
+    ambiguous: [...ambiguous, ...contested].sort(),
+    dropped,
+  }
+}
+
+/**
+ * Compare the migration corpus, the ledger, and the live schema.
+ *
+ * Read-only. Nothing here writes, so it is safe to run on production and safe
+ * to wire into `buddy doctor`.
+ */
+export async function auditMigrationLedger(options: {
+  dir?: string
+  /** Audit a specific dialect instead of the configured one. */
+  dialect?: LedgerDialect
+  /** Audit a database other than the process-wide one. */
+  run?: SqlRunner
+} = {}): Promise<MigrationLedgerAudit> {
+  const dir = migrationsDir(options.dir)
+  const dialect = options.dialect ?? await currentDialect()
+  const files = listMigrationFiles(dir)
+
+  const counts: Record<MigrationStatus, number> = {
+    applied: 0,
+    stranded: 0,
+    pending: 0,
+    partial: 0,
+    unverifiable: 0,
+    reverted: 0,
+  }
+
+  const emptyPlan: LedgerRemapPlan = { remap: [], ambiguous: [], dropped: [] }
+  if (dialect === 'other') {
+    return { supported: false, dialect, dir, entries: [], orphans: [], counts, recordedCount: 0, remapPlan: emptyPlan, drift: false }
+  }
+
+  const run = options.run ?? await defaultRunner()
+  const ledger = await readLedger(run)
+  const recorded = new Set(ledger)
+  const schema = await readLiveSchema(dialect, run)
+
+  const entries: MigrationLedgerEntry[] = []
+  for (const file of files) {
+    let sql = ''
+    try {
+      sql = readFileSync(join(dir, file), 'utf8')
+    }
+    catch {
+      continue
+    }
+
+    const effects = verifiableEffects(migrationEffects(sql), dialect)
+    const present = effects.filter(effect => effectPresent(effect, schema))
+    const absent = effects.filter(effect => !effectPresent(effect, schema))
+    const isRecorded = recorded.has(file)
+    const status = classifyMigration(isRecorded, present, absent)
+    counts[status] += 1
+    entries.push({ file, logical: logicalName(file), recorded: isRecorded, status, effects, present, absent })
+  }
+
+  // Planned against the files that were actually READ, which is what the
+  // classification above used. Planning against the raw directory listing
+  // instead would let an unreadable file produce a remap target that has no
+  // entry, so the audit's report and the reconciler's actions could disagree.
+  const readable = entries.map(entry => entry.file)
+  const remapPlan = planLedgerRemap(ledger, readable)
+  const renamedTo = new Map(remapPlan.remap.map(r => [r.from, r.to]))
+  const orphans: LedgerOrphan[] = ledger
+    .filter(row => !readable.includes(row))
+    .map(row => ({ migration: row, renamedTo: renamedTo.get(row) }))
+
+  const drift = counts.stranded > 0 || counts.partial > 0 || counts.reverted > 0 || orphans.length > 0
+
+  return { supported: true, dialect, dir, entries, orphans, counts, recordedCount: ledger.length, remapPlan, drift }
+}
+
+/**
+ * Ensure the ledger table exists before writing to it.
+ *
+ * Mirrors the shape bun-query-builder creates on the first `executeMigration`,
+ * so reconciling a database that has never migrated does not then collide with
+ * the runner's own CREATE.
+ */
+async function ensureLedgerTable(dialect: LedgerDialect, run: SqlRunner): Promise<void> {
+  const id = dialect === 'postgres'
+    ? 'id SERIAL PRIMARY KEY'
+    : dialect === 'mysql'
+      ? 'id INT AUTO_INCREMENT PRIMARY KEY'
+      : 'id INTEGER PRIMARY KEY AUTOINCREMENT'
+  const timestamp = dialect === 'postgres' ? 'TIMESTAMP' : 'DATETIME'
+  await run(
+    `CREATE TABLE IF NOT EXISTS migrations (${id}, migration VARCHAR(255) NOT NULL UNIQUE, executed_at ${timestamp} DEFAULT CURRENT_TIMESTAMP)`,
+  )
+}
+
+export interface ReconcileResult {
+  /** Ledger rows rewritten from an old filename to its renumbered one. */
+  remapped: LedgerRemap[]
+  /** Files recorded as applied because every effect was already present. */
+  recorded: string[]
+  /** Things the reconciler refused to touch, with why. */
+  skipped: Array<{ file: string, reason: string }>
+}
+
+/**
+ * Bring the ledger back in line with what the schema proves.
+ *
+ * Two operations, both conservative:
+ *
+ *   1. **Remap** a ledger row onto its renumbered file. Nothing runs; only the
+ *      recorded name changes. This is the direct undo of #2203.
+ *   2. **Record** a `stranded` file — one whose every effect is already in the
+ *      schema — so the runner stops treating it as pending.
+ *
+ * Everything else is refused and reported. `partial` files have half-applied
+ * effects and no safe automatic answer; `unverifiable` ones (pure DML, like the
+ * `DELETE FROM oauth_access_tokens` token revocation in the shipped corpus)
+ * leave no trace to check, and recording one on a hunch would skip a migration
+ * that never ran. Those are exactly the cases worth a human's attention, which
+ * is why they are listed rather than silently handled.
+ */
+export async function reconcileMigrationLedger(options: {
+  dir?: string
+  /** Report what would change without writing. */
+  dryRun?: boolean
+  /** Also record `partial` files. Off by default, and rarely right. */
+  includePartial?: boolean
+  /** Reconcile a specific dialect instead of the configured one. */
+  dialect?: LedgerDialect
+  /** Reconcile a database other than the process-wide one. */
+  run?: SqlRunner
+} = {}): Promise<ReconcileResult> {
+  const run = options.run ?? await defaultRunner()
+  const audit = await auditMigrationLedger({ dir: options.dir, dialect: options.dialect, run })
+  const result: ReconcileResult = { remapped: [], recorded: [], skipped: [] }
+  if (!audit.supported) {
+    result.skipped.push({ file: '*', reason: `dialect "${audit.dialect}" is not audited` })
+    return result
+  }
+
+  const plan = audit.remapPlan
+
+  for (const row of plan.ambiguous)
+    result.skipped.push({ file: row, reason: 'ledger row matches more than one file by logical name' })
+  for (const row of plan.dropped)
+    result.skipped.push({ file: row, reason: 'recorded migration no longer exists on disk' })
+
+  const toRecord: string[] = []
+  for (const entry of audit.entries) {
+    if (entry.status === 'stranded') {
+      toRecord.push(entry.file)
+      continue
+    }
+    if (entry.status === 'partial') {
+      if (options.includePartial) {
+        toRecord.push(entry.file)
+        continue
+      }
+      result.skipped.push({
+        file: entry.file,
+        reason: `${entry.present.length}/${entry.effects.length} effects present — resolve by hand, or pass --include-partial`,
+      })
+      continue
+    }
+    if (entry.status === 'reverted') {
+      result.skipped.push({
+        file: entry.file,
+        reason: `recorded, but ${entry.absent.length} effect(s) are missing from the schema`,
+      })
+    }
+  }
+
+  // Anything the ledger writers would refuse is dropped HERE, before any write
+  // happens. Throwing partway through would leave the ledger half-repaired,
+  // which is a worse state than the drift it was called to fix. Ledger rows in
+  // particular come out of the database, so they are not guaranteed to look
+  // like anything this ever wrote.
+  const unsafe = (file: string): boolean => !SAFE_MIGRATION_FILE.test(file)
+  for (const { from, to } of plan.remap.filter(r => unsafe(r.from) || unsafe(r.to)))
+    result.skipped.push({ file: unsafe(from) ? from : to, reason: 'migration filename is not safe to write to the ledger' })
+  for (const file of toRecord.filter(unsafe))
+    result.skipped.push({ file, reason: 'migration filename is not safe to write to the ledger' })
+
+  // A remap changes the row a later record would collide with, so it goes
+  // first. Ordering matters only in the dry run's report, but a report that
+  // does not match the write order is its own trap.
+  const remapped = plan.remap.filter(r => !unsafe(r.from) && !unsafe(r.to))
+  const recordable = toRecord.filter(file => !unsafe(file) && !remapped.some(r => r.to === file))
+
+  if (options.dryRun) {
+    result.remapped = remapped
+    result.recorded = recordable
+    return result
+  }
+
+  await ensureLedgerTable(audit.dialect as LedgerDialect, run)
+
+  for (const { from, to } of remapped) {
+    await run(`UPDATE migrations SET migration = '${to}' WHERE migration = '${from}'`)
+    result.remapped.push({ from, to })
+  }
+
+  for (const file of recordable) {
+    // The row may already exist when a remap just landed on it; a duplicate
+    // insert against the UNIQUE index would abort the rest of the run.
+    const existing = await run(`SELECT migration FROM migrations WHERE migration = '${file}'`)
+    if (existing.length > 0) continue
+    await run(`INSERT INTO migrations (migration) VALUES ('${file}')`)
+    result.recorded.push(file)
+  }
+
+  return result
+}

--- a/storage/framework/core/database/tests/migration-ledger-reconcile.test.ts
+++ b/storage/framework/core/database/tests/migration-ledger-reconcile.test.ts
@@ -1,0 +1,280 @@
+// stacksjs/stacks#2203 — end-to-end reproduction of the ledger drift.
+//
+// The unit tests next door cover the classifier in isolation. This one builds
+// the actual failure: a database whose schema reflects every migration, a
+// ledger still naming the PRE-renumber filenames, and a corpus on disk that has
+// been renumbered underneath it. That is the reported state exactly — 24 files,
+// 6 ledger rows, ~22 migrations' worth of schema — and the thing worth proving
+// is that the audit reads the schema rather than believing the ledger, because
+// only the schema can tell "applied, row lost" from "never ran".
+//
+// Runs against its OWN in-memory SQLite handle, via the audit's injectable
+// `run` executor, rather than the process-wide `db`. That shared handle is a
+// single connection every test file in the directory takes turns repointing and
+// closing (`RangeError: Cannot use a closed database` — the same isolation bug
+// that keeps this whole directory out of CI as a unit), and a test that builds a
+// specific drift state has no business sharing one anyway.
+
+import { Database } from 'bun:sqlite'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { auditMigrationLedger, readLedger, reconcileMigrationLedger } from '../src/migration-ledger'
+
+let dir: string
+let sqlite: Database
+
+/** The injectable executor the audit and reconciler write through. */
+const run = async (sql: string): Promise<any[]> => sqlite.prepare(sql).all() as any[]
+
+const runAudit = (): ReturnType<typeof auditMigrationLedger> =>
+  auditMigrationLedger({ dir, dialect: 'sqlite', run })
+
+const runReconcile = (
+  extra: { dryRun?: boolean, includePartial?: boolean } = {},
+): ReturnType<typeof reconcileMigrationLedger> =>
+  reconcileMigrationLedger({ dir, dialect: 'sqlite', run, ...extra })
+
+afterAll(() => {
+  sqlite?.close()
+  if (dir) rmSync(dir, { recursive: true, force: true })
+})
+
+/** The migrations, by logical name, in the order they were originally written. */
+const MIGRATIONS: Array<{ logical: string, sql: string }> = [
+  { logical: 'create-alert_channels-table', sql: 'CREATE TABLE IF NOT EXISTS "alert_channels" ("id" INTEGER PRIMARY KEY, "name" TEXT)' },
+  { logical: 'create-issues-table', sql: 'CREATE TABLE IF NOT EXISTS "issues" ("id" INTEGER PRIMARY KEY, "title" TEXT)' },
+  { logical: 'create-error_events-table', sql: 'CREATE TABLE IF NOT EXISTS "error_events" ("id" INTEGER PRIMARY KEY)' },
+  { logical: 'create-subscriptions-table', sql: 'CREATE TABLE IF NOT EXISTS "subscriptions" ("id" INTEGER PRIMARY KEY)' },
+]
+
+/** The two that had never run, and only surfaced as 500s weeks later. */
+const NEVER_RAN: Array<{ logical: string, sql: string }> = [
+  { logical: 'add-repository-to-projects', sql: 'ALTER TABLE "projects" ADD COLUMN "repository" TEXT' },
+  { logical: 'create-autofix_runs-table', sql: 'CREATE TABLE IF NOT EXISTS "autofix_runs" ("id" INTEGER PRIMARY KEY)' },
+]
+
+function write(dirPath: string, ordinal: number, logical: string, sql: string): string {
+  const name = `${String(ordinal).padStart(10, '0')}-${logical}.sql`
+  writeFileSync(join(dirPath, name), `${sql};\n`)
+  return name
+}
+
+async function resetLedger(rows: string[]): Promise<void> {
+  sqlite.exec('DROP TABLE IF EXISTS migrations')
+  sqlite.exec(`CREATE TABLE migrations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    migration TEXT NOT NULL UNIQUE,
+    executed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`)
+  // Bound, not inlined: one of the cases below seeds a deliberately hostile
+  // row, and the fixture must be able to plant it without breaking itself.
+  const insert = sqlite.prepare('INSERT INTO migrations (migration) VALUES (?)')
+  for (const row of rows) insert.run(row)
+}
+
+beforeAll(() => {
+  sqlite = new Database(':memory:')
+  dir = mkdtempSync(join(tmpdir(), 'stacks-ledger-'))
+  mkdirSync(dir, { recursive: true })
+
+  // The live schema: every one of the four originals really did run, plus a
+  // `projects` table for the ALTER that never did.
+  for (const m of MIGRATIONS) sqlite.exec(m.sql)
+  sqlite.exec('CREATE TABLE IF NOT EXISTS "projects" ("id" INTEGER PRIMARY KEY)')
+})
+
+beforeEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+  mkdirSync(dir, { recursive: true })
+})
+
+describe('migration ledger drift (stacksjs/stacks#2203)', () => {
+  /**
+   * Renumber the corpus the way regeneration does: same logical migrations,
+   * shifted ordinals, plus the two later files that were queued behind them.
+   */
+  function renumberedCorpus(): { ledgerRows: string[], diskFiles: string[] } {
+    // The ledger recorded them at their ORIGINAL ordinals 1..4.
+    const ledgerRows = MIGRATIONS.map((m, i) => `${String(i + 1).padStart(10, '0')}-${m.logical}.sql`)
+
+    // Regeneration rewrote the sequence: alert_channels moved to the end.
+    const reordered = [MIGRATIONS[1]!, MIGRATIONS[2]!, MIGRATIONS[3]!, MIGRATIONS[0]!]
+    const diskFiles = reordered.map((m, i) => write(dir, i + 1, m.logical, m.sql))
+    NEVER_RAN.forEach((m, i) => diskFiles.push(write(dir, 5 + i, m.logical, m.sql)))
+
+    return { ledgerRows, diskFiles }
+  }
+
+  it('reports the drift instead of trusting the ledger', async () => {
+    const { ledgerRows } = renumberedCorpus()
+    await resetLedger(ledgerRows)
+
+    const audit = await runAudit()
+
+    expect(audit.supported).toBe(true)
+    expect(audit.drift).toBe(true)
+    expect(audit.entries).toHaveLength(6)
+    expect(audit.recordedCount).toBe(4)
+
+    // The four that DID run, and whose tables exist, but whose ledger rows
+    // now name files that are no longer on disk.
+    expect(audit.counts.stranded).toBe(4)
+    // The two that genuinely never ran.
+    expect(audit.counts.pending).toBe(2)
+    expect(audit.entries.filter(e => e.status === 'pending').map(e => e.logical).sort())
+      .toEqual(['add-repository-to-projects', 'create-autofix_runs-table'])
+
+    // Every ledger row is an orphan, and each one names its renumbered file.
+    expect(audit.orphans).toHaveLength(4)
+    expect(audit.orphans.every(o => Boolean(o.renamedTo))).toBe(true)
+  })
+
+  it('does not confuse a stranded migration with a pending one', async () => {
+    // The whole point. A disk-vs-ledger diff alone marks all six as pending;
+    // reading the schema is what separates the four that already ran.
+    const { ledgerRows } = renumberedCorpus()
+    await resetLedger(ledgerRows)
+
+    const audit = await runAudit()
+    const stranded = audit.entries.filter(e => e.status === 'stranded').map(e => e.logical).sort()
+
+    expect(stranded).toEqual([
+      'create-alert_channels-table',
+      'create-error_events-table',
+      'create-issues-table',
+      'create-subscriptions-table',
+    ])
+  })
+
+  it('repairs the ledger without running any migration SQL', async () => {
+    const { ledgerRows } = renumberedCorpus()
+    await resetLedger(ledgerRows)
+
+    const result = await runReconcile()
+
+    // Four rows repointed at their renumbered files; nothing newly recorded,
+    // because the remap already covered all four.
+    expect(result.remapped).toHaveLength(4)
+    expect(result.skipped).toEqual([])
+
+    const ledger = await readLedger(run)
+    expect(ledger).toEqual([
+      '0000000001-create-issues-table.sql',
+      '0000000002-create-error_events-table.sql',
+      '0000000003-create-subscriptions-table.sql',
+      '0000000004-create-alert_channels-table.sql',
+    ])
+
+    // The two that never ran are still absent from the ledger, so `migrate`
+    // will pick them up — the actual fix for the reported 500s.
+    expect(ledger.some(row => row.includes('add-repository-to-projects'))).toBe(false)
+    expect(ledger.some(row => row.includes('create-autofix_runs-table'))).toBe(false)
+
+    // `autofix_runs` was never created, proving reconciliation did not execute
+    // a single statement from a migration file.
+    const tables = await run(`SELECT name FROM sqlite_master WHERE type='table' AND name='autofix_runs'`)
+    expect(tables).toHaveLength(0)
+  })
+
+  it('leaves the corpus clean afterwards, apart from the genuinely pending two', async () => {
+    const { ledgerRows } = renumberedCorpus()
+    await resetLedger(ledgerRows)
+    await runReconcile()
+
+    const audit = await runAudit()
+
+    expect(audit.drift).toBe(false)
+    expect(audit.orphans).toEqual([])
+    expect(audit.counts.stranded).toBe(0)
+    expect(audit.counts.applied).toBe(4)
+    expect(audit.counts.pending).toBe(2)
+  })
+
+  it('records a stranded migration that has no ledger row to repoint', async () => {
+    // The other half of recovery: regeneration folded an old ALTER into a
+    // CREATE, so no ledger row shares its logical name. The schema still proves
+    // it ran, so it gets recorded rather than re-run.
+    write(dir, 1, 'create-issues-table', MIGRATIONS[1]!.sql)
+    await resetLedger([])
+
+    const result = await runReconcile()
+
+    expect(result.remapped).toEqual([])
+    expect(result.recorded).toEqual(['0000000001-create-issues-table.sql'])
+    expect(await readLedger(run)).toEqual(['0000000001-create-issues-table.sql'])
+  })
+
+  it('refuses to record a data migration it cannot verify', async () => {
+    // The shipped corpus contains `revoke-legacy-long-lived-tokens.sql`, a hard
+    // `DELETE FROM oauth_access_tokens`. It leaves no schema trace, so
+    // recording it on a hunch would skip a revocation that never ran — and
+    // re-running it would wipe live tokens a second time. Neither is acceptable
+    // automatically, so it stays out of both lists.
+    write(dir, 1, 'revoke-legacy-long-lived-tokens', 'DELETE FROM alert_channels WHERE name IS NULL')
+    await resetLedger([])
+
+    const audit = await runAudit()
+    expect(audit.counts.unverifiable).toBe(1)
+    expect(audit.counts.stranded).toBe(0)
+
+    const result = await runReconcile()
+    expect(result.recorded).toEqual([])
+    expect(result.remapped).toEqual([])
+    expect(await readLedger(run)).toEqual([])
+  })
+
+  it('refuses a half-applied migration unless explicitly told otherwise', async () => {
+    write(dir, 1, 'create-two-tables', 'CREATE TABLE IF NOT EXISTS "issues" ("id" INTEGER);\nCREATE TABLE IF NOT EXISTS "nope" ("id" INTEGER)')
+    await resetLedger([])
+
+    const audit = await runAudit()
+    expect(audit.counts.partial).toBe(1)
+
+    const refused = await runReconcile()
+    expect(refused.recorded).toEqual([])
+    expect(refused.skipped).toHaveLength(1)
+    expect(refused.skipped[0]!.reason).toContain('1/2 effects present')
+
+    const forced = await runReconcile({ includePartial: true })
+    expect(forced.recorded).toEqual(['0000000001-create-two-tables.sql'])
+  })
+
+  it('skips a ledger row it cannot safely write, without abandoning the rest', async () => {
+    // Ledger rows come out of the database, so they are not guaranteed to look
+    // like anything the framework wrote. A row that cannot be inlined safely
+    // must not abort the repair partway through and leave the ledger in a worse
+    // state than the drift it was called to fix.
+    const { ledgerRows } = renumberedCorpus()
+    await resetLedger([...ledgerRows, `0000000009-evil'; DROP TABLE issues; --.sql`])
+
+    const result = await runReconcile()
+
+    expect(result.remapped).toHaveLength(4)
+    expect(result.skipped.map(s => s.file)).toContain(`0000000009-evil'; DROP TABLE issues; --.sql`)
+
+    // The repair still landed, and the hostile row did nothing.
+    const tables = await run(`SELECT name FROM sqlite_master WHERE type='table' AND name='issues'`)
+    expect(tables).toHaveLength(1)
+  })
+
+  it('reports a clean corpus as clean', async () => {
+    const files = MIGRATIONS.map((m, i) => write(dir, i + 1, m.logical, m.sql))
+    await resetLedger(files)
+
+    const audit = await runAudit()
+    expect(audit.drift).toBe(false)
+    expect(audit.counts.applied).toBe(4)
+    expect(audit.orphans).toEqual([])
+  })
+
+  it('dry run reports the repair without touching the ledger', async () => {
+    const { ledgerRows } = renumberedCorpus()
+    await resetLedger(ledgerRows)
+
+    const plan = await runReconcile({ dryRun: true })
+    expect(plan.remapped).toHaveLength(4)
+    expect(await readLedger(run)).toEqual([...ledgerRows].sort())
+  })
+})

--- a/storage/framework/core/database/tests/migration-ledger.test.ts
+++ b/storage/framework/core/database/tests/migration-ledger.test.ts
@@ -1,0 +1,337 @@
+// Migration ledger drift (stacksjs/stacks#2203).
+//
+// Regenerating the corpus renumbers every file. The `migrations` table keys on
+// the filename, so a renumbered-but-applied migration reads as pending and
+// everything after it queues behind. In the reported case the ledger claimed 6
+// applied while the schema reflected ~22, and the first symptom was a 500 from
+// an unrelated feature weeks later.
+//
+// The classifier is what makes recovery safe, so it is what these cover: the
+// difference between "applied, ledger lost the row" and "genuinely never ran"
+// is the entire decision, and getting it wrong in either direction is worse
+// than the drift — record a migration that never ran and it is skipped forever;
+// re-run one that did and an ADD CONSTRAINT (or the corpus's hard
+// `DELETE FROM oauth_access_tokens`) fires a second time.
+
+import type { LiveSchema, MigrationEffect } from '../src/migration-ledger'
+import { describe, expect, it } from 'bun:test'
+import {
+  classifyMigration,
+  effectPresent,
+  logicalName,
+  migrationEffects,
+  planLedgerRemap,
+  stripForEffects,
+  verifiableEffects,
+} from '../src/migration-ledger'
+
+function schema(parts: Partial<{
+  tables: string[]
+  columns: Record<string, string[]>
+  indexes: string[]
+  constraints: string[]
+  enums: string[]
+}>): LiveSchema {
+  return {
+    tables: new Set(parts.tables ?? []),
+    columns: new Map(Object.entries(parts.columns ?? {}).map(([t, c]) => [t, new Set(c)])),
+    indexes: new Set(parts.indexes ?? []),
+    constraints: new Set(parts.constraints ?? []),
+    enums: new Set(parts.enums ?? []),
+  }
+}
+
+const split = (effects: MigrationEffect[], live: LiveSchema): { present: MigrationEffect[], absent: MigrationEffect[] } => ({
+  present: effects.filter(e => effectPresent(e, live)),
+  absent: effects.filter(e => !effectPresent(e, live)),
+})
+
+describe('logicalName', () => {
+  it('strips the ordinal prefix, which is the only thing a renumber changes', () => {
+    expect(logicalName('0000000003-create-issues-table.sql')).toBe('create-issues-table')
+    expect(logicalName('0000000002-create-issues-table.sql')).toBe('create-issues-table')
+  })
+
+  it('treats the two numberings of one migration as the same migration', () => {
+    // Exactly the reported drift: same logical migration, different ordinal.
+    expect(logicalName('0000000002-create-alert_channels-table.sql'))
+      .toBe(logicalName('0000000005-create-alert_channels-table.sql'))
+  })
+
+  it('handles the timestamp-prefixed files the corpus also carries', () => {
+    expect(logicalName('1785502251814-repair-seeded-image-urls.sql')).toBe('repair-seeded-image-urls')
+  })
+
+  it('leaves an unprefixed name alone', () => {
+    expect(logicalName('create-users-table.sql')).toBe('create-users-table')
+  })
+})
+
+describe('migrationEffects', () => {
+  it('reads a CREATE TABLE, quoted or not', () => {
+    expect(migrationEffects('CREATE TABLE IF NOT EXISTS "issues" ("id" INTEGER);'))
+      .toEqual([{ kind: 'table', name: 'issues' }])
+    expect(migrationEffects('CREATE TABLE issues (id INTEGER);'))
+      .toEqual([{ kind: 'table', name: 'issues' }])
+  })
+
+  it('reads ADD COLUMN, with and without IF NOT EXISTS', () => {
+    expect(migrationEffects('ALTER TABLE "projects" ADD COLUMN "repository" text;'))
+      .toEqual([{ kind: 'column', table: 'projects', name: 'repository' }])
+    expect(migrationEffects('ALTER TABLE "projects" ADD COLUMN IF NOT EXISTS "repository" text;'))
+      .toEqual([{ kind: 'column', table: 'projects', name: 'repository' }])
+  })
+
+  it('reads every action in a multi-action ALTER, not just the first', () => {
+    const effects = migrationEffects('ALTER TABLE "p" ADD COLUMN "a" text, ADD COLUMN "b" text;')
+    expect(effects).toEqual([
+      { kind: 'column', table: 'p', name: 'a' },
+      { kind: 'column', table: 'p', name: 'b' },
+    ])
+  })
+
+  it('reads indexes, constraints and enum types', () => {
+    expect(migrationEffects('CREATE UNIQUE INDEX IF NOT EXISTS "users_email_index" ON "users" ("email");'))
+      .toEqual([{ kind: 'index', name: 'users_email_index' }])
+    expect(migrationEffects('ALTER TABLE "posts" ADD CONSTRAINT "posts_author_fk" FOREIGN KEY ("author_id") REFERENCES "authors" ("id");'))
+      .toEqual([{ kind: 'constraint', table: 'posts', name: 'posts_author_fk' }])
+    expect(migrationEffects(`CREATE TYPE "posts_status_type" AS ENUM ('draft', 'published');`))
+      .toEqual([{ kind: 'enum', name: 'posts_status_type' }])
+  })
+
+  it('credits the rename in SQLite\'s table-rebuild dance to the final name', () => {
+    // bun-query-builder rebuilds a table via `_qb_tmp_<name>`; the rename is
+    // what actually leaves `authors` behind, so checking for `_qb_tmp_authors`
+    // would report the migration as never applied on every healthy database.
+    expect(migrationEffects('ALTER TABLE "_qb_tmp_authors" RENAME TO "authors";'))
+      .toEqual([{ kind: 'table', name: 'authors' }])
+  })
+
+  it('does not count the rebuild scaffold that gets renamed away', () => {
+    // The scaffold is GONE after a successful migration. Counting its CREATE
+    // as an effect makes every rebuild look permanently half-applied, which
+    // would classify the very migrations #2203 is about as `partial` rather
+    // than `stranded` and put them beyond the reconciler's reach.
+    const sql = `
+      CREATE TABLE IF NOT EXISTS "_qb_tmp_authors" ("id" INTEGER);
+      INSERT INTO "_qb_tmp_authors" SELECT * FROM "authors";
+      DROP TABLE "authors";
+      ALTER TABLE "_qb_tmp_authors" RENAME TO "authors";
+    `
+    expect(migrationEffects(sql)).toEqual([{ kind: 'table', name: 'authors' }])
+  })
+
+  it('drops columns added to the scaffold too, not just the table itself', () => {
+    const sql = `
+      CREATE TABLE "_qb_tmp_posts" ("id" INTEGER);
+      ALTER TABLE "_qb_tmp_posts" ADD COLUMN "slug" TEXT;
+      ALTER TABLE "_qb_tmp_posts" RENAME TO "posts";
+    `
+    expect(migrationEffects(sql)).toEqual([{ kind: 'table', name: 'posts' }])
+  })
+
+  it('handles a rename that appears before the create in file order', () => {
+    // The filter runs after the whole file is read, so statement order in the
+    // emitted SQL cannot change the answer.
+    const sql = `
+      ALTER TABLE "_qb_tmp_x" RENAME TO "x";
+      CREATE TABLE "_qb_tmp_x" ("id" INTEGER);
+    `
+    expect(migrationEffects(sql)).toEqual([{ kind: 'table', name: 'x' }])
+  })
+
+  it('reads MySQL\'s short ADD form without mistaking a constraint for a column', () => {
+    expect(migrationEffects('ALTER TABLE `p` ADD `repository` VARCHAR(255);'))
+      .toEqual([{ kind: 'column', table: 'p', name: 'repository' }])
+    expect(migrationEffects('ALTER TABLE "p" ADD CONSTRAINT "c" FOREIGN KEY ("x") REFERENCES "y" ("id");'))
+      .toEqual([{ kind: 'constraint', table: 'p', name: 'c' }])
+  })
+
+  it('finds nothing in a pure data migration', () => {
+    // The safety-critical case. The shipped corpus contains
+    // `0000000098-revoke-legacy-long-lived-tokens.sql`, a hard DELETE. It
+    // leaves no schema trace, so it must never look "already applied".
+    expect(migrationEffects('DELETE FROM oauth_access_tokens WHERE expires_at < NOW();')).toEqual([])
+    expect(migrationEffects('UPDATE teams SET member_count = 0;')).toEqual([])
+  })
+
+  it('does not read SQL out of a comment', () => {
+    expect(migrationEffects('-- CREATE TABLE "ghost" (id INT);\nCREATE TABLE "real" (id INT);'))
+      .toEqual([{ kind: 'table', name: 'real' }])
+    expect(migrationEffects('/* CREATE TABLE "ghost" (id INT); */ CREATE TABLE "real" (id INT);'))
+      .toEqual([{ kind: 'table', name: 'real' }])
+  })
+
+  it('does not read SQL out of a string literal', () => {
+    // Otherwise a data migration whose payload mentions DDL would register as
+    // creating a table, and then be recorded as applied without ever running.
+    expect(migrationEffects(`INSERT INTO audit_log (body) VALUES ('CREATE TABLE "ghost" (id INT)');`))
+      .toEqual([])
+  })
+
+  it('de-duplicates an effect restated across statements', () => {
+    expect(migrationEffects('CREATE TABLE IF NOT EXISTS "a" (id INT);\nCREATE TABLE IF NOT EXISTS "a" (id INT);'))
+      .toEqual([{ kind: 'table', name: 'a' }])
+  })
+})
+
+describe('stripForEffects', () => {
+  it('preserves quoted identifiers while blanking literals', () => {
+    // The opposite of migration-dialect's stripSqlNoise, which blanks both --
+    // that one matches dialect markers, this one needs the names.
+    const out = stripForEffects(`CREATE TABLE "users" (name TEXT DEFAULT 'x');`)
+    expect(out).toContain('"users"')
+    expect(out).not.toContain('\'x\'')
+  })
+
+  it('keeps line count and offsets stable', () => {
+    const sql = '-- header\nCREATE TABLE "a" (id INT);\n'
+    expect(stripForEffects(sql).length).toBe(sql.length)
+    expect(stripForEffects(sql).split('\n').length).toBe(sql.split('\n').length)
+  })
+})
+
+describe('verifiableEffects', () => {
+  const all: MigrationEffect[] = [
+    { kind: 'table', name: 't' },
+    { kind: 'column', table: 't', name: 'c' },
+    { kind: 'index', name: 'i' },
+    { kind: 'constraint', table: 't', name: 'fk' },
+    { kind: 'enum', name: 'e' },
+  ]
+
+  it('drops constraints and enums on SQLite', () => {
+    // The runner records ADD CONSTRAINT / CREATE TYPE files as executed WITHOUT
+    // running them so a later DB_CONNECTION flip can replay the file (#1916).
+    // Checking those effects here would report every one as `reverted`.
+    expect(verifiableEffects(all, 'sqlite').map(e => e.kind)).toEqual(['table', 'column', 'index'])
+  })
+
+  it('drops only enums on MySQL', () => {
+    expect(verifiableEffects(all, 'mysql').map(e => e.kind)).toEqual(['table', 'column', 'index', 'constraint'])
+  })
+
+  it('keeps everything on Postgres', () => {
+    expect(verifiableEffects(all, 'postgres')).toHaveLength(5)
+  })
+})
+
+describe('classifyMigration', () => {
+  const effects = migrationEffects('CREATE TABLE "issues" (id INT);')
+
+  it('calls an unrecorded migration whose effects all exist STRANDED', () => {
+    // The #2203 case: applied to the schema, lost from the ledger by a renumber.
+    const { present, absent } = split(effects, schema({ tables: ['issues'] }))
+    expect(classifyMigration(false, present, absent)).toBe('stranded')
+  })
+
+  it('calls an unrecorded migration with no effects present PENDING', () => {
+    const { present, absent } = split(effects, schema({}))
+    expect(classifyMigration(false, present, absent)).toBe('pending')
+  })
+
+  it('calls a half-applied unrecorded migration PARTIAL', () => {
+    const two = migrationEffects('CREATE TABLE "a" (id INT);\nCREATE TABLE "b" (id INT);')
+    const { present, absent } = split(two, schema({ tables: ['a'] }))
+    expect(classifyMigration(false, present, absent)).toBe('partial')
+  })
+
+  it('calls a recorded migration whose effects exist APPLIED', () => {
+    const { present, absent } = split(effects, schema({ tables: ['issues'] }))
+    expect(classifyMigration(true, present, absent)).toBe('applied')
+  })
+
+  it('calls a recorded migration whose effects vanished REVERTED', () => {
+    const { present, absent } = split(effects, schema({}))
+    expect(classifyMigration(true, present, absent)).toBe('reverted')
+  })
+
+  it('refuses to guess at a migration with nothing to check', () => {
+    // Vacuously "all effects present" is the trap: it would record the corpus's
+    // `DELETE FROM oauth_access_tokens` as applied on the strength of having
+    // nothing to look for, and the revocation would then never run.
+    expect(classifyMigration(false, [], [])).toBe('unverifiable')
+  })
+
+  it('still trusts the ledger for a data migration it cannot check', () => {
+    expect(classifyMigration(true, [], [])).toBe('applied')
+  })
+})
+
+describe('planLedgerRemap', () => {
+  it('rewrites the reported drift', () => {
+    // Verbatim from the issue: same logical migrations, shifted ordinals.
+    const ledger = [
+      '0000000002-create-alert_channels-table.sql',
+      '0000000003-create-issues-table.sql',
+      '0000000004-create-error_events-table.sql',
+      '0000000006-create-subscriptions-table.sql',
+    ]
+    const disk = [
+      '0000000002-create-issues-table.sql',
+      '0000000003-create-error_events-table.sql',
+      '0000000004-create-subscriptions-table.sql',
+      '0000000005-create-alert_channels-table.sql',
+      '0000000006-alter-issues-constraint.sql',
+    ]
+
+    const plan = planLedgerRemap(ledger, disk)
+
+    expect(plan.ambiguous).toEqual([])
+    expect(plan.dropped).toEqual([])
+    expect(plan.remap.sort((a, b) => a.from.localeCompare(b.from))).toEqual([
+      { from: '0000000002-create-alert_channels-table.sql', to: '0000000005-create-alert_channels-table.sql' },
+      { from: '0000000003-create-issues-table.sql', to: '0000000002-create-issues-table.sql' },
+      { from: '0000000004-create-error_events-table.sql', to: '0000000003-create-error_events-table.sql' },
+      { from: '0000000006-create-subscriptions-table.sql', to: '0000000004-create-subscriptions-table.sql' },
+    ])
+  })
+
+  it('leaves rows that already match a file alone', () => {
+    const plan = planLedgerRemap(['0000000001-create-a-table.sql'], ['0000000001-create-a-table.sql'])
+    expect(plan.remap).toEqual([])
+    expect(plan.dropped).toEqual([])
+  })
+
+  it('never steals a file an exact match already claims', () => {
+    // `0000000001-create-a-table.sql` is recorded and present, so the stale
+    // `0000000009-create-a-table.sql` row must NOT be remapped onto it —
+    // that would drop a genuine record and re-run the migration.
+    const plan = planLedgerRemap(
+      ['0000000001-create-a-table.sql', '0000000009-create-a-table.sql'],
+      ['0000000001-create-a-table.sql'],
+    )
+    expect(plan.remap).toEqual([])
+    expect(plan.dropped).toEqual(['0000000009-create-a-table.sql'])
+  })
+
+  it('reports a deleted migration as dropped rather than remapping it', () => {
+    const plan = planLedgerRemap(['0000000007-create-gone-table.sql'], ['0000000001-create-a-table.sql'])
+    expect(plan.remap).toEqual([])
+    expect(plan.dropped).toEqual(['0000000007-create-gone-table.sql'])
+  })
+
+  it('refuses when one logical name matches several files', () => {
+    // `auto-misc` recurs across generate runs, so this is reachable in practice.
+    const plan = planLedgerRemap(
+      ['0000000005-auto-misc.sql'],
+      ['0000000001-auto-misc.sql', '0000000002-auto-misc.sql'],
+    )
+    expect(plan.remap).toEqual([])
+    expect(plan.ambiguous).toEqual(['0000000005-auto-misc.sql'])
+  })
+
+  it('refuses when two ledger rows converge on one file', () => {
+    const plan = planLedgerRemap(
+      ['0000000005-auto-misc.sql', '0000000006-auto-misc.sql'],
+      ['0000000001-auto-misc.sql'],
+    )
+    expect(plan.remap).toEqual([])
+    expect(plan.ambiguous).toEqual(['0000000005-auto-misc.sql', '0000000006-auto-misc.sql'])
+  })
+
+  it('is a no-op on an empty ledger', () => {
+    const plan = planLedgerRemap([], ['0000000001-create-a-table.sql'])
+    expect(plan).toEqual({ remap: [], ambiguous: [], dropped: [] })
+  })
+})


### PR DESCRIPTION
Closes #2203.

## The problem

The `migrations` table keys on the **filename**, and that filename carries an ordinal prefix. Regenerating the corpus from `app/Models` renumbers the whole sequence, so every migration whose number shifted reads as never-applied, and genuinely-new migrations queue behind it.

Nothing compared the ledger to the schema, so nothing caught it. The reported app ran that way for weeks; the first symptom was a 500 from an unrelated feature panel.

## The fix

A comparison across three sources rather than two:

| | |
|---|---|
| `database/migrations/*.sql` | what the corpus says should exist |
| the `migrations` table | what the runner believes it applied |
| the live schema | what is actually there |

The third is what makes it trustworthy. The ledger is precisely the thing under suspicion, so a disk-vs-ledger diff alone cannot tell a renumbered-but-applied migration (harmless once the row is rewritten) from a genuinely pending one (must actually run). Only the schema can, and it is what a human recovering by hand ends up reading anyway.

```
buddy migrate:status              # read-only report, non-zero exit on drift
buddy migrate:status --reconcile  # repoint renumbered rows, record what the
                                  # schema proves. Never runs migration SQL.
```

`migrate:regenerate` now reconciles after renumbering, so `--force` no longer strands anything, and `buddy doctor` grew a probe so drift surfaces without anyone thinking to look.

## Safety

Deliberately conservative, because recording a migration that never ran and re-running one that did are both worse than the drift:

- `partial` (half-applied) files are refused without an explicit flag.
- A migration with no schema-visible effect stays `unverifiable` rather than being vacuously treated as applied. The shipped corpus contains a hard `DELETE FROM oauth_access_tokens`; recording that on a hunch would skip a revocation that never ran.
- Ledger rows come out of the database, so anything that cannot be written safely is skipped **before** any write, rather than aborting a half-finished repair.
- Reconciliation never executes a statement from a migration file. There is a test asserting the table a pending migration would create is still absent afterwards.

## Not done

Issue suggestion 2, dropping the ordinal from the filename and keying on a stable id, would break every existing corpus and ledger in place. Suggestion 1 (rewrite the row on renumber) plus detection covers the reported failure without that migration.

## Verification

- 540 database tests, 205 buddy tests, 0 fail
- 45 new tests: classifier units, plus an end-to-end reproduction that builds the exact reported state (schema reflects every migration, ledger names the pre-renumber filenames, corpus renumbered underneath) and asserts the audit separates the 4 stranded from the 2 genuinely pending
- pickier clean, typecheck clean, `docs:buddy:check` regenerated and passing
- `buddy migrate:status` run against the live local Postgres

One parser bug found and fixed during self-review: SQLite's `_qb_tmp_*` rebuild scaffold was being counted as an effect. Since it is renamed away, it is never present, which would have misreported a genuinely stranded migration as `partial` and put it beyond the reconciler's reach - exactly the case this issue is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)