### PR TITLE
refactor(socials): name the timeline item type

### DIFF
--- a/storage/framework/core/socials/src/types.ts
+++ b/storage/framework/core/socials/src/types.ts
@@ -178,20 +178,30 @@ export interface TimelineQuery {
   limit?: number
 }
 
+/**
+ * One post in a timeline, normalized to the same shape by every driver.
+ *
+ * Named rather than left inline in {@link TimelineResult} so a consumer can
+ * type a single item - a mapper, a row renderer, a test fixture - without
+ * restating the ten fields or reaching for `TimelineResult['items'][number]`.
+ * Apps were redeclaring this verbatim because there was nothing to import.
+ */
+export interface TimelineItem {
+  uri: string
+  authorHandle: string
+  authorName?: string
+  authorAvatar?: string
+  postUrl?: string
+  body: string
+  postedAt: string
+  likeCount: number
+  repostCount: number
+  replyCount: number
+}
+
 export interface TimelineResult {
   cursor?: string
-  items: Array<{
-    uri: string
-    authorHandle: string
-    authorName?: string
-    authorAvatar?: string
-    postUrl?: string
-    body: string
-    postedAt: string
-    likeCount: number
-    repostCount: number
-    replyCount: number
-  }>
+  items: TimelineItem[]
 }
 
 export interface SocialPublishingDriver {


### PR DESCRIPTION
Follow-up to Chris's question on the postline `.d.ts`: *"i wonder whether these should be types as part of stacks, for reusability... if we defined them already elsewhere in core stacks, we can then auto import those types, and would not need those at all?"*

He was right, and it was worse than it looked. **8 of postline's 15 social types are already in `@stacksjs/socials`, byte for byte.**

| duplicated verbatim | postline-only |
|---|---|
| `TimelineResult`, `TimelineQuery`, `SocialIdentityCredentials`, `AuthoredPost`, `AuthoredPostPage`, `RemotePostRef`, `BlueskySession`, `BlueskySessionCredentials` | `CrosspostTargetResult`, `ProviderPurgeAdapter`, `PublishContent`, `SocialDriver`, `SocialProvider` |

Two more nearly match: `PublishedPost` differs only by the provider union, and `PublishPostInput` has genuinely forked (core carries `langs`/`reply`, postline carries `media`).

## The change

`TimelineResult.items` was an anonymous inline array, so nothing could type a single post without restating ten fields or writing `TimelineResult['items'][number]`. That is a large part of why apps redeclared it. Naming it is a pure refactor:

```ts
export interface TimelineItem { uri, authorHandle, authorName?, authorAvatar?,
                                postUrl?, body, postedAt, likeCount,
                                repostCount, replyCount }
export interface TimelineResult { cursor?: string, items: TimelineItem[] }
```

`TimelineResult` is structurally unchanged, and `TimelineItem` ships via the existing `export * from './types'`.

## What I deliberately did not do

Chris's phrasing was "auto import those types". I checked, and a global `.d.ts` would not have worked for the case that prompted this: **`tsc` never sees inside a `.stx` file** — postline's tsconfig has no `.stx` in `include`, and `Bun.Transpiler` erases types without checking them. So ambient globals for stx script blocks are editor hints, not enforcement — the same unenforced-declaration smell as the `.d.ts` this replaces.

What *is* enforced is `app/Support/**/*.ts`, which tsc does check. So the win is real there, and postline's copy is being replaced with re-exports of these (stacksjs/postline, typecheck clean).

pickier clean, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)