### PR TITLE
fix(defaults): repair class attributes mangled by a class sorter

### DIFF
--- a/resources/components/InputGroup.stx
+++ b/resources/components/InputGroup.stx
@@ -25,7 +25,7 @@ const { id, label, type, placeholder, class: classList } = withDefaults(
     <input
       type="{{ type }}"
       id="{{ id }}"
-      class="{{ }} classList"
+      class="{{ classList }}"
       placeholder="{{ placeholder }}"
     />
   </div>

--- a/storage/framework/defaults/resources/components/Container.stx
+++ b/storage/framework/defaults/resources/components/Container.stx
@@ -5,6 +5,6 @@ interface ContainerProps {
 
 const { className = '' } = defineProps<ContainerProps>()
 </script>
-<div class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl {{ }} className">
+<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 {{ className }}">
     <slot />
   </div>

--- a/storage/framework/defaults/resources/components/Docs/Demo/ComboboxDemo.stx
+++ b/storage/framework/defaults/resources/components/Docs/Demo/ComboboxDemo.stx
@@ -56,7 +56,7 @@ function filterItems(items, query) {
                     data-item-id="{{ item.id }}"
                     data-item-name="{{ item.name }}"
                   >
-                    <span class="block truncate selected selected.id : ? 'font-medium' 'font-normal' {{ }} && == item.id">
+                    <span class="block truncate {{ selected && selected.id == item.id ? 'font-medium' : 'font-normal' }}">
                       {{ item.name }}
                     </span>
                     @if(selected && selected.id == item.id)

--- a/storage/framework/defaults/resources/components/Docs/Demo/DocsPlayground.stx
+++ b/storage/framework/defaults/resources/components/Docs/Demo/DocsPlayground.stx
@@ -10,13 +10,13 @@ const { isPreviewMode = true } = defineProps<DocsPlaygroundProps>()
     <div class="relative bg-gray-100 dark:bg-neutral-800 rounded-lg">
       <div class="flex items-stretch justify-end px-3 py-1 md:m-1 bg-gray-100 dark:bg-neutral-800 rounded-t-[10px] md:rounded-lg">
         <button
-          class="flex mr-1 px-3 py-2 font-medium text-blue-500' text-xs dark:text-neutral-300 hover:bg-gray-300 dark:hover:bg-neutral-600' rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 pointer-events-auto : ? 'bg-white 'text-gray-600 {{ }} isPreviewMode"
+          class="pointer-events-auto mr-1 flex rounded-md px-3 py-2 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 {{ isPreviewMode ? 'bg-white text-blue-500' : 'text-gray-600 dark:text-neutral-300 hover:bg-gray-300 dark:hover:bg-neutral-600' }}"
           data-action="toggle-preview"
         >
           Preview
         </button>
         <button
-          class="flex px-3 py-2 font-medium text-blue-500' text-xs dark:text-neutral-300 hover:bg-gray-300 dark:hover:bg-neutral-600' rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 pointer-events-auto : !isPreviewMode ? 'bg-white 'text-gray-600 {{ }}"
+          class="pointer-events-auto flex rounded-md px-3 py-2 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 {{ !isPreviewMode ? 'bg-white text-blue-500' : 'text-gray-600 dark:text-neutral-300 hover:bg-gray-300 dark:hover:bg-neutral-600' }}"
           data-action="toggle-code"
         >
           Code

--- a/storage/framework/defaults/resources/components/Docs/Demo/DropdownDemo.stx
+++ b/storage/framework/defaults/resources/components/Docs/Demo/DropdownDemo.stx
@@ -45,7 +45,7 @@ function getMenuSections(items) {
           data-action="toggle-dropdown"
         >
           Options
-          <div class="h-5 w-5 duration-200 transition-transform : ? '' 'rotate-180' {{ }} i-hugeicons-chevron-down-20-solid isOpen"></div>
+          <div class="i-hugeicons-chevron-down-20-solid w-5 h-5 transition-transform duration-200 {{ isOpen ? 'rotate-180' : '' }}"></div>
         </button>
 
         @if(isOpen)
@@ -55,11 +55,11 @@ function getMenuSections(items) {
                 @foreach(section as item)
                   <button
                     type="button"
-                    class="flex relative items-center px-2 py-2 w-full text-sm hover:bg-gray-50' hover:bg-red-50' outline-none rounded-md transition-colors : ? 'danger' 'text-gray-700 'text-red-600 {{ }} == group item.variant"
+                    class="group relative flex w-full items-center rounded-md px-2 py-2 text-sm outline-none transition-colors {{ item.variant == 'danger' ? 'text-red-600 hover:bg-red-50' : 'text-gray-700 hover:bg-gray-50' }}"
                     data-action="menu-item"
                     data-item-label="{{ item.label }}"
                   >
-                    <div class="mr-2 h-5 w-5 group-hover:text-gray-700' : ? 'danger' 'text-gray-500 'text-red-600' {{ {{ }} }} == item.icon item.variant"></div>
+                    <div class="{{ item.icon }} mr-2 h-5 w-5 {{ item.variant == 'danger' ? 'text-red-600' : 'text-gray-500 group-hover:text-gray-700' }}"></div>
                     {{ item.label }}
                   </button>
                 @endforeach

--- a/storage/framework/defaults/resources/components/Docs/Demo/ListboxDemo.stx
+++ b/storage/framework/defaults/resources/components/Docs/Demo/ListboxDemo.stx
@@ -32,12 +32,12 @@ const { people = [, selectedPerson = people[0], isOpen = false } = defineProps<L
           <div class="absolute overflow-auto mt-1 py-1 max-h-60 w-full text-base sm:text-sm bg-white outline-none ring-1 ring-black/5 rounded-md focus:outline-none shadow-lg">
             @foreach(people as person)
               <div
-                class="relative pl-10 pr-4 py-2 list-none text-amber-900' hover:text-amber-900 hover:bg-amber-100 cursor-default select-none selectedPerson.id : ? 'bg-amber-100 'text-gray-900' {{ }} == person.id"
+                class="list-none relative cursor-default select-none py-2 pl-10 pr-4 hover:bg-amber-100 hover:text-amber-900 {{ selectedPerson.id == person.id ? 'bg-amber-100 text-amber-900' : 'text-gray-900' }}"
                 data-action="select-person"
                 data-person-id="{{ person.id }}"
                 data-person-name="{{ person.name }}"
               >
-                <span class="block truncate selectedPerson.id : ? 'font-medium' 'font-normal' {{ }} == person.id">
+                <span class="block truncate {{ selectedPerson.id == person.id ? 'font-medium' : 'font-normal' }}">
                   {{ person.name }}
                 </span>
                 @if(selectedPerson.id == person.id)

--- a/storage/framework/defaults/resources/components/Docs/Demo/PopoverDemo.stx
+++ b/storage/framework/defaults/resources/components/Docs/Demo/PopoverDemo.stx
@@ -34,7 +34,7 @@ const { solutions = [, isOpen = false } = defineProps<PopoverDemoProps>()
     <div class="items-center mx-auto my-12 space-y-4 h-[150px] w-3/5">
       <div class="relative">
         <button
-          class="inline-flex gap-2 items-center justify-center px-4 py-2.5 font-medium text-sm text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 shadow-sm duration-200 transition-all : ? 'text-white' 'text-white/90' {{ }} group isOpen"
+          class="group inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-all duration-200 {{ isOpen ? 'text-white' : 'text-white/90' }}"
           data-action="toggle-popover"
         >
           <span>Example</span>

--- a/storage/framework/defaults/resources/components/Docs/Demo/RadioGroupDemo.stx
+++ b/storage/framework/defaults/resources/components/Docs/Demo/RadioGroupDemo.stx
@@ -16,17 +16,17 @@ const { plans = [, selected = plans[0] } = defineProps<RadioGroupDemoProps>()
       <div class="space-y-2">
         @foreach(plans as plan)
           <div
-            class="flex relative px-5 py-4 text-white ring-2 ring-offset-2 ring-offset-sky-300' ring-white/60 rounded-lg focus:outline-none shadow-md cursor-pointer selected.name : ? 'bg-sky-900/75 'bg-white' {{ }} == plan.name"
+            class="relative flex cursor-pointer rounded-lg px-5 py-4 shadow-md focus:outline-none {{ selected.name == plan.name ? 'bg-sky-900/75 text-white ring-2 ring-white/60 ring-offset-2 ring-offset-sky-300' : 'bg-white' }}"
             data-action="select-plan"
             data-plan-name="{{ plan.name }}"
           >
             <div class="flex items-center justify-between w-full">
               <div class="flex items-center">
                 <div class="text-sm">
-                  <p class="font-medium selected.name : ? 'text-gray-900' 'text-white' {{ }} == plan.name">
+                  <p class="font-medium {{ selected.name == plan.name ? 'text-white' : 'text-gray-900' }}">
                     {{ plan.name }}
                   </p>
-                  <span class="inline selected.name : ? 'text-gray-500' 'text-sky-100' {{ }} == plan.name">
+                  <span class="inline {{ selected.name == plan.name ? 'text-sky-100' : 'text-gray-500' }}">
                     <span>{{ plan.ram }}/{{ plan.cpus }}</span>
                     <span aria-hidden="true"> &middot; </span>
                     <span>{{ plan.disk }}</span>

--- a/storage/framework/defaults/resources/components/Docs/Demo/StepperDemo.stx
+++ b/storage/framework/defaults/resources/components/Docs/Demo/StepperDemo.stx
@@ -30,19 +30,19 @@ function getStepContent(step) {
       <!-- Stepper indicator -->
       <div class="flex items-center justify-between mb-12">
         @foreach(steps as step)
-          <div class="flex items-center : ? '' 'flex-1' {{ }} loop.last">
+          <div class="flex items-center {{ loop.last ? '' : 'flex-1' }}">
             <div class="flex flex-col items-center">
-              <div class="flex items-center justify-center h-8 w-8 text-blue-600' text-gray-500' ring-blue-600 ring-offset-2' rounded-full : : ? ? '' 'bg-blue-100 'bg-gray-100 'ring-2 {{ {{ }} }} <= == currentStep currentStep loop.index loop.index">
+              <div class="flex items-center justify-center w-8 h-8 rounded-full {{ loop.index <= currentStep ? 'bg-blue-100 text-blue-600' : 'bg-gray-100 text-gray-500' }} {{ loop.index == currentStep ? 'ring-2 ring-blue-600 ring-offset-2' : '' }}">
                 @if(loop.index < currentStep)
                   <div class="h-5 w-5 i-heroicons-check"></div>
                 @else
                   {{ loop.index + 1 }}
                 @endif
               </div>
-              <span class="mt-2 font-medium' text-sm : ? 'text-blue-600 'text-gray-500' {{ }} == currentStep loop.index">{{ step.title }}</span>
+              <span class="mt-2 text-sm {{ loop.index == currentStep ? 'text-blue-600 font-medium' : 'text-gray-500' }}">{{ step.title }}</span>
             </div>
             @if(!loop.last)
-              <div class="flex-1 mx-4 h-0.5 : ? 'bg-blue-500' 'bg-gray-200' {{ }} < currentStep loop.index"></div>
+              <div class="flex-1 h-0.5 mx-4 {{ loop.index < currentStep ? 'bg-blue-500' : 'bg-gray-200' }}"></div>
             @endif
           </div>
         @endforeach
@@ -108,14 +108,14 @@ function getStepContent(step) {
 
       <div class="flex gap-4 justify-center">
         <button
-          class="px-4 py-2 font-medium text-gray-700 text-sm bg-gray-50 hover:bg-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-not-allowed' : ? '' 'opacity-50 {{ }} == 0 currentStep"
+          class="rounded-md bg-gray-50 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 {{ currentStep == 0 ? 'opacity-50 cursor-not-allowed' : '' }}"
           data-action="previous-step"
           {{ currentStep == 0 ? 'disabled' : '' }}
         >
           Previous
         </button>
         <button
-          class="px-4 py-2 font-medium text-sm text-white bg-blue-500 hover:bg-blue-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-not-allowed' - : ? '' 'opacity-50 {{ }} == 1 currentStep steps.length"
+          class="rounded-md bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 {{ currentStep == steps.length - 1 ? 'opacity-50 cursor-not-allowed' : '' }}"
           data-action="next-step"
           {{ currentStep == steps.length - 1 ? 'disabled' : '' }}
         >

--- a/storage/framework/defaults/resources/components/Docs/Demo/SwitchDemo.stx
+++ b/storage/framework/defaults/resources/components/Docs/Demo/SwitchDemo.stx
@@ -9,13 +9,13 @@ const { enabled = false } = defineProps<SwitchDemoProps>()
     <DocsPlayground>
       <div class="flex gap-2 items-center justify-center my-3">
         <button
-          class="inline-flex relative shrink-0 h-[38px] w-[74px] border-2 border-transparent rounded-full focus-visible:ring-2 focus-visible:ring-white/75 focus:outline-none duration-200 ease-in-out transition-colors cursor-pointer : ? 'bg-blue-500' 'bg-gray-400' {{ }} enabled"
+          class="relative h-[38px] w-[74px] inline-flex shrink-0 cursor-pointer border-2 border-transparent rounded-full transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75 {{ enabled ? 'bg-blue-500' : 'bg-gray-400' }}"
           data-action="toggle-switch"
         >
           <span class="sr-only">Use setting</span>
           <span
             aria-hidden="true"
-            class="inline-block h-[34px] w-[34px] bg-white ring-0 rounded-full shadow-lg duration-200 ease-in-out transition transform pointer-events-none : ? 'translate-x-0' 'translate-x-9' {{ }} enabled"
+            class="pointer-events-none inline-block h-[34px] w-[34px] transform rounded-full bg-white shadow-lg ring-0 transition duration-200 ease-in-out {{ enabled ? 'translate-x-9' : 'translate-x-0' }}"
           ></span>
         </button>
       </div>

--- a/storage/framework/defaults/resources/components/Forum/ForumBreadcrumb.stx
+++ b/storage/framework/defaults/resources/components/Forum/ForumBreadcrumb.stx
@@ -20,13 +20,13 @@ const { items = [] } = defineProps<ForumBreadcrumbProps>()
           @if(item.link)
             <a
               href="{{ item.link }}"
-              class="font-medium text-gray-700 text-sm hover:text-blue-600 : ? '' 'ml-1' {{ }} > 0 loop.index"
+              class="text-sm font-medium text-gray-700 hover:text-blue-600 {{ loop.index > 0 ? 'ml-1' : '' }}"
             >
               {{ item.label }}
             </a>
           @else
             <span
-              class="font-medium text-gray-500 text-sm : ? '' 'ml-1' {{ }} > 0 loop.index"
+              class="text-sm font-medium text-gray-500 {{ loop.index > 0 ? 'ml-1' : '' }}"
             >
               {{ item.label }}
             </span>

--- a/storage/framework/defaults/resources/components/Forum/ForumCategoryItem.stx
+++ b/storage/framework/defaults/resources/components/Forum/ForumCategoryItem.stx
@@ -13,7 +13,7 @@ const { title = '', description = '', link = '', topicCount = 0, postCount = 0, 
 </script>
 <div class="flex items-start p-4 hover:bg-gray-50">
     <div class="flex-shrink-0 mr-4">
-      <div class="flex items-center justify-center h-10 w-10 text-gray-500 bg-gray-100 rounded-full {{ }} icon"></div>
+      <div class="{{ icon }} w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center text-gray-500"></div>
     </div>
 
     <div class="flex-grow min-w-0">

--- a/storage/framework/defaults/resources/components/Forum/ForumLayout.stx
+++ b/storage/framework/defaults/resources/components/Forum/ForumLayout.stx
@@ -19,10 +19,10 @@ function isActiveRoute(currentRoute, targetRoute) {
         </div>
       </div>
       <nav class="flex gap-1 text-sm">
-        <a href="/forum" class="px-3 py-2 font-medium' 'hover:bg-gray-100 rounded-md rounded-md' : ? 'bg-gray-100 'forum') {{ }} isActiveRoute(route,">All Discussions</a>
-        <a href="/forum?filter=popular" class="px-3 py-2 font-medium' 'hover:bg-gray-100 rounded-md rounded-md' : ? 'bg-gray-100 'forum-popular') {{ }} isActiveRoute(route,">Popular</a>
-        <a href="/forum?filter=recent" class="px-3 py-2 font-medium' 'hover:bg-gray-100 rounded-md rounded-md' : ? 'bg-gray-100 'forum-recent') {{ }} isActiveRoute(route,">Recent</a>
-        <a href="/forum?filter=solved" class="px-3 py-2 font-medium' 'hover:bg-gray-100 rounded-md rounded-md' : ? 'bg-gray-100 'forum-solved') {{ }} isActiveRoute(route,">Solved</a>
+        <a href="/forum" class="px-3 py-2 {{ isActiveRoute(route, 'forum') ? 'bg-gray-100 rounded-md font-medium' : 'hover:bg-gray-100 rounded-md' }}">All Discussions</a>
+        <a href="/forum?filter=popular" class="px-3 py-2 {{ isActiveRoute(route, 'forum-popular') ? 'bg-gray-100 rounded-md font-medium' : 'hover:bg-gray-100 rounded-md' }}">Popular</a>
+        <a href="/forum?filter=recent" class="px-3 py-2 {{ isActiveRoute(route, 'forum-recent') ? 'bg-gray-100 rounded-md font-medium' : 'hover:bg-gray-100 rounded-md' }}">Recent</a>
+        <a href="/forum?filter=solved" class="px-3 py-2 {{ isActiveRoute(route, 'forum-solved') ? 'bg-gray-100 rounded-md font-medium' : 'hover:bg-gray-100 rounded-md' }}">Solved</a>
       </nav>
     </header>
 

--- a/storage/framework/defaults/resources/components/Forum/ForumPagination.stx
+++ b/storage/framework/defaults/resources/components/Forum/ForumPagination.stx
@@ -11,7 +11,7 @@ const { currentPage = 1, totalPages = 1, pages = [] } = defineProps<ForumPaginat
     <nav class="flex gap-1 items-center">
       <a
         href="#"
-        class="flex items-center justify-center h-10 w-10 hover:bg-gray-100 border rounded-md cursor-not-allowed' : ? '' 'opacity-50 {{ }} == 1 currentPage"
+        class="w-10 h-10 flex items-center justify-center rounded-md border hover:bg-gray-100 {{ currentPage == 1 ? 'opacity-50 cursor-not-allowed' : '' }}"
         data-action="prev-page"
       >
         <span class="i-hugeicons-arrow-left"></span>
@@ -20,7 +20,7 @@ const { currentPage = 1, totalPages = 1, pages = [] } = defineProps<ForumPaginat
       @foreach(pages as page)
         <a
           href="#"
-          class="flex items-center justify-center h-10 w-10 text-white' hover:bg-gray-100' rounded-md : ? 'bg-primary 'border {{ }} == currentPage page"
+          class="w-10 h-10 flex items-center justify-center rounded-md {{ currentPage == page ? 'bg-primary text-white' : 'border hover:bg-gray-100' }}"
           data-action="go-to-page"
           data-page="{{ page }}"
         >
@@ -30,7 +30,7 @@ const { currentPage = 1, totalPages = 1, pages = [] } = defineProps<ForumPaginat
 
       <a
         href="#"
-        class="flex items-center justify-center h-10 w-10 hover:bg-gray-100 border rounded-md cursor-not-allowed' : ? '' 'opacity-50 {{ }} == currentPage totalPages"
+        class="w-10 h-10 flex items-center justify-center rounded-md border hover:bg-gray-100 {{ currentPage == totalPages ? 'opacity-50 cursor-not-allowed' : '' }}"
         data-action="next-page"
       >
         <span class="i-hugeicons-arrow-right"></span>

--- a/storage/framework/defaults/resources/components/Forum/ForumReplyForm.stx
+++ b/storage/framework/defaults/resources/components/Forum/ForumReplyForm.stx
@@ -64,7 +64,7 @@ function canSubmit(content) {
             Preview
           </button>
           <button
-            class="px-4 py-2 text-white bg-primary rounded-md hover:opacity-90 cursor-not-allowed' : ? '' 'opacity-50 {{ }} canSubmit(replyContent)"
+            class="px-4 py-2 bg-primary text-white rounded-md hover:opacity-90 {{ canSubmit(replyContent) ? '' : 'opacity-50 cursor-not-allowed' }}"
             data-action="submit-reply"
             {{ canSubmit(replyContent) ? '' : 'disabled' }}
           >

--- a/storage/framework/defaults/resources/components/Marketing/Feature.stx
+++ b/storage/framework/defaults/resources/components/Marketing/Feature.stx
@@ -14,13 +14,13 @@ name: '',
   icon: ''
 }
 </script>
-<div class="hover:opacity-100' : !isActive ? '' 'opacity-75 {{ {{ }} }} className">
-  <div class="w-9 rounded-lg : ? 'bg-blue-600' 'bg-slate-500' {{ }} isActive">
+<div class="{{ className }} {{ !isActive ? 'opacity-75 hover:opacity-100' : '' }}">
+  <div class="w-9 rounded-lg {{ isActive ? 'bg-blue-600' : 'bg-slate-500' }}">
     <svg aria-hidden="true" class="h-9 w-9" fill="none">
       <!-- feature.icon -->
     </svg>
   </div>
-  <h3 class="mt-6 font-medium text-sm : ? 'text-blue-600' 'text-slate-600' {{ }} isActive">
+  <h3 class="mt-6 text-sm font-medium {{ isActive ? 'text-blue-600' : 'text-slate-600' }}">
     {{ feature.name }}
   </h3>
   <p class="mt-2 font-display text-slate-900 text-xl">

--- a/storage/framework/defaults/resources/components/Marketing/Fields.stx
+++ b/storage/framework/defaults/resources/components/Marketing/Fields.stx
@@ -12,16 +12,16 @@ const { type = 'text', label = '', className = '', id = '', name = '', placehold
 
 const formClasses = 'block w-full appearance-none rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-blue-500 sm:text-sm'
 </script>
-<div class="{{ }} className">
+<div class="{{ className }}">
   @if(label)
     <label for="{{ id }}" class="block mb-3 font-medium text-gray-700 text-sm">
       {{ label }}
     </label>
   @endif
   @if(type == 'text' || type == 'email' || type == 'password')
-    <input id="{{ id }}" type="{{ type }}" name="{{ name }}" placeholder="{{ placeholder }}" class="{{ }} formClasses">
+    <input id="{{ id }}" type="{{ type }}" name="{{ name }}" placeholder="{{ placeholder }}" class="{{ formClasses }}">
   @else
-    <select id="{{ id }}" name="{{ name }}" class="pr-8 {{ }} formClasses">
+    <select id="{{ id }}" name="{{ name }}" class="{{ formClasses }} pr-8">
       <slot />
     </select>
   @endif

--- a/storage/framework/defaults/resources/components/Marketing/Layout.stx
+++ b/storage/framework/defaults/resources/components/Marketing/Layout.stx
@@ -18,7 +18,7 @@ subsets: ['latin'],
 </script>
 <html
   lang="en"
-  class="h-full antialiased bg-white scroll-smooth {{ {{ }} }} inter.variable lexend.variable"
+  class="h-full scroll-smooth bg-white antialiased {{ inter.variable }} {{ lexend.variable }}"
 >
   <body class="flex flex-col h-full">
     <slot />

--- a/storage/framework/defaults/resources/components/Marketing/Plan.stx
+++ b/storage/framework/defaults/resources/components/Marketing/Plan.stx
@@ -11,12 +11,12 @@ interface PlanProps {
 const { name = '', price = '', description = '', href = '', features = [], featured = false } = defineProps<PlanProps>()
 </script>
 <section
-  class="flex lg:order-none' flex-col 'lg:py-8' px-6 py-8 sm:px-8 bg-blue-600 rounded-3xl : ? 'order-first {{ }} featured"
+  class="flex flex-col rounded-3xl px-6 sm:px-8 {{ featured ? 'order-first bg-blue-600 py-8 lg:order-none' : 'lg:py-8' }}"
 >
   <h3 class="mt-5 font-display text-lg text-white">
     {{ name }}
   </h3>
-  <p class="mt-2 text-base : ? 'text-slate-400' 'text-white' {{ }} featured">
+  <p class="mt-2 text-base {{ featured ? 'text-white' : 'text-slate-400' }}">
     {{ description }}
   </p>
   <p class="order-first font-display font-light text-5xl text-white tracking-tight">
@@ -24,18 +24,18 @@ const { name = '', price = '', description = '', href = '', features = [], featu
   </p>
   <ul
     role="list"
-    class="flex order-last flex-col gap-y-3 mt-10 text-sm : ? 'text-slate-200' 'text-white' {{ }} featured"
+    class="order-last mt-10 flex flex-col gap-y-3 text-sm {{ featured ? 'text-white' : 'text-slate-200' }}"
   >
     @foreach(features as feature)
       <li class="flex">
-        <span class="h-5 w-5 : ? 'text-slate-400' 'text-white' {{ }} featured i-hugeicons-checkmark-circle-02"></span>
+        <span class="i-hugeicons-checkmark-circle-02 h-5 w-5 {{ featured ? 'text-white' : 'text-slate-400' }}"></span>
         <span class="ml-4">{{ feature }}</span>
       </li>
     @endforeach
   </ul>
   <a
     href="{{ href }}"
-    class="inline-flex items-center justify-center mt-8 px-4 py-2 font-semibold text-slate-900 text-sm text-white active:text-slate-400 active:text-slate-600 active:bg-blue-200 hover:bg-blue-50 ring-slate-700 rounded-full active:ring-slate-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white' focus-visible:outline-white' focus:outline-none hover:ring-slate-500 : ? 'bg-white 'ring-1 {{ }} featured"
+    class="mt-8 inline-flex items-center justify-center rounded-full py-2 px-4 text-sm font-semibold focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 {{ featured ? 'bg-white text-slate-900 hover:bg-blue-50 active:bg-blue-200 active:text-slate-600 focus-visible:outline-white' : 'ring-1 ring-slate-700 text-white hover:ring-slate-500 active:ring-slate-700 active:text-slate-400 focus-visible:outline-white' }}"
     aria-label="Get started with the {{ name }} plan for {{ price }}"
   >
     Get started

--- a/storage/framework/defaults/resources/components/Marketing/Pricing.stx
+++ b/storage/framework/defaults/resources/components/Marketing/Pricing.stx
@@ -84,12 +84,12 @@ const { plans = [ } = defineProps<PricingProps>()
     <div class="grid gap-y-10 grid-cols-1 lg:grid-cols-3 xl:gap-x-8 -mx-4 mt-16 sm:mx-auto lg:-mx-8 xl:mx-0 max-w-2xl lg:max-w-none">
       @foreach(plans as plan)
         <section
-          class="flex lg:order-none' flex-col 'lg:py-8' px-6 py-8 sm:px-8 bg-blue-600 rounded-3xl : ? 'order-first {{ }} plan.featured"
+          class="flex flex-col rounded-3xl px-6 sm:px-8 {{ plan.featured ? 'order-first bg-blue-600 py-8 lg:order-none' : 'lg:py-8' }}"
         >
           <h3 class="mt-5 font-display text-lg text-white">
             {{ plan.name }}
           </h3>
-          <p class="mt-2 text-base : ? 'text-slate-400' 'text-white' {{ }} plan.featured">
+          <p class="mt-2 text-base {{ plan.featured ? 'text-white' : 'text-slate-400' }}">
             {{ plan.description }}
           </p>
           <p class="order-first font-display font-light text-5xl text-white tracking-tight">
@@ -97,18 +97,18 @@ const { plans = [ } = defineProps<PricingProps>()
           </p>
           <ul
             role="list"
-            class="flex order-last flex-col gap-y-3 mt-10 text-sm : ? 'text-slate-200' 'text-white' {{ }} plan.featured"
+            class="order-last mt-10 flex flex-col gap-y-3 text-sm {{ plan.featured ? 'text-white' : 'text-slate-200' }}"
           >
             @foreach(plan.features as feature)
               <li class="flex">
-                <span class="h-5 w-5 : ? 'text-slate-400' 'text-white' {{ }} i-hugeicons-checkmark-circle-02 plan.featured"></span>
+                <span class="i-hugeicons-checkmark-circle-02 h-5 w-5 {{ plan.featured ? 'text-white' : 'text-slate-400' }}"></span>
                 <span class="ml-4">{{ feature }}</span>
               </li>
             @endforeach
           </ul>
           <a
             href="{{ plan.href }}"
-            class="inline-flex items-center justify-center mt-8 px-4 py-2 font-semibold text-slate-900 text-sm text-white hover:bg-blue-50' ring-slate-700 rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus:outline-none hover:ring-slate-500' : ? 'bg-white 'ring-1 {{ }} plan.featured"
+            class="mt-8 inline-flex items-center justify-center rounded-full py-2 px-4 text-sm font-semibold focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 {{ plan.featured ? 'bg-white text-slate-900 hover:bg-blue-50' : 'ring-1 ring-slate-700 text-white hover:ring-slate-500' }}"
             aria-label="Get started with the {{ plan.name }} plan for {{ plan.price }}"
           >
             Get started

--- a/storage/framework/defaults/resources/components/Marketing/PrimaryFeatures.stx
+++ b/storage/framework/defaults/resources/components/Marketing/PrimaryFeatures.stx
@@ -44,14 +44,14 @@ const { features = [, selectedIndex = 0 } = defineProps<PrimaryFeaturesProps>()
       <div class="flex overflow-x-auto sm:overflow-visible lg:col-span-5 -mx-4 mt-16 pb-4 sm:mx-0 sm:pb-0">
         <div class="flex lg:block relative z-10 gap-x-4 lg:gap-x-0 lg:gap-y-1 px-4 sm:mx-auto sm:px-0 lg:mx-0 whitespace-nowrap lg:whitespace-normal">
           @foreach(features as feature)
-            <div class="relative px-4 py-1 lg:p-6 'hover:bg-white/10 lg:bg-white/10 lg:hover:bg-white/5' rounded-full lg:ring-1 lg:ring-inset lg:ring-white/10' lg:rounded-l-xl lg:rounded-r-none selectedIndex : ? 'bg-white {{ }} == group loop.index">
+            <div class="group relative rounded-full px-4 py-1 lg:rounded-l-xl lg:rounded-r-none lg:p-6 {{ loop.index == selectedIndex ? 'bg-white lg:bg-white/10 lg:ring-1 lg:ring-inset lg:ring-white/10' : 'hover:bg-white/10 lg:hover:bg-white/5' }}">
               <h3>
-                <button class="font-display text-lg lg:text-white' lg:text-white' hover:text-white selectedIndex : ? 'text-blue-100 'text-blue-600 {{ }} == loop.index" data-action="select-tab" data-index="{{ loop.index }}">
+                <button class="font-display text-lg {{ loop.index == selectedIndex ? 'text-blue-600 lg:text-white' : 'text-blue-100 hover:text-white lg:text-white' }}" data-action="select-tab" data-index="{{ loop.index }}">
                   <span class="absolute inset-0 rounded-full lg:rounded-l-xl lg:rounded-r-none"></span>
                   {{ feature.title }}
                 </button>
               </h3>
-              <p class="hidden lg:block mt-2 text-sm group-hover:text-white' selectedIndex : ? 'text-blue-100 'text-white' {{ }} == loop.index">
+              <p class="mt-2 hidden text-sm lg:block {{ loop.index == selectedIndex ? 'text-white' : 'text-blue-100 group-hover:text-white' }}">
                 {{ feature.description }}
               </p>
             </div>
@@ -62,7 +62,7 @@ const { features = [, selectedIndex = 0 } = defineProps<PrimaryFeaturesProps>()
       <!-- Tab Panels -->
       <div class="lg:col-span-7">
         @foreach(features as feature)
-          <div class="selectedIndex : != ? '' 'hidden' {{ }} loop.index">
+          <div class="{{ loop.index != selectedIndex ? 'hidden' : '' }}">
             <div class="lg:hidden relative sm:px-6">
               <div class="absolute bottom-[-4.25rem] top-[-6.5rem] sm:inset-x-0 bg-white/10 ring-1 ring-inset ring-white/10 sm:rounded-t-xl -inset-x-4"></div>
               <p class="relative mx-auto max-w-2xl text-base text-white sm:text-center">

--- a/storage/framework/defaults/resources/components/Marketing/PrimaryFeatures2.stx
+++ b/storage/framework/defaults/resources/components/Marketing/PrimaryFeatures2.stx
@@ -58,15 +58,15 @@ const { backgroundImage = '/images/screenshots/background-features.jpg', screens
       <div class="flex overflow-x-auto sm:overflow-visible lg:col-span-5 -mx-4 pb-4 sm:mx-0 sm:pb-0">
         <div class="flex lg:block relative z-10 gap-x-4 lg:gap-x-0 lg:gap-y-1 px-4 sm:mx-auto sm:px-0 lg:mx-0 whitespace-nowrap lg:whitespace-normal">
           @foreach(features as feature)
-            <div class="relative px-4 py-1 lg:p-6 'hover:bg-white/10 lg:bg-white/10 lg:hover:bg-white/5' rounded-full lg:ring-1 lg:ring-inset lg:ring-white/10' lg:rounded-l-xl lg:rounded-r-none selectedIndex : ? 'bg-white {{ }} == group loop.index">
+            <div class="group relative rounded-full px-4 py-1 lg:rounded-l-xl lg:rounded-r-none lg:p-6 {{ loop.index == selectedIndex ? 'bg-white lg:bg-white/10 lg:ring-1 lg:ring-inset lg:ring-white/10' : 'hover:bg-white/10 lg:hover:bg-white/5' }}">
               <h3>
-                <button class="font-display text-lg lg:text-white' lg:text-white' hover:text-white selectedIndex : ? 'text-blue-100 'text-blue-600 {{ }} == loop.index" data-action="select-tab" data-index="{{ loop.index }}">
+                <button class="font-display text-lg {{ loop.index == selectedIndex ? 'text-blue-600 lg:text-white' : 'text-blue-100 hover:text-white lg:text-white' }}" data-action="select-tab" data-index="{{ loop.index }}">
                   <span class="absolute inset-0 rounded-full lg:rounded-l-xl lg:rounded-r-none"></span>
                   {{ feature.title }}
                 </button>
               </h3>
               @if(tabOrientation == 'vertical')
-                <p class="hidden lg:block mt-2 text-sm group-hover:text-white' selectedIndex : ? 'text-blue-100 'text-white' {{ }} == loop.index">
+                <p class="mt-2 hidden text-sm lg:block {{ loop.index == selectedIndex ? 'text-white' : 'text-blue-100 group-hover:text-white' }}">
                   {{ feature.description }}
                 </p>
               @endif
@@ -77,7 +77,7 @@ const { backgroundImage = '/images/screenshots/background-features.jpg', screens
 
       <div class="lg:col-span-7">
         @foreach(features as feature)
-          <div class="selectedIndex : != ? '' 'hidden' {{ }} loop.index">
+          <div class="{{ loop.index != selectedIndex ? 'hidden' : '' }}">
             <div class="lg:hidden relative sm:px-6">
               <div class="absolute bottom-[-4.25rem] top-[-6.5rem] sm:inset-x-0 bg-white/10 ring-1 ring-inset ring-white/10 sm:rounded-t-xl -inset-x-4"></div>
               <p class="relative mx-auto max-w-2xl text-base text-white sm:text-center">

--- a/storage/framework/defaults/resources/components/Marketing/SecondaryFeatures.stx
+++ b/storage/framework/defaults/resources/components/Marketing/SecondaryFeatures.stx
@@ -45,12 +45,12 @@ const { features = [, selectedIndex = 0 } = defineProps<SecondaryFeaturesProps>(
       <div class="grid gap-x-8 grid-cols-3 pt-12">
         @foreach(features as feature)
           <div class="relative">
-            <div class="w-9 rounded-lg selectedIndex : ? 'bg-blue-600' 'bg-slate-500' {{ }} == loop.index">
+            <div class="w-9 rounded-lg {{ loop.index == selectedIndex ? 'bg-blue-600' : 'bg-slate-500' }}">
               <svg aria-hidden="true" class="h-9 w-9" fill="none">
                 {{ feature.icon }}
               </svg>
             </div>
-            <h3 class="mt-6 font-medium text-sm selectedIndex : ? 'text-blue-600' 'text-slate-600' {{ }} == loop.index">
+            <h3 class="mt-6 text-sm font-medium {{ loop.index == selectedIndex ? 'text-blue-600' : 'text-slate-600' }}">
               <button data-action="select-feature" data-index="{{ loop.index }}">{{ feature.name }}</button>
             </h3>
             <p class="mt-2 font-display text-slate-900 text-xl">
@@ -66,7 +66,7 @@ const { features = [, selectedIndex = 0 } = defineProps<SecondaryFeaturesProps>(
       <div class="overflow-hidden relative mt-20 px-14 py-16 xl:px-16 bg-slate-200 rounded-4xl">
         <div class="flex -mx-5">
           @foreach(features as feature)
-            <div class="px-5 duration-500 ease-in-out transition selectedIndex : != ? '' 'opacity-60' {{ }} loop.index" style="transform: translateX(-{{ selectedIndex * 100 }}%)">
+            <div class="px-5 transition duration-500 ease-in-out {{ loop.index != selectedIndex ? 'opacity-60' : '' }}" style="transform: translateX(-{{ selectedIndex * 100 }}%)">
               <div class="overflow-hidden w-[52.75rem] bg-white ring-1 ring-slate-500/10 rounded-xl shadow-lg shadow-slate-900/5">
                 <img class="w-full" src="{{ feature.image }}" alt="" sizes="52.75rem">
               </div>


### PR DESCRIPTION
Closes #2209.

## It's 61 attributes across 23 files, not one view

The issue found `blog/category.stx` and noted it may already be gone upstream. It is — but the same corruption is sitting in 23 other files that **are** still shipped.

`storage/framework/defaults/resources/` is live (`frameworkPath('defaults/resources/…')`, `path/src/index.ts:416`) and `buddy new` copies the repo wholesale, so all 61 reached every scaffolded app. One of them is in `resources/components/InputGroup.stx` — this repo's own app code.

## Root cause: `9e06583afc`

`git log -S` pins it to **`9e06583afc` "chore: fix lint errors"** (2026-04-14, 542 files). It ran a Tailwind-style class sorter over `class="..."` that split on whitespace **without respecting `{{ }}` boundaries**, so `{{`, the expression, and `}}` sorted as if they were class names:

```
before  class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 {{ className }}"
after   class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl {{ }} className"
```

The tell is that the classes really are in sort order. stx then throws on the orphaned operators, aborting the build once the route scanner reaches the file.

**Not a live regression.** I verified both `pickier --fix` and `buddy format --write` leave `{{ ternary }}`-in-class intact today. This is committed damage.

## Repaired mechanically, not by rewriting intent

A sort permutes but **preserves the token multiset**, so each mangled value matches exactly one pre-commit value under `tokens.sort()`. **61/61 matched, 0 ambiguous.**

That mattered at this volume — hand-reconstructing 61 ternaries invites fresh bugs, and the nested cases are genuinely unreadable:

```
": : ? ? '' 'bg-blue-100 'bg-gray-100 'ring-2 {{ {{ }} }} <= == currentStep currentStep loop.index loop.index"
```

recovers to two separate expressions in one attribute:

```
"flex items-center justify-center w-8 h-8 rounded-full {{ loop.index <= currentStep ? 'bg-blue-100 text-blue-600' : 'bg-gray-100 text-gray-500' }} {{ loop.index == currentStep ? 'ring-2 ring-blue-600 ring-offset-2' : '' }}"
```

## Deliberately untouched

`ModelRecordsDashboard.stx` has two `{{ }}` hits that are **prose in comments**, explaining that a placeholder in a class attribute is not reactively bound. The repair skips it, and the audit grep excludes it.

## Verification

- 0 mangled attributes remain outside that comment
- 23 repaired files parse clean under `lintStxStrict` (0 parse errors)
- pickier clean

## Follow-up

The issue's second ask — *"audit for other similarly-mangled `{{ … }}`-in-attribute default views"* — is what found these. To stop it recurring, an empty-interpolation-inside-an-attribute check belongs in `buddy lint --stx` (#2208), scoped to attribute values so the comment case above stays legal. I'll add it there rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)