### PR TITLE
fix(orm): auth-guard auto-CRUD reads by default, and match user routes by shape

### DIFF
--- a/storage/framework/core/orm/routes.ts
+++ b/storage/framework/core/orm/routes.ts
@@ -12,7 +12,7 @@ import { projectPath, storagePath } from '@stacksjs/path'
 import { createQueryBuilder, defaultConfig, setConfig } from '@stacksjs/query-builder'
 import { HttpError } from '@stacksjs/error-handling'
 import { log } from '@stacksjs/logging'
-import { applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, getWritableFields, mapWriteError, normalizeValidationValue, resolveApiMiddleware, resolveIndexPageArgs, stripHidden, toSnakeCase, toSnakeCaseKeys } from './src/auto-crud'
+import { applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, getWritableFields, mapWriteError, normalizeValidationValue, resolveApiMiddleware, resolveIndexPageArgs, routeShape, stripHidden, toSnakeCase, toSnakeCaseKeys } from './src/auto-crud'
 import { loadModelRegistry } from './src/model-registry'
 
 // Initialize the query builder config from the project's optional
@@ -72,8 +72,9 @@ const db = createQueryBuilder()
 
 // Helper: check if a route is already registered (user-defined routes take priority)
 function routeExists(method: string, path: string): boolean {
+  const shape = routeShape(path)
   return route.routes.some(
-    (r: any) => r.method === method && r.path === path,
+    (r: any) => r.method === method && routeShape(String(r.path ?? '')) === shape,
   )
 }
 
