### PR TITLE
fix: docs proxy gating, register session, password-reset enumeration

### DIFF
--- a/storage/framework/core/actions/src/dev/views.ts
+++ b/storage/framework/core/actions/src/dev/views.ts
@@ -146,6 +146,31 @@ async function startDefaultServer() {
   const apiBase = `http://127.0.0.1:${apiPort}`
   const docsBase = `http://127.0.0.1:${docsPort}`
 
+  // Whether `/docs` belongs to the docs dev server at all
+  // (stacksjs/stacks#2213).
+  //
+  // The proxy used to be unconditional and sat ahead of page routing, so an app
+  // with its own `resources/views/docs.stx` could never serve it in dev, and an
+  // app with no docs site at all got a proxy to a dead port instead of a 404.
+  // Worse, `buddy serve` has no `/docs` branch — it just resolves the page
+  // route — so dev and production disagreed about what `/docs` is. The page
+  // that shipped was the one nobody could review locally.
+  //
+  // Resolved once here rather than per request: both checks are filesystem
+  // stats, and the answer cannot change without a restart anyway.
+  //
+  // A userland page wins outright. Otherwise the proxy runs only when a docs
+  // site actually exists, and when neither is true `/docs` falls through to
+  // normal routing, which turns the dead-port case into an ordinary 404.
+  //
+  // A plain existence check, not `firstExistingPath` — that helper prefers the
+  // candidate containing templates, which is meaningless for a docs site made
+  // of markdown and for a single `.stx` file.
+  const hasUserDocsView = ['docs.stx', 'docs/index.stx']
+    .some(rel => existsSync(projectPath(`${userViewsPath}/${rel}`)))
+  const hasDocsSite = existsSync(projectPath('docs'))
+  const docsProxyEnabled = !hasUserDocsView && hasDocsSite
+
   // Cookie name the SPA writes when a user logs in. Defaults to whatever
   // `config.auth.defaultTokenName` is set to, falling back to `auth-token`.
   const authCookie = (config as any)?.auth?.defaultTokenName ?? 'auth-token'
@@ -214,7 +239,7 @@ async function startDefaultServer() {
       //      a static stx page, so they always belong to bun-router.
       // Without (2), `route.post('/subscribe', ...)` declared at the
       // root (no /api prefix) hits stx-serve and 404s.
-      if (url.pathname === '/docs' || url.pathname.startsWith('/docs/'))
+      if (docsProxyEnabled && (url.pathname === '/docs' || url.pathname.startsWith('/docs/')))
         return proxyToBackend(req, docsBase, '/docs')
 
       if (isApiBoundRequest(req, url.pathname))

--- a/storage/framework/core/auth/src/register.ts
+++ b/storage/framework/core/auth/src/register.ts
@@ -28,7 +28,35 @@ function duplicateEmailError(): HttpError {
 // which `validator.isEmail()` would have to special-case anyway.
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-export async function register(credentials: NewUser): Promise<{ token: AuthToken }> {
+/**
+ * What a successful registration hands back: a complete session, matching
+ * `Auth.loginUsingId()`.
+ *
+ * Named rather than inlined on the signature so consumers can type the result,
+ * and because pickier's unused-parameter analysis mis-reads a multi-line return
+ * annotation and flags `credentials` as unused.
+ */
+export interface RegistrationResult {
+  token: AuthToken
+  refreshToken?: string
+  expiresIn?: number
+}
+
+/**
+ * Register a user and open a full session for them.
+ *
+ * Returns the same triple `Auth.loginUsingId()` does. It used to return only
+ * the access token, because it called `Auth.createToken()` — a wrapper that
+ * mints a refresh token and an expiry and then throws both away. With
+ * `config.auth.tokenExpiry` defaulting to one hour, that made every freshly
+ * registered account unable to refresh: a client that correctly stores the pair
+ * and exchanges it at `/auth/refresh` worked for everyone except the user who
+ * had just signed up, who was logged out an hour into their first session
+ * (stacksjs/stacks#2212).
+ *
+ * Additive, so `const { token } = await register(...)` is unaffected.
+ */
+export async function register(credentials: NewUser): Promise<RegistrationResult> {
   const { email, password, name } = credentials
 
   // Cheap structural validation before we hit the DB. Bad-email registration
@@ -102,6 +130,11 @@ export async function register(credentials: NewUser): Promise<{ token: AuthToken
   if (!user)
     throw new Error('Failed to retrieve created user')
 
-  // Create and return the authentication token
-  return { token: await Auth.createToken(user, 'user-auth-token') }
+  // `createTokenForUser`, not `createToken` — the latter drops the refresh
+  // token and expiry on the floor. Same token name as before.
+  const { plainTextToken, refreshToken, expiresIn } = await Auth.createTokenForUser(user, {
+    name: 'user-auth-token',
+  })
+
+  return { token: plainTextToken, refreshToken, expiresIn }
 }

--- a/storage/framework/core/auth/tests/register.test.ts
+++ b/storage/framework/core/auth/tests/register.test.ts
@@ -138,7 +138,15 @@ mock.module('@stacksjs/orm', () => ({
 
 mock.module('../src/authentication', () => ({
   Auth: {
-    createToken: async () => 'tok_test',
+    // `createTokenForUser`, not `createToken`. Registration has to mint the
+    // whole session — `createToken` is a wrapper that discards the refresh
+    // token and expiry, which left every new account unable to refresh
+    // (stacksjs/stacks#2212).
+    createTokenForUser: async () => ({
+      plainTextToken: 'tok_test',
+      refreshToken: 'refresh_test',
+      expiresIn: 3600,
+    }),
   },
 }))
 
@@ -179,7 +187,14 @@ describe('register() transactional create (#1953)', () => {
   test('fresh email → token, hashed password inserted inside the trx, fetch by id', async () => {
     const result = await register({ email: 'fresh@example.com', password: 'long-enough-pw', name: 'Fresh' } as any)
 
-    expect(result).toEqual({ token: 'tok_test' as any })
+    // The full session, not just the access token — a registration that hands
+    // back no refresh token strands the account at `tokenExpiry` (one hour by
+    // default) with no way to renew (stacksjs/stacks#2212).
+    expect(result).toEqual({
+      token: 'tok_test' as any,
+      refreshToken: 'refresh_test',
+      expiresIn: 3600,
+    })
     expect(transactionCalled).toBe(true)
     expect(insertRanOnTrx).toBe(true)
     // Never the plaintext.

--- a/storage/framework/defaults/app/Actions/Auth/RegisterAction.ts
+++ b/storage/framework/defaults/app/Actions/Auth/RegisterAction.ts
@@ -46,7 +46,17 @@ export default new Action({
         to: user?.email,
       })
 
+      // Same OAuth2-compatible payload LoginAction returns, so a client can
+      // code against one shape. Registering used to hand back only `token`,
+      // which left brand-new accounts with no refresh token to exchange — they
+      // were signed out an hour into their first session while every other
+      // user refreshed normally (stacksjs/stacks#2212). The legacy `token`
+      // alias stays for backward compatibility.
       return response.json({
+        access_token: result.token,
+        refresh_token: result.refreshToken,
+        token_type: 'Bearer',
+        expires_in: result.expiresIn,
         token: result.token,
         user: {
           id: user?.id,

--- a/storage/framework/defaults/app/Actions/Password/SendPasswordResetEmailAction.ts
+++ b/storage/framework/defaults/app/Actions/Password/SendPasswordResetEmailAction.ts
@@ -1,9 +1,20 @@
 import { Action } from '@stacksjs/actions'
 import { RateLimiter } from '@stacksjs/auth'
+import { log } from '@stacksjs/logging'
 import { User } from '@stacksjs/orm'
 import { job } from '@stacksjs/queue'
 import { response } from '@stacksjs/router'
 import { schema } from '@stacksjs/validation'
+
+/**
+ * The one thing this endpoint ever says.
+ *
+ * Held in a constant because the security property is that EVERY path returns
+ * it byte for byte — unknown address, known address, and a mail dispatch that
+ * blew up. The moment one branch returns something else, the endpoint becomes
+ * an account-existence oracle again (stacksjs/stacks#2214).
+ */
+const NEUTRAL_RESPONSE = 'If an account exists for that email address, a password reset link has been sent.'
 
 export default new Action({
   name: 'SendPasswordResetEmailAction',
@@ -15,52 +26,45 @@ export default new Action({
     },
   },
   async handle(request) {
-    console.log('[Action] SendPasswordResetEmailAction.handle() called')
-
     const email = request.get('email')
-    console.log('[Action] Email from request:', email)
 
-    if (!email) {
-      console.log('[Action] No email provided, returning 422')
+    if (!email)
       return response.error('Email is required', 422)
-    }
 
-    // Rate limit password reset requests by email
+    // Rate limiting is per-email, so it does not slow enumeration ACROSS
+    // addresses at all — the shape of the attack this endpoint invites. It
+    // stays because it still limits hammering one mailbox, but it is not the
+    // control that protects existence; the uniform response below is.
     const rateLimitKey = `password_reset:${email.toLowerCase()}`
-    if (await RateLimiter.isRateLimited(rateLimitKey)) {
-      console.log('[Action] Rate limited for:', rateLimitKey)
+    if (await RateLimiter.isRateLimited(rateLimitKey))
       return response.error('Too many password reset attempts. Please try again later.', 429)
-    }
 
-    // Record the attempt
     await RateLimiter.recordFailedAttempt(rateLimitKey)
-    console.log('[Action] Recorded rate limit attempt')
 
-    // Check if user exists
-    console.log('[Action] Looking up user by email...')
     const user = await User.where('email', email).first()
 
-    if (!user) {
-      console.log('[Action] User not found for email:', email)
-      return response.error('No account found with this email address.', 404)
+    // No early return for a missing user. It used to answer
+    // `404 "No account found with this email address."`, which let anyone test
+    // an arbitrary list of addresses for membership against an unauthenticated
+    // endpoint. The sibling `PasswordResetAction` already refuses to leak the
+    // same fact, so this was an inconsistency between two files in one
+    // directory rather than a disagreement about the threat.
+    if (user) {
+      try {
+        await job('SendPasswordResetEmailJob', { email })
+          .onQueue('emails')
+          .dispatch()
+      }
+      catch (error) {
+        // Swallowed DELIBERATELY, and this is the subtle half. Returning a 500
+        // here would reintroduce the oracle whenever the mailer is degraded:
+        // an unknown address never reaches dispatch, so it can never 5xx, and
+        // "neutral message vs. send failure" becomes the tell. The operator
+        // gets the failure in the logs; the caller gets what everyone gets.
+        log.error('[password-reset] failed to dispatch reset email', error)
+      }
     }
-    console.log('[Action] User found:', user.id)
 
-    // Dispatch password reset email job to queue (with 10 second delay)
-    console.log('[Action] About to dispatch SendPasswordResetEmailJob with 10s delay...')
-    try {
-      await job('SendPasswordResetEmailJob', { email })
-        .onQueue('emails')
-        .dispatch()
-      console.log('[Action] Job dispatched successfully with 10s delay!')
-    }
-    catch (error) {
-      console.error('[Action] Failed to dispatch email job for', email)
-      console.error('[Action] Error:', error)
-      return response.error('Failed to send password reset email. Please try again later.', 500)
-    }
-
-    console.log('[Action] Returning success response')
-    return response.success('Password reset link has been sent to your email.')
+    return response.success(NEUTRAL_RESPONSE)
   },
 })


### PR DESCRIPTION
Closes #2213, #2212, #2214. Three independent fixes, one branch — each is a few lines and they touch disjoint files.

---

## #2213 — `/docs` proxy was unconditional

`dev/views.ts` proxied `/docs` ahead of page routing with no existence check, so an app with its own `resources/views/docs.stx` could never serve it, and an app with no docs site got a proxy to a dead port instead of a 404.

The costly part is that `buddy serve` has no `/docs` branch at all — it just resolves the page route. **Dev and production disagreed about what `/docs` is**, so the page that ships was the one nobody could review locally.

Now: a userland page wins outright; the proxy runs only when a `docs/` site exists; otherwise `/docs` falls through to normal routing, which turns the dead-port case into an ordinary 404. Resolved once at startup — both checks are filesystem stats and the answer can't change without a restart.

Verified all five combinations (docs site only, `docs.stx` only, `docs/index.stx` only, both, neither) — 5/5.

---

## #2212 — registration minted a session and discarded half of it

`register()` called `Auth.createToken()`, a **wrapper that mints a refresh token and expiry and throws both away**. So the action had nothing but an access token to return.

The issue reasoned that both endpoints call `loginUsingId()` — they don't; `register()` never did. The root is one layer lower, which is where this fixes it: `register()` now uses `createTokenForUser` and returns the same triple `loginUsingId()` does. Additive, so `const { token } = await register(...)` is unaffected.

With `tokenExpiry` defaulting to one hour, a client that correctly stores the pair worked for everyone *except* the user who had just signed up.

---

## #2214 — password reset was an account-existence oracle

`404 "No account found with this email address."` vs `200`, unauthenticated, with rate limiting keyed **per-email** — so it doesn't slow enumeration across addresses at all.

**Three things had to change, not one:**

1. the 404 becomes the neutral 200
2. a failed job dispatch **also** returns the neutral 200 — this is the trap the issue flagged. Returning 500 rebuilds the oracle whenever the mailer is degraded, since an unknown address never reaches dispatch and so can never 5xx
3. the `console.log` trail is gone — it echoed the submitted address at four points, putting user emails into framework-default logs

The message lives in one constant because the property is that every branch returns it byte for byte.

**Not addressed:** a known address does strictly more work (a queue dispatch), so a timing signal remains. That needs its own change, and it's a far weaker oracle than a 404 with an explanatory message.

---

## Verification

- auth: **258 pass, 0 fail**. One test legitimately needed updating — it mocked `Auth` with only `createToken`, and asserted `{ token }` alone; both now reflect the full session.
- pickier clean, framework + app typecheck clean.

One incidental finding: pickier's `no-unused-vars` mis-reads a multi-line return-type annotation and flagged the still-used `credentials` parameter. Worked around by naming the type (`RegistrationResult`), which is better anyway, but it's a real false positive worth a separate report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)