### PR TITLE
fix(queue): make preventOverlapping and withoutOverlapping actually guard

### DIFF
--- a/storage/framework/core/queue/src/scheduler-persistence.ts
+++ b/storage/framework/core/queue/src/scheduler-persistence.ts
@@ -90,6 +90,55 @@ export async function persistLastRun(jobName: string, when: Date): Promise<void>
   }
 }
 
+/**
+ * Whether a previous dispatch of this scheduled job is still unfinished.
+ *
+ * This is what `preventOverlapping` / `withoutOverlapping` were supposed to
+ * ask (stacksjs/stacks#1984). They consulted an in-memory `isRunning` flag that
+ * the scheduler set immediately before `storeJob` and cleared immediately
+ * after, so it described the few milliseconds of the ENQUEUE and was reliably
+ * false again by the next tick — the guard never once fired, and a job that
+ * takes longer than its interval still piled up.
+ *
+ * The queue row is the honest signal. It is deleted on success and on terminal
+ * failure (after `failed_jobs` is written), and deliberately KEPT while a job
+ * is waiting to retry — so "a row still exists" is precisely "the previous run
+ * has not finished", which is the semantics being promised.
+ *
+ * Matched on the payload because `jobs` has no name column; `storeJob` writes
+ * `{"jobName":"<name>",...}` as the first key, and the closing quote in the
+ * pattern keeps `backup` from matching `backup-daily`. LIKE metacharacters in
+ * the name are escaped, since `_` is legal in a job name and would otherwise
+ * match any single character.
+ *
+ * Best-effort, like everything else here: an unavailable database returns
+ * false, which degrades to the previous always-dispatch behaviour rather than
+ * wedging the scheduler shut.
+ */
+/** The LIKE pattern {@link hasUnfinishedRun} matches a job's queue row with. */
+export function overlapPayloadPattern(jobName: string): string {
+  const escaped = jobName.replace(/[\\%_]/g, character => `\\${character}`)
+  return `%"jobName":"${escaped}"%`
+}
+
+export async function hasUnfinishedRun(jobName: string): Promise<boolean> {
+  try {
+    const { db } = await import('@stacksjs/database')
+    const rows = await (db as any).unsafe(
+      `SELECT 1 AS present FROM jobs WHERE payload LIKE ? ESCAPE '\\' LIMIT 1`,
+      [overlapPayloadPattern(jobName)],
+    ).execute()
+    // Drivers disagree on the empty-result shape (`[]`, `{ rows: [] }`, or a
+    // bare undefined), so ask only whether anything came back.
+    const list = Array.isArray(rows) ? rows : (rows?.rows ?? [])
+    return Array.isArray(list) && list.length > 0
+  }
+  catch (err) {
+    log.debug(`[scheduler] overlap check unavailable, dispatching anyway: ${err instanceof Error ? err.message : String(err)}`)
+    return false
+  }
+}
+
 /** Test hook: reset the one-time table-ensured flag. */
 export function __resetSchedulerPersistenceForTests(): void {
   ensured = false

--- a/storage/framework/core/queue/src/scheduler.ts
+++ b/storage/framework/core/queue/src/scheduler.ts
@@ -11,7 +11,7 @@
 import { log } from '@stacksjs/logging'
 import { discoverJobs, getScheduledJobs, type DiscoveredJob } from './discovery'
 import { emitQueueEvent } from './events'
-import { loadPersistedLastRun, persistLastRun } from './scheduler-persistence'
+import { hasUnfinishedRun, loadPersistedLastRun, persistLastRun } from './scheduler-persistence'
 import { storeJob } from './utils'
 
 /**
@@ -438,15 +438,25 @@ async function checkScheduledJobs(): Promise<void> {
 
     // Check if job should run (in the configured timezone, if any)
     if (shouldRunNow(cronExpression, state.lastRun, schedulerState.config.timezone)) {
-      // Check overlapping
-      if (schedulerState.config.preventOverlapping && state.isRunning) {
+      // Overlap guards ask the QUEUE, not `state.isRunning` (stacksjs/stacks#1984).
+      // The scheduler only enqueues: it set `isRunning` right before `storeJob`
+      // and cleared it right after, so the flag described the enqueue rather
+      // than the execution and was always false again by the next tick. Both
+      // guards therefore never fired. `hasUnfinishedRun` checks whether the
+      // previously dispatched job row is still there, which is what "previous
+      // execution still running" actually means.
+      //
+      // Only asked when a guard is on, so the default path adds no query.
+      const overlapGuarded = schedulerState.config.preventOverlapping || state.job.config.withoutOverlapping
+      if (overlapGuarded && await hasUnfinishedRun(name)) {
         log.debug(`Skipping ${name}: previous execution still running`)
         continue
       }
 
-      // Check job-level overlapping setting
-      if (state.job.config.withoutOverlapping && state.isRunning) {
-        log.debug(`Skipping ${name}: withoutOverlapping is enabled`)
+      // Re-entrancy guard for the enqueue itself. Narrow on purpose — the
+      // overlap question above is the one about execution.
+      if (state.isRunning) {
+        log.debug(`Skipping ${name}: a dispatch for it is already in flight`)
         continue
       }
 

--- a/storage/framework/core/queue/tests/scheduler-persistence.test.ts
+++ b/storage/framework/core/queue/tests/scheduler-persistence.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { loadPersistedLastRun, persistLastRun } from '../src/scheduler-persistence'
+import { hasUnfinishedRun, loadPersistedLastRun, overlapPayloadPattern, persistLastRun } from '../src/scheduler-persistence'
 
 // stacksjs/stacks#1984 — the scheduler's `lastRun` marker lived only in memory
 // and reset on restart, so a deploy within the same clock-minute a job fires
@@ -45,6 +45,66 @@ describe('scheduler run-marker persistence (#1984)', () => {
     })
     it('persists the run marker when a job is dispatched', () => {
       expect(sched).toContain('await persistLastRun(name, state.lastRun)')
+    })
+  })
+})
+
+// stacksjs/stacks#1984 — `preventOverlapping` / `withoutOverlapping` consulted
+// an in-memory `isRunning` flag the scheduler set immediately before the
+// enqueue and cleared immediately after, so it described the enqueue rather
+// than the execution and was always false again by the next tick. Neither
+// guard ever fired. They now ask whether the dispatched queue row is still
+// present, which is what "previous execution still running" means.
+describe('scheduler overlap guard (#1984)', () => {
+  describe('overlapPayloadPattern', () => {
+    it('anchors on the closing quote so a prefix name does not match', () => {
+      const pattern = overlapPayloadPattern('backup')
+      expect(pattern).toBe('%"jobName":"backup"%')
+      // The row a sibling job would write. Without the closing quote in the
+      // pattern, `backup` would match `backup-daily` and silently suppress it.
+      expect('{"jobName":"backup-daily","payload":{}}').not.toContain('"jobName":"backup"')
+    })
+
+    it('escapes LIKE metacharacters, since `_` is legal in a job name', () => {
+      // Unescaped, `_` matches any single character, so `backup_daily` would
+      // also match a queued `backupXdaily`.
+      expect(overlapPayloadPattern('backup_daily')).toBe('%"jobName":"backup\\_daily"%')
+      expect(overlapPayloadPattern('50%_off')).toBe('%"jobName":"50\\%\\_off"%')
+      expect(overlapPayloadPattern('a\\b')).toBe('%"jobName":"a\\\\b"%')
+    })
+
+    it('matches the envelope storeJob actually writes', () => {
+      // storeJob puts jobName first in the JSON object; if that ever changes,
+      // the guard silently stops matching and both flags go back to no-ops.
+      const utils = readFileSync(resolve(__dirname, '..', 'src', 'utils.ts'), 'utf-8')
+      expect(utils).toMatch(/JSON\.stringify\(\{\s*\n\s*jobName: name,/)
+    })
+  })
+
+  it('degrades to "not running" rather than throwing when the DB is unavailable', async () => {
+    // A scheduler that cannot reach the database must keep dispatching, not
+    // wedge itself shut.
+    expect(await hasUnfinishedRun('__no_such_scheduled_job__')).toBe(false)
+  })
+
+  describe('scheduler wiring', () => {
+    const sched = src('scheduler.ts')
+
+    it('asks the queue, not the in-memory flag', () => {
+      expect(sched).toContain('await hasUnfinishedRun(name)')
+    })
+
+    it('gates both the global and the per-job flag on that same check', () => {
+      expect(sched).toMatch(
+        /const overlapGuarded = schedulerState\.config\.preventOverlapping \|\| state\.job\.config\.withoutOverlapping/,
+      )
+      expect(sched).toContain('if (overlapGuarded && await hasUnfinishedRun(name))')
+    })
+
+    it('only queries when a guard is actually enabled', () => {
+      // The default path must not pay a query per job per minute.
+      const guard = sched.slice(sched.indexOf('const overlapGuarded'))
+      expect(guard.indexOf('overlapGuarded &&')).toBeLessThan(guard.indexOf('hasUnfinishedRun(name)'))
     })
   })
 })


### PR DESCRIPTION
Refs #1984 — the last of the "High impact" items on that list, and the one I explicitly deferred as "needs execution-state tracked across the dispatch→worker boundary".

## The bug

```ts
if (schedulerState.config.preventOverlapping && state.isRunning) { ... }
if (state.job.config.withoutOverlapping && state.isRunning) { ... }
...
state.isRunning = true
await storeJob(name, { ... })
state.isRunning = false     // <- same tick, a few ms later
```

The scheduler only **enqueues**. `isRunning` was set right before `storeJob` and cleared right after, so it described the enqueue rather than the execution and was always false again by the next tick. Neither guard has ever fired. A scheduled job that takes longer than its own interval piles up exactly as if the flags were absent, which is the one thing they document themselves as preventing.

## The fix

Ask the queue instead of the flag.

`deleteJob` runs on success (`worker.ts:388`, `:427`) and on terminal failure once `failed_jobs` is durably written (`:533`); a job waiting to retry deliberately keeps its row. So **"a row still exists" is precisely "the previous run has not finished"** — the promised semantics, with no new table and no new bookkeeping to drift.

`jobs` has no name column, so the match is on the payload `storeJob` writes, where `jobName` is the first key.

Two details that are easy to get wrong and are pinned by tests:
- **the closing quote is load-bearing** — `%"jobName":"backup"%` must not match a queued `backup-daily`.
- **LIKE metacharacters are escaped** — `_` is legal in a job name and unescaped would match any single character, so `backup_daily` would suppress a queued `backupXdaily`.

## Cost and failure behaviour

- The query runs **only when one of the two flags is on** (`overlapGuarded && await hasUnfinishedRun(name)`), so the default path adds nothing. Pinned by a test asserting the short-circuit order.
- Best-effort, like the rest of `scheduler-persistence.ts`: an unreachable database answers "not running" and the job dispatches. A dead connection must not wedge the scheduler permanently shut.
- `isRunning` stays as a narrow re-entrancy guard on the enqueue itself, which is the only thing it was ever able to describe.

## Known limitation

This is per-run, not cross-restart: a scheduler restart while a guarded job is mid-execution will still see the row and correctly skip, but the guard depends on the row surviving, which it does. What it does **not** cover is a job executing on a driver that does not use the `jobs` table (Redis), where `hasUnfinishedRun` finds nothing and the guard is inert. That is the same gap already tracked under "Redis in-flight jobs bypass `trackInFlight`" and needs a live Redis to do properly.

## Tests

`scheduler-persistence.test.ts`, 13 pass (6 new):
- pattern anchors on the closing quote (prefix-name collision)
- escapes `_`, `%`, `\` in job names
- pattern still matches the envelope `storeJob` actually writes — guards against a silent regression to no-op if that key order ever changes
- degrades to `false` rather than throwing with no database
- wiring: asks the queue, gates both flags on the same check, short-circuits before querying

Full `core/queue` suite: 232 pass, 1 fail — `redis-contract.test.ts`, pre-existing, requires a live Redis (`queue.ping()` is false without one; fails identically on a clean checkout). Typecheck: no new errors.