### PR TITLE
security: drop plaintext tenant mail passwords from .env.production

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -13,7 +13,7 @@ APP_URL=https://stacksjs.com
 APP_MAINTENANCE=false
 APP_MAINTENANCE_SECRET=
 APP_COMING_SOON=true
-APP_COMING_SOON_SECRET=trailhead
+APP_COMING_SOON_SECRET=
 SUDO_PASSWORD="encrypted:7PodDMbbrpZyE/zRVVI31YothRVjYugjL78Ap0xSeShYAYzBi3c="
 
 # No PORT here: on the shared box each site's port is set by the deploy
@@ -45,9 +45,11 @@ MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
 MAIL_FROM_NAME="${APP_NAME}"
 MAIL_FROM_ADDRESS="no-reply@stacksjs.org"
-MAIL_PASSWORD_CHRIS=k_qZxzn7gHDf1jLHZMl0-w
-MAIL_PASSWORD_BLAKE=I6PKOS4x24-lq-8R0zAKgw
-MAIL_PASSWORD_GLENN=XX96v2Y_79YajNbSsynujQ
+
+# Per-mailbox SMTP passwords (MAIL_PASSWORD_<LOCALPART>) are tenant credentials
+# and must never be committed here. This file ships to every `buddy new` app, so
+# anything written below is published. Set them in the deploy environment, or
+# encrypt them with dotenvx the way .env.development and .env.staging do.
 
 STRIPE_SECRET_KEY=
 STRIPE_PUBLIC_KEY=


### PR DESCRIPTION
`.env.production` is committed in this public repo and carried four plaintext values:

- `MAIL_PASSWORD_CHRIS`, `MAIL_PASSWORD_BLAKE`, `MAIL_PASSWORD_GLENN` — real per-mailbox SMTP passwords
- `APP_COMING_SOON_SECRET` — the coming-soon bypass token

They were readable at HEAD via the raw contents API. Because this file ships with every `buddy new` scaffold, the same three passwords also reached at least one downstream public repo.

### Scope

Only `.env.production` is affected. `.env.development` and `.env.staging` hold the same keys correctly encrypted with dotenvx — I checked each value in all three files.

The remaining plaintext in `.env.production` is non-secret config (hosts, ports, names, URLs, `DEBUG`, region/profile) or literal placeholders: `MAIL_PASSWORD`, `MAIL_USERNAME` and `MEILISEARCH_KEY` are the strings `null`, `null` and `masterKey`. Left alone.

### What this does and does not do

This stops the values being served at HEAD and stops new apps inheriting them. It does **not** un-publish them — they remain in history here and at HEAD of the downstream repo until that is merged too.

**The three mailbox passwords need rotating at the provider.** That is the fix; this PR is the cleanup.

### Related

`APP_COMING_SOON_SECRET` is blanked rather than deleted since it is a legitimate config key. Worth noting it was never actually an access control in the app that consumed it — the token was emitted to every visitor as a `<body>` data attribute and the gate was pure CSS, so treat its exposure as hygiene rather than a breach.

This repo also has 6 open secret-scanning alerts, all flagged `publicly_leaked`, the oldest from 2023-08-03 — a Mailgun key, a Twilio SID, a Slack webhook, two GitHub PATs and a Stripe test key. Out of scope here, but they are unresolved.