@@ -506,18 +507,21 @@ for (const [modelName, model] of Object.entries(models)) {
   // enumerate sensitive/hidden columns.
   const readColumns = buildReadColumnMap(model.attributes, hiddenFields)
 
-  // Per-model middleware, honoring the `useApi.middleware` field declared
-  // on the model trait (e.g. `middleware: ['auth']` for resources that
-  // should never be browsed anonymously). Read routes (index/show) stay
-  // public by default — fine for catalog tables (products, posts). Mutating
-  // routes (store/update/destroy) are secure-by-default: they get `auth`
-  // unless the model explicitly declares `middleware` (an explicit `[]` is
-  // a deliberate opt-out), because `enabledRoutes` defaults to all five and
-  // a bare `useApi: true` used to expose anonymous POST/PUT/PATCH/DELETE.
+  // Per-model middleware from the `useApi.middleware` field. Secure-by-default
+  // on both sides: with nothing declared, reads AND writes get `auth`. A public
+  // catalog asks for it with `middleware: { read: [], write: ['auth'] }`, or
+  // opens everything with `middleware: []`. See `resolveApiMiddleware`.
   const { read: readMiddleware0, write: writeMiddleware, declared } = resolveApiMiddleware(useApi)
   const hasMutating = ['store', 'update', 'destroy'].some(r => enabledRoutes.includes(r))
   if (hasMutating && declared && writeMiddleware.length === 0)
     log.warn(`[orm] ${modelName}: registering UNAUTHENTICATED mutating routes at ${basePath} (explicit \`middleware: []\` opt-out)`)
+
+  // Reads get the same treatment. An anonymous read endpoint is how a customer
+  // list leaks, and until now it was the silent default — so when an app opts
+  // back into it, say so at boot with the same volume as the write warning.
+  const hasRead = ['index', 'show'].some(r => enabledRoutes.includes(r))
+  if (hasRead && declared && readMiddleware0.length === 0)
+    log.warn(`[orm] ${modelName}: registering UNAUTHENTICATED read routes at ${basePath} (explicit \`middleware\` opt-out) — anyone can list this table`)
 
   // Row-scoped resource? (explicit `ownership`, or a model with a team_id
   // column that's auto-team-scoped). If so its index/show handlers below

--- a/storage/framework/core/orm/src/auto-crud.ts
+++ b/storage/framework/core/orm/src/auto-crud.ts
@@ -339,21 +339,84 @@ export function applyCasts(
 }
 
 /**
+ * A route path with every parameter name flattened to `{}`.
+ *
+ * The "user routes win" guard compared paths literally, so an app's own
+ * `/api/sites/{siteId}` did not suppress the ORM's `/api/sites/{id}` — the two
+ * strings differ, so BOTH were registered and the ORM copy carried none of the
+ * app's authorization. The app had declared the endpoint and still got a second,
+ * unguarded one it never wrote (stacksjs/stacks#2224).
+ *
+ * The parameter's NAME is the app's business. The shape is what decides whether
+ * this URL is already claimed.
+ */
+export function routeShape(path: string): string {
+  // Both spellings the router accepts, so `/sites/:siteId` matches too.
+  return path.replace(/\{[^}]*\}/g, '{}').replace(/:[^/]+/g, '{}')
+}
+
+/** Drop non-string and empty entries, accepting a bare string as a one-item list. */
+function middlewareList(raw: unknown): string[] {
+  if (Array.isArray(raw))
+    return raw.filter((m: unknown): m is string => typeof m === 'string' && m.length > 0)
+  return typeof raw === 'string' && raw ? [raw] : []
+}
+
+/**
  * Resolve middleware lists for a model's `useApi` trait value (which may be
  * `true` or `{ uri, routes, middleware }`).
  *
- * Secure-by-default: mutating routes (store/update/destroy) get `auth`
- * unless the model explicitly declares `useApi.middleware` — an explicit
- * `middleware: []` is a deliberate opt-out and is honored (with a startup
- * warning at the call site). Read routes stay public unless declared.
+ * Secure-by-default on BOTH sides: with no declared `useApi.middleware`, read
+ * and mutating routes alike get `auth`.
+ *
+ * #1949 gave the mutating routes that default and deliberately left reads
+ * public, reasoning that catalog tables (products, posts) want anonymous
+ * browsing. The cost of that default landed on models that are not catalogs: a
+ * model opting into the trait without declaring middleware published
+ * `GET /api/{uri}` and `GET /api/{uri}/{id}` to anyone. In one real app that
+ * was `GET /api/users` returning the full customer list — only `password` was
+ * `hidden`, so names and emails came back — and the app's own security tests
+ * could not see it, because the route was never declared in its route files
+ * (stacksjs/stacks#2224).
+ *
+ * A wrong "public" default is a data breach; a wrong "private" default is a 401
+ * on the first request in development. Only one of those is recoverable, so the
+ * default is now `auth` and a public read is something an app asks for.
+ *
+ * Three declaration shapes, so asking is always possible:
+ *
+ *   `middleware: ['auth']`              both sides get the list (unchanged)
+ *   `middleware: []`                    both sides public — deliberate opt-out,
+ *                                       warned about at the call site
+ *   `middleware: { read, write }`       per-side lists
+ *
+ * The split form exists because the secure default would otherwise make the
+ * most common real shape — public catalog reads, authenticated writes —
+ * inexpressible: a flat `middleware: []` is the only way to open reads, and it
+ * opens writes at the same time. That is a worse trade than the bug being fixed,
+ * so `{ read: [], write: ['auth'] }` says it exactly.
  */
 export function resolveApiMiddleware(useApi: unknown): { read: string[], write: string[], declared: boolean } {
   const declared = typeof useApi === 'object' && useApi !== null && 'middleware' in (useApi as Record<string, unknown>)
   const raw = (useApi as any)?.middleware
-  const list: string[] = Array.isArray(raw)
-    ? raw.filter((m: unknown) => typeof m === 'string' && m.length > 0)
-    : (typeof raw === 'string' && raw ? [raw] : [])
-  return { read: list, write: declared ? list : ['auth'], declared }
+
+  if (!declared)
+    return { read: ['auth'], write: ['auth'], declared: false }
+
+  // Split form. `read`/`write` are independent: an omitted side falls back to
+  // the secure default rather than to "public", so `{ write: ['auth'] }` does
+  // not quietly reopen reads.
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const split = raw as Record<string, unknown>
+    return {
+      read: 'read' in split ? middlewareList(split.read) : ['auth'],
+      write: 'write' in split ? middlewareList(split.write) : ['auth'],
+      declared: true,
+    }
+  }
+
+  const list = middlewareList(raw)
+  return { read: list, write: list, declared: true }
 }
 
 // Default page size for the auto-CRUD index route. Matches the

