### PR TITLE
fix(testing): make actingAs() actually authenticate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1008,6 +1008,7 @@
       "name": "@stacksjs/testing",
       "version": "0.70.293",
       "dependencies": {
+        "@stacksjs/auth": "workspace:*",
         "@stacksjs/ts-cloud": "^0.7.103",
       },
       "devDependencies": {

--- a/storage/framework/core/testing/package.json
+++ b/storage/framework/core/testing/package.json
@@ -74,6 +74,7 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
+    "@stacksjs/auth": "workspace:*",
     "@stacksjs/ts-cloud": "^0.7.103"
   },
   "devDependencies": {

--- a/storage/framework/core/testing/src/feature.ts
+++ b/storage/framework/core/testing/src/feature.ts
@@ -100,19 +100,66 @@ export function featureTest(baseUrl: string = 'http://localhost'): FeatureTestCl
   let actingUser: { id: number | string, [k: string]: unknown } | null = null
   let extraHeaders: Record<string, string> = {}
 
-  function buildHeaders(body?: unknown): Record<string, string> {
+  /**
+   * Bearer token minted for `actingUser`, cached for the life of the client so
+   * a multi-request test does not create a personal access token per call.
+   */
+  let actingToken: string | null = null
+
+  /**
+   * Authenticate as `actingUser` by minting a REAL token.
+   *
+   * This used to attach an `X-Test-Acting-User` sentinel header and claim "the
+   * auth middleware checks it when APP_ENV === 'test'". No middleware has ever
+   * read that header — the string existed only here, in the package that wrote
+   * it — so `actingAs()` was a no-op and every feature test against an
+   * `auth`-guarded route got a 401 (stacksjs/stacks#2228).
+   *
+   * The fix is not to teach the middleware the sentinel. A header that
+   * authenticates as an arbitrary user whenever an env var is set is a
+   * production auth bypass one misconfiguration away, and it would also mean
+   * feature tests exercise a code path that only exists for tests. Minting a
+   * token through `Auth.loginUsingId()` sends the request through the same
+   * bearer-token path a real client uses, so the test actually covers the
+   * middleware it is meant to cover.
+   *
+   * Imported lazily: a test that never calls `actingAs()` should not pay for
+   * booting auth and the ORM.
+   */
+  async function resolveActingToken(): Promise<string | null> {
+    if (!actingUser) return null
+    if (actingToken) return actingToken
+
+    const { Auth } = await import('@stacksjs/auth')
+    const id = Number(actingUser.id)
+    if (!Number.isFinite(id))
+      throw new TypeError(`actingAs() needs a user with a numeric id; got ${JSON.stringify(actingUser.id)}`)
+
+    const session = await Auth.loginUsingId(id)
+    if (!session) {
+      throw new Error(
+        `actingAs() could not authenticate user ${id}: no such user. `
+        + `Create the row first (e.g. via a factory) so a token can be issued against it.`,
+      )
+    }
+
+    actingToken = String(session.token)
+    return actingToken
+  }
+
+  async function buildHeaders(body?: unknown): Promise<Record<string, string>> {
     const headers: Record<string, string> = {
       'Accept': 'application/json',
       ...extraHeaders,
     }
     if (body !== undefined) headers['Content-Type'] = 'application/json'
-    if (actingUser) {
-      // Stacks ships token-based auth — tests use a dev token, but the
-      // simpler path here is to expose the user via a sentinel header
-      // the auth middleware understands in test mode. The auth middleware
-      // checks `X-Test-Acting-User` only when APP_ENV === 'test'.
-      headers['X-Test-Acting-User'] = JSON.stringify(actingUser)
-    }
+
+    const token = await resolveActingToken()
+    // An explicit `withHeaders({ Authorization })` wins: a test that sets its
+    // own token is deliberately exercising that token, not the acting user's.
+    if (token && !headers.Authorization && !headers.authorization)
+      headers.Authorization = `Bearer ${token}`
+
     return headers
   }
 
@@ -121,7 +168,7 @@ export function featureTest(baseUrl: string = 'http://localhost'): FeatureTestCl
     const url = path.startsWith('http') ? path : `${baseUrl}${path}`
     const init: RequestInit = {
       method,
-      headers: buildHeaders(body),
+      headers: await buildHeaders(body),
       body: body === undefined ? undefined : typeof body === 'string' ? body : JSON.stringify(body),
     }
     const res = await handler(new Request(url, init))
@@ -131,6 +178,9 @@ export function featureTest(baseUrl: string = 'http://localhost'): FeatureTestCl
   const client: FeatureTestClient = {
     actingAs(user) {
       actingUser = user
+      // Drop any token minted for a previous user, or a second
+      // `actingAs()` in the same test would keep sending the first one's.
+      actingToken = null
       return client
     },
     withHeaders(headers) {

--- a/storage/framework/core/testing/tests/acting-as.test.ts
+++ b/storage/framework/core/testing/tests/acting-as.test.ts
@@ -1,0 +1,128 @@
+/**
+ * stacksjs/stacks#2228 — `featureTest().actingAs(user)` attached an
+ * `X-Test-Acting-User` header and documented that "the auth middleware checks
+ * `X-Test-Acting-User` only when APP_ENV === 'test'". No middleware ever read
+ * it; the string appeared only in the package that wrote it. So `actingAs()`
+ * was a no-op, every feature test against an `auth`-guarded route 401'd, and
+ * there was no supported way to assert an authorization outcome over HTTP.
+ *
+ * It now mints a REAL token through `Auth.loginUsingId()` and sends it as a
+ * bearer, so the request goes through the same middleware path a real client
+ * uses. Teaching the middleware the sentinel instead would have put an
+ * authenticate-as-anyone header in production code, one misconfigured env var
+ * from being a full auth bypass.
+ *
+ * `@stacksjs/auth` and `@stacksjs/router` are mocked so this exercises the
+ * header contract without booting the ORM or a server.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// `mock.module` is process-wide and bun does not restore it between test
+// files, so capture the real namespaces and put them back in afterAll. The
+// spread matters: mocking patches the live namespace in place, so a bare
+// capture would "restore" the mock itself.
+const realRouter = { ...await import('@stacksjs/router') }
+
+afterAll(() => {
+  mock.module('@stacksjs/router', () => realRouter)
+})
+
+/** Every request the mocked server saw, in order. */
+const seen: Request[] = []
+let mintedFor: number[] = []
+
+mock.module('@stacksjs/router', () => ({
+  ...realRouter,
+  serverResponse: async (req: Request) => {
+    seen.push(req)
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  },
+}))
+
+mock.module('@stacksjs/auth', () => ({
+  Auth: {
+    loginUsingId: async (id: number) => {
+      mintedFor.push(id)
+      // `null` is the "no such user" contract loginUsingId already has.
+      if (id === 404)
+        return null
+      return { user: { id }, token: `tok_for_${id}`, refreshToken: `refresh_${id}`, expiresIn: 3600 }
+    },
+  },
+}))
+
+const { featureTest } = await import('../src/feature')
+
+beforeEach(() => {
+  seen.length = 0
+  mintedFor = []
+})
+
+const lastHeader = (name: string): string | null => seen.at(-1)!.headers.get(name)
+
+describe('featureTest().actingAs() (#2228)', () => {
+  test('sends a real bearer token, not the sentinel header', async () => {
+    await featureTest().actingAs({ id: 7 }).get('/api/sites')
+
+    expect(lastHeader('Authorization')).toBe('Bearer tok_for_7')
+    // The regression: this is what it used to send instead, and nothing read it.
+    expect(lastHeader('X-Test-Acting-User')).toBeNull()
+    expect(mintedFor).toEqual([7])
+  })
+
+  test('sends no Authorization header when acting as nobody', async () => {
+    await featureTest().get('/api/sites')
+
+    expect(lastHeader('Authorization')).toBeNull()
+    // A test that never authenticates must not pay for booting auth.
+    expect(mintedFor).toEqual([])
+  })
+
+  test('mints once and reuses across requests', async () => {
+    const client = featureTest().actingAs({ id: 7 })
+    await client.get('/api/sites')
+    await client.get('/api/sites/1')
+    await client.post('/api/sites', { name: 'x' })
+
+    expect(mintedFor).toEqual([7])
+    expect(seen).toHaveLength(3)
+    expect(seen.every(r => r.headers.get('Authorization') === 'Bearer tok_for_7')).toBe(true)
+  })
+
+  test('re-mints when switching user, so the first token is not reused', async () => {
+    const client = featureTest().actingAs({ id: 7 })
+    await client.get('/api/sites')
+    client.actingAs({ id: 9 })
+    await client.get('/api/sites')
+
+    expect(mintedFor).toEqual([7, 9])
+    expect(lastHeader('Authorization')).toBe('Bearer tok_for_9')
+  })
+
+  test('an explicit Authorization header wins over the acting user', async () => {
+    // A test passing its own token is deliberately exercising that token.
+    await featureTest()
+      .actingAs({ id: 7 })
+      .withHeaders({ Authorization: 'Bearer handmade' })
+      .get('/api/sites')
+
+    expect(lastHeader('Authorization')).toBe('Bearer handmade')
+  })
+
+  test('a user that cannot be authenticated fails loudly', async () => {
+    // Silently sending no token would resurface as a confusing 401 on the
+    // assertion instead of naming the actual cause.
+    await expect(featureTest().actingAs({ id: 404 }).get('/api/sites'))
+      .rejects.toThrow(/could not authenticate user 404/)
+  })
+
+  test('a non-numeric id is rejected before any token is minted', async () => {
+    await expect(featureTest().actingAs({ id: 'abc' }).get('/api/sites'))
+      .rejects.toThrow(/numeric id/)
+    expect(mintedFor).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #2228.

## The bug

```ts
// core/testing/src/feature.ts
// The auth middleware checks `X-Test-Acting-User` only when APP_ENV === 'test'.
headers['X-Test-Acting-User'] = JSON.stringify(actingUser)
```

No middleware has ever read that header. `grep -rn X-Test-Acting-User storage/` returns exactly the two lines that write it. So `actingAs()` was a no-op and every feature test against an `auth`-guarded route got a 401 regardless of the user passed in.

That leaves **no supported way to assert an authorization outcome over HTTP**, and it shows in what apps do instead. analyticshq's headline invariant is that 18 site-scoped endpoints are owner-gated; with no working `actingAs()`, its authz test asserts against the route file *as a string*:

```ts
const analytics = readFileSync(join(import.meta.dir, '../../routes/analytics.ts'), 'utf8')
expect(block).toContain('requireSiteOwner(request, siteId)')
```

Across its whole `tests/` tree there is not one HTTP request and not one database row. Those tests pass whether or not the gate works.

## Why not just teach the middleware the sentinel

That was the obvious fix and I think it is the wrong one:

- It puts an **authenticate-as-any-user header into production code**, gated only on an env var. `APP_ENV=test` reaching a reachable environment turns it into a full auth bypass. That is a bad trade for test ergonomics.
- Feature tests would then exercise a code path that exists only for tests, which is the opposite of the point.

## The fix

`actingAs()` mints a **real** token through `Auth.loginUsingId()` and sends it as `Authorization: Bearer`. The request goes through the same bearer path a real client uses, so the test covers the middleware it is meant to cover, and no test-only branch exists in the auth middleware at all.

Details worth knowing:
- minted **once per client**, reused across requests, re-minted when the acting user changes (otherwise a second `actingAs()` in one test keeps sending the first user's token — a silently wrong pass)
- an explicit `withHeaders({ Authorization })` **wins**, since a test supplying its own token is deliberately exercising that token
- a user that cannot be authenticated **raises**, naming the id, rather than silently sending nothing and resurfacing as a confusing 401 on the assertion
- `@stacksjs/auth` is imported lazily so a test that never calls `actingAs()` does not pay for booting auth and the ORM; declared as a real dependency since it is now a runtime import

## Tests

`storage/framework/core/testing/tests/acting-as.test.ts`, 7 pass. `@stacksjs/auth` and `@stacksjs/router` are mocked, so this pins the header contract without a DB or a server:

- sends `Bearer`, and asserts `X-Test-Acting-User` is **absent** — the regression itself
- no `Authorization` and no mint at all when acting as nobody
- mints once across three requests
- re-mints on user switch, and the second request carries the second token
- explicit `Authorization` wins
- unauthenticatable user raises with the id in the message
- non-numeric id rejected before any mint

`core/testing`: 28 pass, 0 fail. Lint clean, typecheck adds no errors.

## Follow-on

Apps that worked around this — asserting against route source text — can now port those to real HTTP requests. Worth mentioning in the release notes, since a passing string-assertion test is exactly the kind that hides a regression.