### PR TITLE
fix(database): stop merging framework demo models into every app's schema

### DIFF
--- a/config/database.ts
+++ b/config/database.ts
@@ -98,6 +98,25 @@ export default {
   migrationLocks: 'migration_locks',
 
   /**
+   * **Model Discovery**
+   *
+   * Which model definitions the migration generator treats as yours.
+   */
+  models: {
+    /**
+     * Generate migrations for the framework's own models in
+     * `storage/framework/defaults/app/Models` on top of your `app/Models`.
+     *
+     * Leave this off unless your app uses built-in models without publishing
+     * them; the defaults already stand in on their own when `app/Models` is
+     * empty. `./buddy publish model <Name>` copies a single one into your app.
+     *
+     * Override for one run with `STACKS_INCLUDE_FRAMEWORK_MODELS=1`.
+     */
+    includeFrameworkDefaults: false,
+  },
+
+  /**
    * **Read Routing**
    *
    * How reads are distributed across the replicas declared on the active

--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -194,12 +194,67 @@ function configureQueryBuilder(
   resetConnection()
 }
 
-export function prepareMigrationModelsDir(): { modelsDir: string, skip: boolean } {
+export function prepareMigrationModelsDir(): { modelsDir: string, skip: boolean, excludedTables: string[] } {
   const sources = resolveModelSources()
   return {
     modelsDir: sources?.dir ?? path.userModelsPath(),
     skip: !sources,
+    excludedTables: sources?.excludedTables ?? [],
   }
+}
+
+const DROP_TABLE_RE = /^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?["'`]?(\w+)["'`]?/i
+
+/**
+ * Drop the generated `DROP TABLE`s for framework defaults that are simply out
+ * of scope, rather than deleted.
+ *
+ * The generator diffs the model set against the stored snapshot, so the first
+ * run after framework defaults stop being merged (stacksjs/stacks#2220) sees
+ * sixty-odd tables vanish from the model set and proposes dropping every one
+ * of them — including any that hold data. "This app no longer generates this
+ * table" is not "destroy this table"; the same distinction
+ * `withoutManagedColumnDropSql` draws for framework-managed columns.
+ *
+ * Self-limiting: the snapshot advances to the narrowed model set at the end of
+ * the same run, so the drops are never proposed again. A table an app really
+ * does want gone is still dropped by hand, the way it always was.
+ */
+export function withoutExcludedTableDropSql(
+  statements: string[],
+  excludedTables: readonly string[],
+  operations: readonly MigrationOperation[],
+): { statements: string[], removed: string[] } {
+  if (excludedTables.length === 0)
+    return { statements, removed: [] }
+
+  const excluded = new Set(excludedTables.map(table => table.toLowerCase()))
+  const normalize = (sql: string): string => sql.replace(/\s+/g, ' ').trim().replace(/;$/, '')
+  const dropped = new Set(
+    operations
+      .filter(op => op.kind === 'drop_table' && excluded.has(op.table.toLowerCase()))
+      .filter(op => Boolean(op.sql))
+      .map(op => normalize(op.sql)),
+  )
+
+  const removed: string[] = []
+  const kept = statements.filter((statement) => {
+    if (dropped.has(normalize(statement))) {
+      removed.push(statement)
+      return false
+    }
+    // Fallback for a dialect whose emitted statement doesn't match the
+    // operation's `sql` byte for byte (Postgres appends CASCADE, MySQL uses
+    // backticks). The shape is simple enough to match directly.
+    const match = statement.match(DROP_TABLE_RE)
+    if (match?.[1] && excluded.has(match[1].toLowerCase())) {
+      removed.push(statement)
+      return false
+    }
+    return true
+  })
+
+  return { statements: kept, removed }
 }
 
 /**
@@ -1614,7 +1669,7 @@ export async function previewPendingMigrations(options: GenerateMigrationsOption
   try {
     configureQueryBuilder()
     const dialect = getDialect()
-    const { modelsDir, skip } = prepareMigrationModelsDir()
+    const { modelsDir, skip, excludedTables } = prepareMigrationModelsDir()
     if (skip)
       return []
     const { applyRenames, fromDb } = resolveGenerateOptions(options)
@@ -1626,7 +1681,17 @@ export async function previewPendingMigrations(options: GenerateMigrationsOption
       applyRenames,
       fromDb,
     })
-    const operations = result.operations ?? []
+    let operations = result.operations ?? []
+    // Out-of-scope framework defaults are never dropped (see
+    // `withoutExcludedTableDropSql`), so they must not appear in the
+    // confirmation gate either — sixty phantom drops would train the user to
+    // approve a prompt that is, on any other run, worth reading.
+    if (excludedTables.length > 0) {
+      const excluded = new Set(excludedTables.map(table => table.toLowerCase()))
+      operations = operations.filter(
+        (op: MigrationOperation) => !(op.kind === 'drop_table' && excluded.has(op.table.toLowerCase())),
+      )
+    }
     // Framework-managed columns (trait ALTERs, not model `attributes`) are not
     // real strays — don't surface them as destructive drops in the confirmation
     // gate, or migrate never shows "nothing to migrate" (stacksjs/stacks#2075).
@@ -1812,7 +1877,7 @@ export async function generateMigrations(options: GenerateMigrationsOptions = {}
     }
     const storedPlan = readStoredMigrationPlan(getQbDialect())
 
-    const { modelsDir, skip } = prepareMigrationModelsDir()
+    const { modelsDir, skip, excludedTables } = prepareMigrationModelsDir()
     if (skip) {
       log.debug('No app/Models directory found; using committed framework migrations')
       return ok('Migrations generated')
@@ -1820,6 +1885,14 @@ export async function generateMigrations(options: GenerateMigrationsOptions = {}
 
     const { applyRenames, fromDb } = resolveGenerateOptions(options)
     log.debug(`[migration] Generating migrations for dialect: ${dialect}, models: ${modelsDir}`)
+    // The first question asked when an expected table doesn't generate. Cheap
+    // to leave in, and it names the flag that answers it.
+    if (excludedTables.length > 0) {
+      log.debug(
+        `[migration] ${excludedTables.length} framework default model(s) out of scope because app/Models defines this app's schema. `
+        + `Enable database.models.includeFrameworkDefaults (or STACKS_INCLUDE_FRAMEWORK_MODELS=1) to generate them too.`,
+      )
+    }
     // dryRun: true — bun-query-builder's own file writer numbers migrations
     // from its own internal counter (1, 2, 3, ...), unaware of any already-
     // committed migration files. On a project with existing migrations that
@@ -1849,6 +1922,22 @@ export async function generateMigrations(options: GenerateMigrationsOptions = {}
       const filtered = withoutManagedColumnDropSql(sqlStatements, await frameworkManagedColumns(), result.operations ?? [])
       if (filtered.removed.length > 0)
         log.debug(`[migration] Skipped ${filtered.removed.length} generated drop(s) of framework-managed column(s) (stacksjs/stacks#2075)`)
+      sqlStatements = filtered.statements
+    }
+
+    // Same idea one level up: framework defaults that are out of scope because
+    // this app has its own models must not be read as tables the app deleted.
+    // Said out loud rather than at debug — an app upgrading into #2220's fix
+    // sees its table count fall by sixty, and should know why nothing dropped.
+    if (result.hasChanges && sqlStatements.length > 0 && excludedTables.length > 0) {
+      const filtered = withoutExcludedTableDropSql(sqlStatements, excludedTables, result.operations ?? [])
+      if (filtered.removed.length > 0) {
+        log.info(
+          `[migration] Left ${filtered.removed.length} framework-default table(s) in place rather than dropping them. `
+          + `They are no longer generated because app/Models defines this app's schema; the tables and their data are untouched. `
+          + `Set database.models.includeFrameworkDefaults to keep generating them (stacksjs/stacks#2220).`,
+        )
+      }
       sqlStatements = filtered.statements
     }
 

--- a/storage/framework/core/database/src/model-sources.ts
+++ b/storage/framework/core/database/src/model-sources.ts
@@ -253,22 +253,27 @@ export function resolveModelSources(options: {
   const contributing = useFramework ? framework : []
   const excluded = useFramework ? [] : framework
 
+  // Shadowing is detected against EVERY framework default, not just the ones
+  // contributing models. The hazard it exists to report - a userland model
+  // taking over a framework table's name while the framework's own code goes on
+  // reading that table - does not depend on whether the default is in the
+  // generator's scope. If anything it is sharper once defaults are excluded,
+  // because then nothing else describes the table at all.
+  const frameworkByName = new Map<string, ModelSource>()
+  for (const model of framework) frameworkByName.set(model.name, model)
+
+  const shadowed: ShadowedModel[] = []
+  for (const model of user) {
+    const replaced = frameworkByName.get(model.name)
+    if (replaced)
+      shadowed.push({ name: model.name, userFile: model.file, frameworkFile: replaced.file })
+  }
+
   // Userland still overrides a framework model of the same name, which is what
   // the merge path is for.
   const byName = new Map<string, ModelSource>()
   for (const model of contributing) byName.set(model.name, model)
-
-  // Shadowing is only reachable on the merge path: `contributing` is empty when
-  // the defaults are out of scope, so nothing framework-owned is in the map for
-  // a userland model to replace, and the loop records nothing.
-  const shadowed: ShadowedModel[] = []
-  for (const model of user) {
-    const replaced = byName.get(model.name)
-    if (replaced?.origin === 'framework')
-      shadowed.push({ name: model.name, userFile: model.file, frameworkFile: replaced.file })
-
-    byName.set(model.name, model)
-  }
+  for (const model of user) byName.set(model.name, model)
 
   const models = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
 

--- a/storage/framework/core/database/src/model-sources.ts
+++ b/storage/framework/core/database/src/model-sources.ts
@@ -1,7 +1,7 @@
 /**
  * Resolve the model definitions the migration generator should read.
  *
- * Two problems this exists to solve.
+ * Three problems this exists to solve.
  *
  * 1. The generator only ever looked at `app/Models`. A vendored framework
  *    checkout (and every freshly scaffolded project) has no such directory, so
@@ -19,14 +19,26 @@
  *    dropped print_devices, payments and orders, which is far worse than the
  *    failure it was meant to fix.
  *
- * So models from both roots are collected recursively and staged into one flat
- * directory that bqb can read completely. Userland wins on a name collision, so
- * an app can still override a framework model.
+ * 3. Fixing (1) by MERGING the two roots made every app inherit the framework's
+ *    demo schema. Userland only overrode by name, so an app with five models
+ *    migrated its five plus the framework's sixty-two — `carts`, `coupons`,
+ *    `drivers`, `waitlist_restaurants` and the rest — and ended up with 88
+ *    tables and a migrations table whose rows mostly had no file in the repo
+ *    (stacksjs/stacks#2220). The intent in (1) was a FALLBACK for the root with
+ *    no models of its own; a merge is not that. Defaults now apply only when
+ *    userland contributes nothing, which is exactly the vendored-checkout and
+ *    fresh-scaffold case they were added for.
+ *
+ * Models are collected recursively and staged into one flat directory that bqb
+ * can read completely.
  */
 
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
+import process from 'node:process'
+import { config } from '@stacksjs/config'
 import { path } from '@stacksjs/path'
+import { plural, snakeCase } from '@stacksjs/strings'
 
 export interface ModelSource {
   /** Absolute path to the model file. */
@@ -60,8 +72,23 @@ export interface ResolvedModelSources {
    * generates a migration dropping that table's columns - while the framework's
    * own code goes on reading them. Reported here so the migration generator can
    * recognise that case; see `shadowed-models.ts`.
+   *
+   * Only ever populated on the opt-in merge path below: with the defaults out
+   * of scope entirely there is nothing left for a userland model to shadow.
    */
   shadowed: ShadowedModel[]
+  /**
+   * Framework defaults left OUT because userland has its own models.
+   *
+   * Empty in the two cases that matter most: an app that opted back into the
+   * union, and a vendored checkout with no `app/Models` (where the defaults
+   * ARE the model set). Callers use it to explain the narrowing, and the
+   * migration generator uses {@link excludedTables} to keep the first run
+   * after the narrowing from proposing a drop of every table that left scope.
+   */
+  excluded: ModelSource[]
+  /** Table names owned by {@link excluded}, lowercased. */
+  excludedTables: string[]
 }
 
 /** Collect model files recursively, skipping index barrels and dotfiles. */
@@ -144,13 +171,70 @@ function stage(models: ModelSource[]): string {
 }
 
 /**
- * Resolve models from userland and framework defaults.
+ * The table a model file declares, matching how the generator derives it:
+ * an explicit `table:` wins, otherwise the pluralised snake_case model name.
+ *
+ * Read with a regex rather than by importing the model. This runs for every
+ * excluded default on every generate, and importing 62 modules (each pulling
+ * in `@stacksjs/orm` and `@stacksjs/validation`) to learn a string the file
+ * states literally is not worth the boot. A model that computes its table name
+ * at runtime is not matched, which costs only the drop suppression below —
+ * the table still generates normally.
+ */
+export function declaredTableName(source: ModelSource): string {
+  let contents = ''
+  try {
+    contents = readFileSync(source.file, 'utf8')
+  }
+  catch { /* unreadable; fall through to the name-derived default */ }
+
+  const declared = contents.match(/^\s*table:\s*['"`]([^'"`]+)['"`]/m)
+  if (declared?.[1])
+    return declared[1].toLowerCase()
+
+  const named = contents.match(/^\s*name:\s*['"`]([^'"`]+)['"`]/m)
+  return plural(snakeCase(named?.[1] ?? source.name)).toLowerCase()
+}
+
+/**
+ * Whether the framework's own models should be merged in ALONGSIDE userland's,
+ * rather than only standing in when userland has none.
+ *
+ * Off by default (stacksjs/stacks#2220). An app that genuinely wants the union
+ * — one that uses the built-in `User`, `Team` or commerce models without
+ * publishing them into `app/Models` — turns it back on rather than living with
+ * a schema it never asked for. `buddy publish model <Name>` is the other way
+ * out, and the one that keeps the app's schema self-describing.
+ *
+ * The env var wins over config so a one-off generate can flip it without an
+ * edit, matching `STACKS_MIGRATE_NO_RENAME` / `STACKS_MIGRATE_FROM_DB`.
+ */
+function shouldIncludeFrameworkDefaults(): boolean {
+  const flag = process.env.STACKS_INCLUDE_FRAMEWORK_MODELS
+  if (flag === '1' || flag === 'true')
+    return true
+  if (flag === '0' || flag === 'false')
+    return false
+
+  // Optional-chained rather than trusted: the generator also runs in contexts
+  // (tests, programmatic migrations) where the config graph is only partly
+  // booted. A miss degrades to the default, which is the conservative answer.
+  return (config as any)?.database?.models?.includeFrameworkDefaults === true
+}
+
+/**
+ * Resolve models from userland, falling back to the framework defaults.
  *
  * Returns `null` when neither root holds a model, which callers should treat as
  * "nothing to generate from" rather than as an error: it is the legitimate
  * state of a project that has not defined any models yet.
  */
-export function resolveModelSources(options: { userRoot?: string, frameworkRoot?: string } = {}): ResolvedModelSources | null {
+export function resolveModelSources(options: {
+  userRoot?: string
+  frameworkRoot?: string
+  /** Force the merge on or off, bypassing config and env. */
+  includeFrameworkDefaults?: boolean
+} = {}): ResolvedModelSources | null {
   const userRoot = options.userRoot ?? path.userModelsPath()
   const frameworkRoot = options.frameworkRoot ?? path.frameworkPath('defaults/app/Models')
 
@@ -160,10 +244,23 @@ export function resolveModelSources(options: { userRoot?: string, frameworkRoot?
   if (user.length === 0 && framework.length === 0)
     return null
 
-  // Userland overrides a framework model of the same name.
-  const byName = new Map<string, ModelSource>()
-  for (const model of framework) byName.set(model.name, model)
+  const merge = options.includeFrameworkDefaults ?? shouldIncludeFrameworkDefaults()
 
+  // Defaults are a fallback: they stand in only when userland has no models of
+  // its own. Merging them made every app inherit the framework's demo schema
+  // (stacksjs/stacks#2220).
+  const useFramework = merge || user.length === 0
+  const contributing = useFramework ? framework : []
+  const excluded = useFramework ? [] : framework
+
+  // Userland still overrides a framework model of the same name, which is what
+  // the merge path is for.
+  const byName = new Map<string, ModelSource>()
+  for (const model of contributing) byName.set(model.name, model)
+
+  // Shadowing is only reachable on the merge path: `contributing` is empty when
+  // the defaults are out of scope, so nothing framework-owned is in the map for
+  // a userland model to replace, and the loop records nothing.
   const shadowed: ShadowedModel[] = []
   for (const model of user) {
     const replaced = byName.get(model.name)
@@ -178,18 +275,20 @@ export function resolveModelSources(options: { userRoot?: string, frameworkRoot?
   const roots: string[] = []
   if (user.length > 0)
     roots.push(userRoot)
-  if (framework.length > 0)
+  if (contributing.length > 0)
     roots.push(frameworkRoot)
+
+  const excludedTables = [...new Set(excluded.map(declaredTableName))].sort()
 
   // Fast path: a single root whose models are all top level needs no staging,
   // so the common userland-only project keeps reading its own directory.
-  const onlyUser = framework.length === 0
+  const onlyUser = contributing.length === 0
   const allFlat = models.every(m => basename(join(m.file, '..')) === basename(onlyUser ? userRoot : frameworkRoot))
   if (roots.length === 1 && allFlat) {
-    return { dir: roots[0]!, models, roots, staged: false, shadowed }
+    return { dir: roots[0]!, models, roots, staged: false, shadowed, excluded, excludedTables }
   }
 
-  return { dir: stage(models), models, roots, staged: true, shadowed }
+  return { dir: stage(models), models, roots, staged: true, shadowed, excluded, excludedTables }
 }
 
 /** Remove the staging directory. Safe to call when it was never created. */

--- a/storage/framework/core/database/tests/model-sources.test.ts
+++ b/storage/framework/core/database/tests/model-sources.test.ts
@@ -16,7 +16,7 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { prepareMigrationModelsDir } from '../src/migrations'
+import { prepareMigrationModelsDir, withoutExcludedTableDropSql } from '../src/migrations'
 import { cleanupModelStaging, resolveModelSources } from '../src/model-sources'
 
 const TMP = join(import.meta.dir, '.tmp-model-sources')
@@ -65,7 +65,9 @@ describe('resolveModelSources', () => {
     expect(staged).toEqual(['PrintDevice.ts', 'User.ts'])
   })
 
-  it('lets a userland model override a framework model of the same name', () => {
+  it('uses ONLY userland models once userland has any', () => {
+    // stacksjs/stacks#2220. Merging the two roots gave a five-model app the
+    // framework's whole demo schema — 88 tables for an app that needed 9.
     const user = join(TMP, 'user')
     const framework = join(TMP, 'framework')
     makeModel(user, 'User')
@@ -73,10 +75,71 @@ describe('resolveModelSources', () => {
     makeModel(framework, 'Post')
 
     const resolved = resolveModelSources({ userRoot: user, frameworkRoot: framework })!
-    const userModel = resolved.models.find(m => m.name === 'User')!
 
-    expect(userModel.origin).toBe('user')
-    expect(resolved.models).toHaveLength(2)
+    expect(resolved.models.map(m => m.name)).toEqual(['User'])
+    expect(resolved.models[0]!.origin).toBe('user')
+    expect(resolved.roots).toEqual([user])
+  })
+
+  it('reports the framework defaults it left out, and the tables they own', () => {
+    const user = join(TMP, 'user')
+    const framework = join(TMP, 'framework')
+    makeModel(user, 'Project')
+    makeModel(framework, 'Cart')
+    makeModel(join(framework, 'commerce'), 'PrintDevice')
+
+    const resolved = resolveModelSources({ userRoot: user, frameworkRoot: framework })!
+
+    expect(resolved.excluded.map(m => m.name).sort()).toEqual(['Cart', 'PrintDevice'])
+    // Derived exactly as the generator derives them, so the drop suppression
+    // in `withoutExcludedTableDropSql` can match what bqb emits.
+    expect(resolved.excludedTables).toEqual(['carts', 'print_devices'])
+  })
+
+  it('prefers a model file\'s explicit `table` over the pluralised name', () => {
+    const user = join(TMP, 'user')
+    const framework = join(TMP, 'framework')
+    makeModel(user, 'Project')
+    mkdirSync(framework, { recursive: true })
+    writeFileSync(
+      join(framework, 'Person.ts'),
+      `export default {\n  name: 'Person',\n  table: 'people',\n}\n`,
+    )
+
+    const resolved = resolveModelSources({ userRoot: user, frameworkRoot: framework })!
+    expect(resolved.excludedTables).toEqual(['people'])
+  })
+
+  it('still merges the defaults in when the app opts back in', () => {
+    const user = join(TMP, 'user')
+    const framework = join(TMP, 'framework')
+    makeModel(user, 'User')
+    makeModel(framework, 'User')
+    makeModel(framework, 'Post')
+
+    const resolved = resolveModelSources({
+      userRoot: user,
+      frameworkRoot: framework,
+      includeFrameworkDefaults: true,
+    })!
+
+    expect(resolved.models.map(m => m.name).sort()).toEqual(['Post', 'User'])
+    // Userland still wins the name collision — that is what the merge is for.
+    expect(resolved.models.find(m => m.name === 'User')!.origin).toBe('user')
+    expect(resolved.excluded).toEqual([])
+  })
+
+  it('falls back to the framework defaults when userland has no models', () => {
+    // The vendored checkout / fresh scaffold case the fallback exists for.
+    const framework = join(TMP, 'framework')
+    makeModel(framework, 'User')
+    makeModel(framework, 'Post')
+
+    const resolved = resolveModelSources({ userRoot: join(TMP, 'none'), frameworkRoot: framework })!
+
+    expect(resolved.models.map(m => m.name).sort()).toEqual(['Post', 'User'])
+    expect(resolved.excluded).toEqual([])
+    expect(resolved.excludedTables).toEqual([])
   })
 
   it('skips index barrels and dotfiles', () => {
@@ -101,6 +164,59 @@ describe('resolveModelSources', () => {
     const second = resolveModelSources({ userRoot: join(TMP, 'none'), frameworkRoot: framework })!
 
     expect(readdirSync(second.dir).some(f => f === 'Ghost.ts')).toBe(false)
+  })
+})
+
+describe('withoutExcludedTableDropSql', () => {
+  // The narrowing in #2220 removes ~62 tables from the model set at once. The
+  // generator diffs against the stored snapshot, so without this the very
+  // first `generate:migrations` after upgrading proposes dropping all of them.
+  const op = (table: string, sql: string) => ({
+    kind: 'drop_table' as const,
+    table,
+    destructive: true,
+    sql,
+  })
+
+  it('drops the DROP for an out-of-scope framework table', () => {
+    const statements = [`DROP TABLE "carts"`, `CREATE TABLE "projects" (id INTEGER)`]
+    const result = withoutExcludedTableDropSql(statements, ['carts'], [op('carts', `DROP TABLE "carts"`)])
+
+    expect(result.statements).toEqual([`CREATE TABLE "projects" (id INTEGER)`])
+    expect(result.removed).toEqual([`DROP TABLE "carts"`])
+  })
+
+  it('leaves a drop of a table the app actually owns alone', () => {
+    // A model the user deleted must still generate its drop.
+    const statements = [`DROP TABLE "old_projects"`]
+    const result = withoutExcludedTableDropSql(statements, ['carts'], [op('old_projects', `DROP TABLE "old_projects"`)])
+
+    expect(result.statements).toEqual(statements)
+    expect(result.removed).toEqual([])
+  })
+
+  it('matches across dialect spellings of the same drop', () => {
+    // Postgres appends CASCADE and MySQL uses backticks, so the operation's
+    // `sql` is not always byte-identical to the emitted statement.
+    const statements = [`DROP TABLE IF EXISTS \`coupons\``, `DROP TABLE IF EXISTS "carts" CASCADE`]
+    const result = withoutExcludedTableDropSql(statements, ['coupons', 'carts'], [])
+
+    expect(result.statements).toEqual([])
+    expect(result.removed).toHaveLength(2)
+  })
+
+  it('is a no-op when nothing was excluded', () => {
+    const statements = [`DROP TABLE "carts"`]
+    expect(withoutExcludedTableDropSql(statements, [], [op('carts', `DROP TABLE "carts"`)]).statements)
+      .toEqual(statements)
+  })
+
+  it('does not touch a DELETE or an ALTER that merely names an excluded table', () => {
+    const statements = [
+      `ALTER TABLE "carts" ADD COLUMN note VARCHAR(255)`,
+      `DELETE FROM "carts"`,
+    ]
+    expect(withoutExcludedTableDropSql(statements, ['carts'], []).statements).toEqual(statements)
   })
 })
 

--- a/storage/framework/core/types/src/database.ts
+++ b/storage/framework/core/types/src/database.ts
@@ -143,6 +143,31 @@ export interface DatabaseOptions {
   migrations: string
   migrationLocks: string
 
+  /** How the migration generator decides which model definitions are in scope. */
+  models?: {
+    /**
+     * Also generate migrations for the framework's own models in
+     * `storage/framework/defaults/app/Models`, on top of your `app/Models`.
+     *
+     * Off by default. The defaults stand in only when `app/Models` is empty —
+     * a vendored framework checkout, or a project that has not defined a model
+     * yet. Merging them into every app meant a five-model project migrated
+     * sixty-seven tables, most of them demo schema (`carts`, `coupons`,
+     * `drivers`, ...), and most of its `migrations` rows had no SQL file in the
+     * repo (stacksjs/stacks#2220).
+     *
+     * Turn it on if your app uses built-in models — `User`, `Team`, the
+     * commerce set — without publishing them. `./buddy publish model <Name>`
+     * is the alternative, and the one that leaves the app's schema
+     * self-describing.
+     *
+     * Env override for a single run: `STACKS_INCLUDE_FRAMEWORK_MODELS=1`.
+     *
+     * @default false
+     */
+    includeFrameworkDefaults?: boolean
+  }
+
   /**
    * How reads are distributed across the active connection's replicas.
    * Cross-cutting rather than per-connection: one connection is active at


### PR DESCRIPTION
Closes #2220.

## The bug

`resolveModelSources()` merged `app/Models` with the framework's own 62 models in `storage/framework/defaults/app/Models`, overriding only by name. Nothing excluded the rest, so a five-model app migrated sixty-seven tables: `carts`, `coupons`, `drivers`, `waitlist_restaurants` and the rest of the demo schema into a log-streaming product. The reporting app ended up with 88 tables and 80 `migrations` rows, 65 with no SQL file in the repo, so a fresh clone could not rebuild its own schema.

The merge was overreach in the fix that added it. That fix existed because a vendored checkout and a fresh scaffold have no `app/Models`, so the generator silently produced nothing. The correct shape for that is a fallback.

## The fix

Framework defaults stand in **only when userland contributes no models at all**.

- `buddy new` lays down an empty `app/Models`, so scaffolds and vendored checkouts resolve exactly as they do today (verified against this repo: still 69 models in scope).
- An app that wants the union sets `database.models.includeFrameworkDefaults`, or `STACKS_INCLUDE_FRAMEWORK_MODELS=1` for one run.
- `buddy publish model <Name>` remains the alternative, and the one that leaves the app's schema self-describing.

Verified end-to-end with a single `app/Models/Project.ts` in this repo: 1 model in scope, 69 framework tables reported excluded. With `STACKS_INCLUDE_FRAMEWORK_MODELS=1`: 70 in scope, 0 excluded, userland still winning the name collision.

## Narrowing must not destroy anything

This is the part worth reviewing. The generator diffs models against the stored snapshot, so the **first** run after this change sees sixty-odd tables leave the model set, and bun-query-builder's `generateDiffOperations` emits `drop_table` for every table in the previous plan that is missing from the next one. Shipped as-is, upgrading would have proposed dropping tables that hold data.

`withoutExcludedTableDropSql()` suppresses exactly those drops and logs that it did. "This app no longer generates this table" is not "destroy this table" — the same distinction `withoutManagedColumnDropSql` already draws for framework-managed columns. It matches on the operation's own `sql` with a dialect-tolerant regex fallback (Postgres appends `CASCADE`, MySQL uses backticks).

It is self-limiting: the snapshot advances to the narrowed model set at the end of the same run, so the drops are never proposed again. `previewPendingMigrations()` filters them too, so `buddy migrate`'s destructive-change gate does not show sixty phantom drops and train users to approve a prompt that is, on any other run, worth reading.

## On the issue's third ask

> Emit the generated migrations into `database/migrations` so the corpus is complete and committable

Addressed by the same change rather than separately: with the merge gone the generator never produces those 65 framework migrations, so the corpus and the ledger describe the same set of tables.

## Tests

`storage/framework/core/database/tests/model-sources.test.ts`, 18 pass:
- only userland models once userland has any
- excluded defaults and their table names reported, derived the way the generator derives them
- explicit `table:` beats the pluralised name
- opt-in restores the merge, userland still winning collisions
- fallback intact when userland has none
- 5 cases on the drop suppression: suppressed for out-of-scope tables, **not** suppressed for a table the app really deleted, dialect spellings, no-op when nothing excluded, and `ALTER`/`DELETE` naming an excluded table left alone

Full `core/database` suite: 676 pass, 0 fail. Typecheck adds no new errors (24 remain, all pre-existing: `desktop-build`, `alias` duplicate keys, Stripe API pin, `browser/composables`, `ts-cloud`).