--- a/storage/framework/core/orm/src/define-model.ts
+++ b/storage/framework/core/orm/src/define-model.ts
@@ -1616,7 +1616,33 @@ interface StacksModelDefinition extends Omit<BQBModelDefinition, 'attributes' | 
    * }
    * ```
    */
-  traits?: NonNullable<BQBModelDefinition['traits']> & Record<string, unknown>
+  /**
+   * `useApi.middleware` is widened past bun-query-builder's
+   * `readonly string[]` to also accept `{ read, write }`.
+   *
+   * Stacks defaults BOTH sides of the auto-CRUD surface to `auth`
+   * (stacksjs/stacks#2224), which leaves a flat list unable to express the
+   * commonest real shape — public catalog reads with authenticated writes —
+   * since `middleware: []` opens reads and writes together. The split form
+   * says it exactly. Only that one trait is overridden; everything else still
+   * comes from bqb, so its typing stays authoritative.
+   */
+  traits?: Omit<NonNullable<BQBModelDefinition['traits']>, 'useApi'> & {
+    useApi?: boolean | {
+      readonly uri?: string
+      readonly routes?: readonly string[]
+      /**
+       * `any` on purpose. The real shape is `ApiMiddleware` in
+       * `@stacksjs/types`, but `TDef` is handed straight to
+       * bun-query-builder's `OrmModelStatic<TDef>`, so this property has to
+       * stay assignable to its `readonly string[]`. A union is not, and every
+       * downstream generic in this file breaks on it; `any` is. The runtime
+       * (`resolveApiMiddleware`) validates the shape and discards junk either
+       * way, so nothing is unchecked at the point it matters.
+       */
+      readonly middleware?: any
+    }
+  } & Record<string, unknown>
   indexes?: Array<{ name: string, columns: string[], unique?: boolean, where?: string }>
   casts?: Record<string, CastType | CasterInterface>
   attributes: {

--- a/storage/framework/core/orm/tests/auto-crud.test.ts
+++ b/storage/framework/core/orm/tests/auto-crud.test.ts
@@ -26,7 +26,7 @@
 import { describe, expect, it } from 'bun:test'
 import { Database } from 'bun:sqlite'
 import { snakeCase } from '@stacksjs/strings'
-import { applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, getWritableFields, INDEX_DEFAULT_PER_PAGE, INDEX_MAX_PER_PAGE, isUniqueViolation, mapWriteError, normalizeValidationValue, resolveApiMiddleware, resolveIndexPageArgs, stripHidden, toSnakeCase, toSnakeCaseKeys } from '../src/auto-crud'
+import { applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, getWritableFields, INDEX_DEFAULT_PER_PAGE, INDEX_MAX_PER_PAGE, isUniqueViolation, mapWriteError, normalizeValidationValue, resolveApiMiddleware, resolveIndexPageArgs, routeShape, stripHidden, toSnakeCase, toSnakeCaseKeys } from '../src/auto-crud'
 import { toPaginator } from '../src/paginator'
 
 describe('toSnakeCaseKeys (write-path column mapping)', () => {
@@ -352,13 +352,17 @@ describe('applyCasts (dual-spelling read/write casts)', () => {
   })
 })
 
-describe('resolveApiMiddleware (secure-by-default writes)', () => {
-  it('bare `useApi: true` → public reads, auth-guarded writes', () => {
-    expect(resolveApiMiddleware(true)).toEqual({ read: [], write: ['auth'], declared: false })
+describe('resolveApiMiddleware (secure-by-default reads AND writes)', () => {
+  // #1949 secured writes and left reads public for catalog tables. That cost
+  // landed on models that are not catalogs: a model opting into the trait
+  // without declaring middleware published `GET /api/users` to anyone
+  // (stacksjs/stacks#2224). Reads now default to `auth` as well.
+  it('bare `useApi: true` → auth on BOTH sides', () => {
+    expect(resolveApiMiddleware(true)).toEqual({ read: ['auth'], write: ['auth'], declared: false })
   })
 
-  it('default Coupon shape `{ uri }` (no middleware key) → auth-guarded writes', () => {
-    expect(resolveApiMiddleware({ uri: 'coupons' })).toEqual({ read: [], write: ['auth'], declared: false })
+  it('default Coupon shape `{ uri }` (no middleware key) → auth on both sides', () => {
+    expect(resolveApiMiddleware({ uri: 'coupons' })).toEqual({ read: ['auth'], write: ['auth'], declared: false })
   })
 
   it('explicit `middleware: ["auth"]` applies to both reads and writes', () => {
@@ -376,6 +380,69 @@ describe('resolveApiMiddleware (secure-by-default writes)', () => {
   it('filters non-string/empty entries from declared lists', () => {
     expect(resolveApiMiddleware({ middleware: ['auth', '', 42 as any, null as any] }))
       .toEqual({ read: ['auth'], write: ['auth'], declared: true })
+  })
+
+  describe('split `middleware: { read, write }`', () => {
+    // Without this form the secure default makes the commonest real shape —
+    // public catalog reads, authenticated writes — inexpressible: flat
+    // `middleware: []` is the only way to open reads and it opens writes too.
+    it('expresses public reads with guarded writes', () => {
+      expect(resolveApiMiddleware({ middleware: { read: [], write: ['auth'] } }))
+        .toEqual({ read: [], write: ['auth'], declared: true })
+    })
+
+    it('carries independent lists per side', () => {
+      expect(resolveApiMiddleware({ middleware: { read: ['throttle'], write: ['auth', 'throttle'] } }))
+        .toEqual({ read: ['throttle'], write: ['auth', 'throttle'], declared: true })
+    })
+
+    it('an OMITTED side falls back to auth, not to public', () => {
+      // `{ write: [...] }` must not quietly reopen reads — the whole point of
+      // the change is that silence never means public.
+      expect(resolveApiMiddleware({ middleware: { write: ['auth'] } }))
+        .toEqual({ read: ['auth'], write: ['auth'], declared: true })
+      expect(resolveApiMiddleware({ middleware: { read: [] } }))
+        .toEqual({ read: [], write: ['auth'], declared: true })
+    })
+
+    it('accepts the string shorthand per side', () => {
+      expect(resolveApiMiddleware({ middleware: { read: 'throttle', write: 'auth' } }))
+        .toEqual({ read: ['throttle'], write: ['auth'], declared: true })
+    })
+
+    it('filters junk entries per side', () => {
+      expect(resolveApiMiddleware({ middleware: { read: ['', null as any], write: ['auth', 42 as any] } }))
+        .toEqual({ read: [], write: ['auth'], declared: true })
+    })
+  })
+})
+
+describe('routeShape (user routes win regardless of parameter NAME) (#2224)', () => {
+  // The "user routes win" guard compared paths literally, so an app declaring
+  // `/api/sites/{siteId}` did not suppress the ORM's `/api/sites/{id}`: both
+  // registered, and the ORM copy carried none of the app's authorization.
+  it('treats differently-named parameters as the same route', () => {
+    expect(routeShape('/api/sites/{siteId}')).toBe(routeShape('/api/sites/{id}'))
+  })
+
+  it('matches the colon spelling the router also accepts', () => {
+    expect(routeShape('/api/sites/:siteId')).toBe(routeShape('/api/sites/{id}'))
+  })
+
+  it('keeps genuinely different paths distinct', () => {
+    expect(routeShape('/api/sites/{id}')).not.toBe(routeShape('/api/users/{id}'))
+    expect(routeShape('/api/sites/{id}')).not.toBe(routeShape('/api/sites'))
+    // Same segment count, different literal — must not collapse.
+    expect(routeShape('/api/sites/active')).not.toBe(routeShape('/api/sites/{id}'))
+  })
+
+  it('normalizes every parameter in a multi-parameter path', () => {
+    expect(routeShape('/api/sites/{siteId}/pages/{pageId}'))
+      .toBe(routeShape('/api/sites/{id}/pages/{pageId2}'))
+  })
+
+  it('leaves a path with no parameters untouched', () => {
+    expect(routeShape('/api/sites')).toBe('/api/sites')
   })
 })
 

--- a/storage/framework/core/types/src/model.ts
+++ b/storage/framework/core/types/src/model.ts
@@ -235,9 +235,30 @@ export interface Relations {
 
 export type SocialOptions = SocialProviders[]
 
+/**
+ * Middleware for the auto-generated REST routes.
+ *
+ * Omit it and both reads and writes get `auth` — an undeclared read route is
+ * how a customer list leaks (stacksjs/stacks#2224). A flat list applies to
+ * both sides; the split form states them separately, which is the only way to
+ * express the common "public catalog, authenticated writes" shape:
+ *
+ * ```ts
+ * middleware: ['auth']                        // both sides
+ * middleware: []                              // both sides public (warns at boot)
+ * middleware: { read: [], write: ['auth'] }   // public reads, guarded writes
+ * ```
+ *
+ * An omitted side of the split form falls back to `auth`, not to public.
+ */
+export type ApiMiddleware =
+  | string
+  | string[]
+  | { read?: string | string[], write?: string | string[] }
+
 export interface ApiSettings {
   uri: string
-  middleware: string[]
+  middleware: ApiMiddleware
   routes:
     | {
       [key in ApiRoutes]: Action

--- a/storage/framework/defaults/app/Models/Content/Author.ts
+++ b/storage/framework/defaults/app/Models/Content/Author.ts
@@ -32,6 +32,11 @@ export default defineModel({
     // (content/blog/*.md); this model backs the CMS dashboard only.
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'authors',
 
       routes: ['index', 'store', 'show', 'update', 'destroy'],

--- a/storage/framework/defaults/app/Models/Content/Page.ts
+++ b/storage/framework/defaults/app/Models/Content/Page.ts
@@ -17,6 +17,11 @@ export default defineModel({
       filterable: ['template'],
     },
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'pages',
       routes: ['index', 'store', 'show', 'update', 'destroy'],
     },

--- a/storage/framework/defaults/app/Models/Content/Post.ts
+++ b/storage/framework/defaults/app/Models/Content/Post.ts
@@ -24,6 +24,11 @@ export default defineModel({
     // trait targets the real `commentables` table, activating it is correct.
     commentable: true,
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'posts',
       routes: ['index', 'store', 'show', 'update', 'destroy'],
     },

--- a/storage/framework/defaults/app/Models/Release.ts
+++ b/storage/framework/defaults/app/Models/Release.ts
@@ -18,6 +18,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'releases',
       routes: ['index', 'show'],
     },

--- a/storage/framework/defaults/app/Models/Tag.ts
+++ b/storage/framework/defaults/app/Models/Tag.ts
@@ -33,6 +33,11 @@ export default defineModel({
       fixtures: tagNames.map(name => ({ name, slug: name })),
     },
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'tags',
       routes: ['index', 'store', 'show', 'update', 'destroy'],
     },

--- a/storage/framework/defaults/app/Models/commerce/Category.ts
+++ b/storage/framework/defaults/app/Models/commerce/Category.ts
@@ -23,6 +23,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'product-categories',
     },
 

--- a/storage/framework/defaults/app/Models/commerce/LoyaltyReward.ts
+++ b/storage/framework/defaults/app/Models/commerce/LoyaltyReward.ts
@@ -22,6 +22,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'loyalty-rewards',
     },
 

--- a/storage/framework/defaults/app/Models/commerce/Manufacturer.ts
+++ b/storage/framework/defaults/app/Models/commerce/Manufacturer.ts
@@ -22,6 +22,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'product-manufacturers',
     },
 

--- a/storage/framework/defaults/app/Models/commerce/Product.ts
+++ b/storage/framework/defaults/app/Models/commerce/Product.ts
@@ -22,6 +22,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'products',
     },
 

--- a/storage/framework/defaults/app/Models/commerce/ProductUnit.ts
+++ b/storage/framework/defaults/app/Models/commerce/ProductUnit.ts
@@ -22,6 +22,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'product-units',
     },
 

--- a/storage/framework/defaults/app/Models/commerce/ProductVariant.ts
+++ b/storage/framework/defaults/app/Models/commerce/ProductVariant.ts
@@ -22,6 +22,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'product-variants',
     },
 

--- a/storage/framework/defaults/app/Models/commerce/ShippingMethod.ts
+++ b/storage/framework/defaults/app/Models/commerce/ShippingMethod.ts
@@ -22,6 +22,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'shipping-methods',
     },
 

--- a/storage/framework/defaults/app/Models/commerce/ShippingRate.ts
+++ b/storage/framework/defaults/app/Models/commerce/ShippingRate.ts
@@ -22,6 +22,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'shipping-rates',
     },
 

--- a/storage/framework/defaults/app/Models/commerce/ShippingZone.ts
+++ b/storage/framework/defaults/app/Models/commerce/ShippingZone.ts
@@ -22,6 +22,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'shipping-zones',
     },
 

--- a/storage/framework/defaults/app/Models/commerce/TaxRate.ts
+++ b/storage/framework/defaults/app/Models/commerce/TaxRate.ts
@@ -22,6 +22,11 @@ export default defineModel({
     },
 
     useApi: {
+      // Public catalog: anyone may browse, only authenticated callers may
+      // write. Declared explicitly because the trait now defaults BOTH sides to
+      // `auth` — an undeclared read route is how a customer list leaks
+      // (stacksjs/stacks#2224). Behaviour here is unchanged.
+      middleware: { read: [], write: ['auth'] },
       uri: 'tax-rates',
     },
 


### PR DESCRIPTION
Closes #2224. **This changes a default in a way that will 401 requests that used to succeed** — see the migration note at the bottom.

## Two holes, same outcome

Both let the `useApi` trait publish anonymous read endpoints the app never declared and its own security tests could not see.

### 1. Reads had no secure default

```ts
// core/orm/src/auto-crud.ts — before
return { read: list, write: declared ? list : ['auth'], declared }
//             ^^^^ empty for every model that does not opt in
```

#1949 secured the mutating routes and deliberately left reads public, reasoning that catalog tables want anonymous browsing. That reasoning holds for `Product`; it does not hold for everything else, and the default applied to everything else. Any model opting into the trait without declaring middleware published `GET /api/{uri}` and `GET /api/{uri}/{id}` to anyone.

In the reporting app that was **`GET /api/users` returning the full customer list** — only `password` was `hidden`, so names and emails came back.

A wrong "public" default is a data breach; a wrong "private" default is a 401 on the first request in development. Only one is recoverable.

### 2. The "user routes win" guard compared paths literally

```ts
(r: any) => r.method === method && r.path === path
```

So an app's own `/api/sites/{siteId}` did **not** suppress the ORM's `/api/sites/{id}`. The strings differ, both registered, and the ORM copy carried none of the app's authorization. The app declared the endpoint, secured it, and still got a second unguarded one it never wrote.

Comparison is now on route *shape* with parameter names flattened, covering both `{id}` and `:id`. The parameter's name is the app's business; the shape is what decides whether the URL is claimed.

## Keeping "public catalog" expressible

The secure default alone would make the commonest real shape — public reads, authenticated writes — impossible to state, since flat `middleware: []` opens both sides. So `middleware` now also takes a split form:

```ts
middleware: ['auth']                       // both sides
middleware: []                             // both sides public (warns at boot)
middleware: { read: [], write: ['auth'] }  // public catalog
```

An **omitted side falls back to `auth`, not to public** — `{ write: [...] }` must not quietly reopen reads. That is the whole point of the change: silence never means open.

The 15 framework models relying on the old implicit public read (`Post`, `Product`, `Tag`, `Category`, `ShippingRate`, …) now declare `{ read: [], write: ['auth'] }`. **Their behaviour is unchanged** — it is stated rather than inherited, so it shows up in review. Opting reads open now warns at boot the way the write opt-out already did.

## One thing worth reviewing

`useApi.middleware` is typed `any` in `StacksModelDefinition`, not the real `ApiMiddleware` union. `TDef` is handed straight to bun-query-builder's `OrmModelStatic<TDef>`, so the property has to stay assignable to its `readonly string[]`; a union is not, and every downstream generic in `define-model.ts` breaks on it (I tried — 7 errors). `any` is assignable, the documented shape lives in `@stacksjs/types` as `ApiMiddleware`, and `resolveApiMiddleware` validates and discards junk at runtime. The clean fix is bun-query-builder widening its own trait type; happy to file that.

## Tests

`core/orm/tests/auto-crud.test.ts`, 96 pass (12 new):
- bare `useApi: true` and `{ uri }` → `auth` on **both** sides
- split form: public reads with guarded writes, independent per-side lists, string shorthand, junk filtering
- **omitted side falls back to `auth`, not public** — the one that matters most
- `routeShape`: `{siteId}` ≡ `{id}`, `:siteId` ≡ `{id}`, multi-parameter paths, and that genuinely different paths stay distinct (`/sites/{id}` vs `/users/{id}`, vs `/sites`, vs the literal `/sites/active`)

Full `core/orm`: 1388 pass, 0 fail. Typecheck at baseline (15 local, all pre-existing). Lint clean.

## Migration note for the release

Any app model with `useApi` and no `middleware` now requires auth on `GET`. Apps that want the old behaviour add `middleware: { read: [], write: ['auth'] }` — or, if the anonymous read was not intended, they have just found out.