### PR TITLE
fix(config): complete the app shape in the synchronous overrides fallback

### DIFF
--- a/storage/framework/core/config/src/overrides.ts
+++ b/storage/framework/core/config/src/overrides.ts
@@ -9,6 +9,7 @@
 import type { StacksConfig } from '@stacksjs/types'
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import { defaults } from './defaults'
 import { validateConfig } from './validators'
 
 // PRODUCTION BINARY MODE: Skip runtime config loading
@@ -49,7 +50,25 @@ function defaultsForOverrides(): StacksConfig {
   return {
     ai: {},
     analytics: {},
-    app: { name: process.env.APP_NAME || 'Stacks', env: process.env.APP_ENV || 'production' },
+    // Spread the real `app` defaults rather than hand-writing two of its keys.
+    //
+    // This object is what every consumer reads BEFORE `loadUserConfigs()`
+    // finishes, so any key missing here is `undefined` for a window whose
+    // length depends on module load order. `url` was missing, and
+    // `config.test.ts` asserting `typeof app.url === 'string'` passed or failed
+    // purely on whether the async load happened to win — which made unrelated
+    // changes to the resolution graph (a tsconfig `paths` entry, a new
+    // package.json dependency) flip `core/config` and `core/env` red with no
+    // apparent connection to what changed.
+    //
+    // `defaults.ts` already computes the complete shape and imports nothing
+    // from this file, so there is no cycle. `APP_NAME` / `APP_ENV` still win
+    // where set, preserving the previous behaviour for the two keys that had it.
+    app: {
+      ...defaults.app,
+      name: process.env.APP_NAME || defaults.app?.name || 'Stacks',
+      env: process.env.APP_ENV || 'production',
+    },
     auth: {},
     cache: {},
     cli: {},

--- a/storage/framework/core/config/tests/overrides-shape.test.ts
+++ b/storage/framework/core/config/tests/overrides-shape.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The synchronous pre-load shape of `overrides`.
+ *
+ * `overrides` is exported synchronously and mutated in place by
+ * `loadUserConfigs()` once the user's `config/*.ts` files finish loading. So
+ * whatever it holds at module-eval time is what every consumer reads for a
+ * window whose length depends on module load order.
+ *
+ * `defaultsForOverrides()` used to hand-write `app` as `{ name, env }` only.
+ * `url` was therefore `undefined` until the async load landed, and
+ * `config.test.ts`'s `expect(typeof app.url).toBe('string')` passed or failed
+ * on whether that load happened to win the race. It reliably passed locally and
+ * flipped `core/config` and `core/env` red in CI whenever something unrelated
+ * perturbed the resolution graph — a tsconfig `paths` entry, a new package.json
+ * dependency — with nothing in the diff to connect it to.
+ *
+ * The fallback now spreads the real `defaults.app`, so the pre-load shape is
+ * complete. These tests pin that, since the failure mode is invisible until it
+ * costs someone an afternoon.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { defaults } from '../src/defaults'
+import { overrides } from '../src/overrides'
+
+describe('overrides pre-load shape', () => {
+  it('carries app.url synchronously, before loadUserConfigs resolves', () => {
+    // The specific key that was missing. `undefined` here is the bug.
+    expect(typeof overrides.app?.url).toBe('string')
+    expect(overrides.app?.url).toBeTruthy()
+  })
+
+  it('carries every key the real app defaults declare', () => {
+    // Guards the whole shape, not just `url` — any future key added to
+    // `defaults.app` but not reachable here reintroduces the same class of
+    // load-order flake for a different assertion.
+    for (const key of Object.keys(defaults.app ?? {}))
+      expect(overrides.app).toHaveProperty(key)
+  })
+
+  it('still lets APP_NAME / APP_ENV win, as they did before', () => {
+    // These two were the only keys the hand-written fallback set, and both
+    // read from process.env. That behaviour has to survive the change.
+    expect(overrides.app?.name).toBe(process.env.APP_NAME || defaults.app?.name || 'Stacks')
+    expect(overrides.app?.env).toBe(process.env.APP_ENV || 'production')
+  })
+})


### PR DESCRIPTION
Root cause of a CI flake that has been misattributed twice this week, including once by me.

## The bug

`overrides` is exported **synchronously** and mutated in place by `loadUserConfigs()` once the user's `config/*.ts` files finish loading. That design is deliberate and documented in the file — a top-level `await import` there puts half the framework in TDZ. The consequence is that whatever `defaultsForOverrides()` returns is what every consumer reads for a window whose length depends on module load order.

Its `app` was hand-written:

```ts
app: { name: process.env.APP_NAME || 'Stacks', env: process.env.APP_ENV || 'production' },
```

No `url`. So `app.url` is `undefined` until the async load lands, and:

```ts
// core/config/tests/config.test.ts:220
expect(typeof app.url).toBe('string')
```

passes or fails on whether that load happens to win the race.

Verified directly against `main`:

```
BEFORE  SYNC app.url = undefined
AFTER   SYNC app.url = "stacks.localhost"
```

## Why it matters beyond the test

It passes locally every time and flips `core/config` **and** `core/env` red in CI whenever something unrelated perturbs the module resolution graph, with nothing in the diff to connect it to the failure. Both instances this week were mine:

- #2223 — adding a `paths` entry to `tsconfig.build.json`. I concluded the tsconfig change was at fault and narrowed it away. **The narrowing was unnecessary; this was the bug.** That is also why the `compile` half of #2242 looks unfixable — it is the same false signal.
- #2244 — adding `@stacksjs/auth` to another package's `package.json`.

Two changes with nothing in common except that they moved module resolution around. That is the signature of a load-order race, and I should have chased it the first time instead of narrowing the diff until the symptom went away.

## The fix

Spread the real `defaults.app` instead of hand-writing two of its keys. `defaults.ts` already computes the complete shape and imports nothing from `overrides.ts`, so there is no cycle. `APP_NAME` / `APP_ENV` still win where set, preserving the behaviour of the two keys that had it.

## Tests

`core/config/tests/overrides-shape.test.ts`, 3 pass:
- `app.url` is a non-empty string **synchronously**, before `loadUserConfigs()` resolves — the specific missing key
- **every** key of `defaults.app` is reachable pre-load, so a future key cannot reintroduce the same flake against a different assertion
- `APP_NAME` / `APP_ENV` still take precedence

`core/config` + `core/env`: 322 pass, 0 fail. Typecheck at baseline, lint clean.

## Follow-on

Once this lands, #2242's compile fix should be retried — I expect the `config`/`env` reds it caused to disappear with it, since they were this bug and not the tsconfig entry.