### PR TITLE
fix(types): resolve @stacksjs subpath imports to sources — typecheck green

### DIFF
--- a/storage/framework/core/tsconfig.build.json
+++ b/storage/framework/core/tsconfig.build.json
@@ -17,6 +17,17 @@
     "moduleResolution": "bundler",
     "paths": {
       "~/*": ["../../../*"],
+      // Deep subpath imports need their own entries, for the same reason they
+      // do in `tsconfig.json`: `@stacksjs/*` binds the wildcard to the whole
+      // remainder, so `@stacksjs/actions/blog` looks for `./actions/blog/src`,
+      // misses, and falls back to the package's unbuilt `dist/`. Bun honours
+      // these mappings during `bun build`, so without them
+      // `buddy compile:*` cannot resolve the blog feed renderer and the
+      // compile job fails on a checkout that has not built every package.
+      "@stacksjs/actions/*": ["./actions/src/*"],
+      "@stacksjs/browser/*": ["./browser/src/*"],
+      "@stacksjs/composables/*": ["./composables/src/*"],
+      "@stacksjs/desktop-build": ["./desktop/src"],
       "@stacksjs/*": ["./*/src"],
       "ts-pantry": ["../../../node_modules/ts-pantry"],
       "*": ["../../../pantry/*"]

--- a/storage/framework/core/tsconfig.build.json
+++ b/storage/framework/core/tsconfig.build.json
@@ -17,19 +17,6 @@
     "moduleResolution": "bundler",
     "paths": {
       "~/*": ["../../../*"],
-      // `@stacksjs/*` below binds the wildcard to the whole remainder, so
-      // `@stacksjs/actions/blog` looks for `./actions/blog/src`, misses, and
-      // falls back to the package's unbuilt `dist/`. Bun honours these mappings
-      // during `bun build`, so without this entry `buddy compile:*` cannot
-      // resolve the blog feed renderer on a checkout that has not built every
-      // package, which is every CI run.
-      //
-      // Deliberately only `actions`. The equivalent `browser` / `composables`
-      // entries belong in `tsconfig.json` (where they fix typecheck) and are
-      // NOT mirrored here: adding them to this file made `core/config` and
-      // `core/env` tests fail in CI, since this config also governs how
-      // `bun test` resolves specifiers for every package under `core/`.
-      "@stacksjs/actions/*": ["./actions/src/*"],
       "@stacksjs/*": ["./*/src"],
       "ts-pantry": ["../../../node_modules/ts-pantry"],
       "*": ["../../../pantry/*"]

--- a/storage/framework/core/tsconfig.build.json
+++ b/storage/framework/core/tsconfig.build.json
@@ -17,17 +17,19 @@
     "moduleResolution": "bundler",
     "paths": {
       "~/*": ["../../../*"],
-      // Deep subpath imports need their own entries, for the same reason they
-      // do in `tsconfig.json`: `@stacksjs/*` binds the wildcard to the whole
-      // remainder, so `@stacksjs/actions/blog` looks for `./actions/blog/src`,
-      // misses, and falls back to the package's unbuilt `dist/`. Bun honours
-      // these mappings during `bun build`, so without them
-      // `buddy compile:*` cannot resolve the blog feed renderer and the
-      // compile job fails on a checkout that has not built every package.
+      // `@stacksjs/*` below binds the wildcard to the whole remainder, so
+      // `@stacksjs/actions/blog` looks for `./actions/blog/src`, misses, and
+      // falls back to the package's unbuilt `dist/`. Bun honours these mappings
+      // during `bun build`, so without this entry `buddy compile:*` cannot
+      // resolve the blog feed renderer on a checkout that has not built every
+      // package, which is every CI run.
+      //
+      // Deliberately only `actions`. The equivalent `browser` / `composables`
+      // entries belong in `tsconfig.json` (where they fix typecheck) and are
+      // NOT mirrored here: adding them to this file made `core/config` and
+      // `core/env` tests fail in CI, since this config also governs how
+      // `bun test` resolves specifiers for every package under `core/`.
       "@stacksjs/actions/*": ["./actions/src/*"],
-      "@stacksjs/browser/*": ["./browser/src/*"],
-      "@stacksjs/composables/*": ["./composables/src/*"],
-      "@stacksjs/desktop-build": ["./desktop/src"],
       "@stacksjs/*": ["./*/src"],
       "ts-pantry": ["../../../node_modules/ts-pantry"],
       "*": ["../../../pantry/*"]

--- a/storage/framework/core/tsconfig.json
+++ b/storage/framework/core/tsconfig.json
@@ -6,7 +6,16 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
+      // Deep subpath imports need their own mapping: `@stacksjs/*` below binds
+      // the wildcard to the WHOLE remainder, so `@stacksjs/browser/composables/csrf`
+      // resolves to `./browser/composables/csrf/src`, which does not exist. tsc
+      // then falls back to node resolution and lands on the package's `dist/`,
+      // which nothing builds before `bun run typecheck` — so these read as
+      // "Cannot find module" on a clean checkout and in CI, and are four of the
+      // six errors that have kept the typecheck job red.
       "@stacksjs/actions/*": ["./actions/src/*"],
+      "@stacksjs/browser/*": ["./browser/src/*"],
+      "@stacksjs/composables/*": ["./composables/src/*"],
       "@stacksjs/*": ["./*/src"],
       "stacks/*": ["./*/src"],
       "buddy": ["./buddy/src/index.ts"],

--- a/storage/framework/core/tsconfig.json
+++ b/storage/framework/core/tsconfig.json
@@ -16,6 +16,10 @@
       "@stacksjs/actions/*": ["./actions/src/*"],
       "@stacksjs/browser/*": ["./browser/src/*"],
       "@stacksjs/composables/*": ["./composables/src/*"],
+      // Published name and directory name disagree: `@stacksjs/desktop-build`
+      // lives in `core/desktop/`. `@stacksjs/*` looks for `./desktop-build/src`
+      // and misses, which is the remaining pair of typecheck errors.
+      "@stacksjs/desktop-build": ["./desktop/src"],
       "@stacksjs/*": ["./*/src"],
       "stacks/*": ["./*/src"],
       "buddy": ["./buddy/src/index.ts"],


### PR DESCRIPTION
Found while verifying #2220 and #1984 against CI. Not part of either issue, but it takes **`typecheck` from red to green on main** — the first green typecheck this repo has had in a while, so every other PR gets a real signal instead of a known-red one.

| job | main | this PR |
|---|---|---|
| typecheck | ❌ 6 errors | ✅ **pass** |
| test | ❌ `database defaults` | ❌ `database defaults` (identical) |
| compile | ❌ | ❌ (unchanged — see below) |
| lint / artifact-freshness / size | ✅ | ✅ |

## Cause

```jsonc
"@stacksjs/*": ["./*/src"],
```

The wildcard binds the **whole** remainder of the specifier, so `@stacksjs/browser/composables/csrf` maps to `./browser/composables/csrf/src` — a directory that does not exist. Resolution falls through to node and lands on the package's `dist/`, which nothing builds first: the typecheck job is `bun install --frozen-lockfile` then `bun run typecheck`. On any clean checkout those specifiers are unresolvable.

`@stacksjs/actions/*` already carried exactly this mapping for exactly this reason. This adds it for the other packages consumed by subpath:

```
browser/src/composables/useFetch.ts    -> @stacksjs/composables/useFetch
browser/src/composables/useStorage.ts  -> @stacksjs/composables/useStorage
defaults/functions/auth.ts             -> @stacksjs/browser/composables/csrf
defaults/functions/auth.ts             -> @stacksjs/browser/composables/useStorage
```

The last two errors are a different flavour of the same thing: `@stacksjs/desktop-build` is published under that name but lives in `core/desktop/`, so `@stacksjs/*` looked for `./desktop-build/src` and missed.

Only `core/tsconfig.json` changes. Nothing else.

## What I deliberately left out

`compile` fails on the same class of bug:

```
error: Could not resolve: "@stacksjs/actions/blog"
  at core/buddy/src/production-server.ts:370:53
```

Adding `@stacksjs/actions/*` to `core/tsconfig.build.json` fixes it — verified locally, 1930 modules bundled and linked, binary reports its version. **But that file is also extended by `core/config` and `core/env`'s own tsconfigs**, so it changes how `bun test` resolves specifiers for those packages, and both suites go red (`app.url` comes back `undefined`).

Bisected across four CI runs against two different bases: `tsconfig.json` alone is always at main's baseline; every run carrying the `tsconfig.build.json` entry adds `config` and `env`. My first attempt narrowed that file to `actions` only, which kept precisely the entry at fault — so it did not help, and the bisect is what caught it rather than the reasoning.

Trading a red `typecheck` for a red `test` is not a fix, so the compile half is dropped here and filed separately (#2242). It needs someone to decide whether `core/config` / `core/env` should stop extending the build config, or whether the compile should resolve `actions` some other way.

## Verification

Local, with `browser/`, `composables/` and `desktop/`'s `dist/` moved aside to reproduce CI's unbuilt state:

| state | matching typecheck errors |
|---|---|
| no `dist/`, no fix (= CI today) | 6 |
| no `dist/`, with fix | **0** |

All four mapping targets confirmed to exist as sources. Rebased onto current `main` (`452d4b9d6e`).

## Related, not fixed here

The same stale-`dist/` condition breaks the dashboard at runtime, not just tsc: `buddy dev --dashboard` emitted 39 `Bundle failed` messages for these specifiers until I rebuilt both packages by hand. `dist/` is gitignored, so any checkout that predates a build hits it. Noted in #1989, where I ran into it.
