### PR TITLE
fix(queue): resolve job names against the framework defaults too

### DIFF
--- a/storage/framework/core/queue/src/job.ts
+++ b/storage/framework/core/queue/src/job.ts
@@ -5,7 +5,7 @@
  * For class-based jobs, use bun-queue's JobBase directly.
  */
 
-import { appPath } from '@stacksjs/path'
+import { appPath, frameworkPath } from '@stacksjs/path'
 import { env as envVars } from '@stacksjs/env'
 import { enqueueAfterCommit, isInTransaction } from '@stacksjs/database'
 import { moveToDeadLetter } from './dead-letter'
@@ -549,9 +549,51 @@ export function jobBatch(jobs: Array<import('./action').Job | import('./batch').
 }
 
 /**
+ * Locate a job file by name, userland first.
+ *
+ * Actions resolve by string out of the framework defaults; jobs did not, so a
+ * framework-shipped action that dispatched a framework-shipped job by name
+ * could never find it. The default password-reset flow is exactly that shape —
+ * `SendPasswordResetEmailAction` resolves from `@stacksjs/defaults`, then calls
+ * `job('SendPasswordResetEmailJob')`, which looked only in the app's own
+ * `app/Jobs/`. In a stock app that directory holds a `.gitkeep`, so password
+ * reset silently sent nothing (stacksjs/stacks#2225).
+ *
+ * The three candidates mirror `resolveActionFile`:
+ *   1. `app/Jobs/<name>.ts`                     — userland always wins
+ *   2. `storage/framework/defaults/app/Jobs/…`  — vendored framework checkout
+ *   3. `@stacksjs/defaults`'s copy of the same  — framework-as-dependencies
+ *
+ * (3) resolves the package root through `package.json` and joins the subpath by
+ * hand rather than importing `@stacksjs/defaults/app/Jobs/<name>`, for the
+ * reason documented on `resolveActionFile`: the `./*` exports map rewrites the
+ * subpath under the `bun` condition and does not land on the file.
+ */
+export async function resolveJobFile(name: string): Promise<string | null> {
+  const candidates = [
+    appPath(`Jobs/${name}.ts`),
+    frameworkPath(`defaults/app/Jobs/${name}.ts`),
+  ]
+
+  try {
+    const pkgUrl = import.meta.resolve('@stacksjs/defaults/package.json')
+    const root = new URL('.', pkgUrl).pathname
+    candidates.push(`${root}app/Jobs/${name}.ts`)
+  }
+  catch { /* not installed in this layout; the two paths above still apply */ }
+
+  for (const candidate of candidates) {
+    if (await Bun.file(candidate).exists())
+      return candidate
+  }
+  return null
+}
+
+/**
  * Run a job immediately by name
  *
- * This loads the job from app/Jobs/{name}.ts and executes it
+ * This loads the job from app/Jobs/{name}.ts, falling back to the framework
+ * defaults, and executes it
  *
  * Wraps execution in `withTraceId(...)` so log lines, db queries, and
  * downstream HTTP calls emitted from inside the job carry the same
@@ -565,7 +607,19 @@ export async function runJob(name: string, options: { payload?: any; context?: a
   const traceId = options.traceId ?? `job:${name}:${Math.random().toString(36).slice(2, 10)}`
 
   await withTraceId(traceId, async () => {
-    const jobPath = appPath(`Jobs/${name}.ts`)
+    const jobPath = await resolveJobFile(name)
+
+    // Named explicitly rather than letting `import(undefined)` throw a module
+    // resolution error: the fix for a missing job is to create it or correct
+    // the name, and the old message pointed only at the app directory even
+    // when the job was meant to come from the framework.
+    if (!jobPath) {
+      throw new Error(
+        `Job ${name} not found. Looked in app/Jobs/${name}.ts and the framework defaults `
+        + `(storage/framework/defaults/app/Jobs, @stacksjs/defaults).`,
+      )
+    }
+
     const jobModule = await import(jobPath)
     const jobConfig = jobModule.default
 

--- a/storage/framework/core/queue/tests/job-resolution.test.ts
+++ b/storage/framework/core/queue/tests/job-resolution.test.ts
@@ -1,0 +1,70 @@
+/**
+ * stacksjs/stacks#2225 — `runJob` resolved job names only against the project's
+ * own `app/Jobs/`, with no fallback to the framework defaults. Actions have
+ * such a fallback, so a framework-shipped action could resolve by string and
+ * then dispatch a framework-shipped job that could never be found.
+ *
+ * The default password-reset flow is exactly that shape:
+ * `Actions/Password/SendPasswordResetEmailAction` resolves out of
+ * `@stacksjs/defaults`, then calls `job('SendPasswordResetEmailJob')`. In a
+ * stock app `app/Jobs/` holds a `.gitkeep`, so the dispatch threw and password
+ * reset silently sent nothing.
+ */
+
+import { afterAll, describe, expect, it } from 'bun:test'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { appPath, frameworkPath } from '@stacksjs/path'
+import { resolveJobFile } from '../src/job'
+
+describe('resolveJobFile (#2225)', () => {
+  it('finds a framework default job with no userland copy', async () => {
+    // The exact job the shipped password-reset action dispatches. If this
+    // stops resolving, that flow is silently broken again.
+    const resolved = await resolveJobFile('SendPasswordResetEmailJob')
+
+    expect(resolved).not.toBeNull()
+    expect(existsSync(resolved!)).toBe(true)
+    expect(resolved).toContain('defaults/app/Jobs/SendPasswordResetEmailJob.ts')
+  })
+
+  it('returns null for a job that exists nowhere', async () => {
+    // Must be null rather than a non-existent path, so `runJob` can raise a
+    // message naming every place it looked instead of a module-resolution error.
+    expect(await resolveJobFile('__NoSuchJobAnywhere__')).toBeNull()
+  })
+
+  it('resolves the other shipped defaults too, not just one special case', async () => {
+    for (const name of ['SendEmailJob', 'PruneQueryLogsJob', 'SyncSearchIndexJob']) {
+      expect(await resolveJobFile(name)).not.toBeNull()
+    }
+  })
+
+  describe('userland precedence', () => {
+    // A framework default an app is allowed to override. Created and removed
+    // here so the repo's own app/Jobs is left exactly as it was found.
+    const OVERRIDE = 'SendPasswordResetEmailJob'
+    const userCopy = appPath(`Jobs/${OVERRIDE}.ts`)
+    const preexisting = existsSync(userCopy)
+
+    afterAll(() => {
+      if (!preexisting)
+        rmSync(userCopy, { force: true })
+    })
+
+    it('prefers app/Jobs over the framework default of the same name', async () => {
+      if (preexisting) {
+        // Never clobber a real file; the assertion below still holds for it.
+        expect(await resolveJobFile(OVERRIDE)).toBe(userCopy)
+        return
+      }
+
+      mkdirSync(appPath('Jobs'), { recursive: true })
+      writeFileSync(userCopy, 'export default { handle: async () => {} }\n')
+
+      expect(await resolveJobFile(OVERRIDE)).toBe(userCopy)
+      // ...and the framework copy it shadowed is genuinely there, so this is a
+      // real precedence assertion rather than a "only one candidate existed" one.
+      expect(existsSync(frameworkPath(`defaults/app/Jobs/${OVERRIDE}.ts`))).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Closes #2225.

## The bug

`runJob` built `appPath('Jobs/<name>.ts')` and imported it, with no fallback. Actions have one — `Actions/Password/SendPasswordResetEmailAction` resolves out of `@stacksjs/defaults` — so a framework-shipped action can resolve by string and then dispatch a framework-shipped job that can never be found.

**The default password-reset flow is exactly that shape**, so it is broken in every stock app:

1. `routes/auth.ts` registers the shipped action by string — resolves fine.
2. The action calls `job('SendPasswordResetEmailJob').onQueue('emails').dispatch()`.
3. Under `QUEUE_DRIVER=sync` that goes straight to `runJob`.
4. A stock app's `app/Jobs/` holds a `.gitkeep`; the job lives only in the defaults package.

The endpoint accepted the request and sent nothing. Worth noting it fails *silently* by design now — #2214 made that action swallow dispatch errors so a degraded mailer can't become an account-existence oracle. Correct for that threat, and it means this bug had no symptom at all beyond "the email never arrives".

## The fix

Resolution mirrors `resolveActionFile`, in the same order:

1. `app/Jobs/<name>.ts` — userland always wins, so overriding a shipped job is unchanged
2. `storage/framework/defaults/app/Jobs/<name>.ts` — vendored framework checkout
3. `@stacksjs/defaults`'s copy — framework-as-dependencies app

(3) resolves the package root through `package.json` and joins the subpath by hand rather than importing `@stacksjs/defaults/app/Jobs/<name>`. Not a preference — it is the reason already documented on `resolveActionFile`: the `./*` exports map rewrites the subpath under the `bun` condition and does not land on the file.

A name that exists nowhere now raises a message naming every location tried, instead of a module-resolution error pointing only at the app directory.

## Tests

`storage/framework/core/queue/tests/job-resolution.test.ts`, 4 pass:
- resolves `SendPasswordResetEmailJob` with no userland copy — the exact job the shipped action dispatches, so this going red means that flow is silently broken again
- returns `null` (not a bogus path) for a job that exists nowhere
- resolves the other shipped defaults too, so it is not one special case
- `app/Jobs` wins over the framework default of the same name, asserted with the shadowed framework copy confirmed present so it is a real precedence test rather than a single-candidate one

The precedence test creates and removes its fixture only when the repo does not already have that file, so `app/Jobs/` is left exactly as found.

`core/queue` + `core/testing`: 257 pass, 1 fail — `redis-contract.test.ts`, pre-existing, needs a live Redis. Typecheck adds no errors.