### PR TITLE
fix(orm): enforce declared validation rules on direct model writes

### DIFF
--- a/storage/framework/core/orm/routes.ts
+++ b/storage/framework/core/orm/routes.ts
@@ -12,7 +12,7 @@ import { projectPath, storagePath } from '@stacksjs/path'
 import { createQueryBuilder, defaultConfig, setConfig } from '@stacksjs/query-builder'
 import { HttpError } from '@stacksjs/error-handling'
 import { log } from '@stacksjs/logging'
-import { applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, getWritableFields, mapWriteError, normalizeValidationValue, resolveApiMiddleware, resolveIndexPageArgs, routeShape, stripHidden, toSnakeCase, toSnakeCaseKeys } from './src/auto-crud'
+import { applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, getWritableFields, mapWriteError, normalizeValidationValue, resolveApiMiddleware, resolveIndexPageArgs, routeShape, stripHidden, toSnakeCase, toSnakeCaseKeys, validateWriteBody } from './src/auto-crud'
 import { loadModelRegistry } from './src/model-registry'
 
 // Initialize the query builder config from the project's optional
@@ -84,39 +84,6 @@ function getHiddenFields(model: any): string[] {
   return Object.entries(model.attributes)
     .filter(([_, attr]: [string, any]) => attr.hidden === true)
     .map(([name]: [string, any]) => name)
-}
-
-// Run each declared `validation.rule` against an incoming write payload.
-// Returns { valid: true } or { valid: false, errors }. Per-attribute custom
-// messages from `validation.message` override the rule's default text.
-//
-// Skips fields the caller never sent on PATCH requests so a partial update
-// doesn't trip a "required" rule on a sibling field that wasn't touched.
-// eslint-disable-next-line pickier/no-unused-vars
-function validateWriteBody(
-  _data: Record<string, any>,
-  _model: any,
-  _hook: 'creating' | 'updating',
-): { valid: true } | { valid: false, errors: Record<string, string[]> } {
-  const data = _data
-  const model = _model
-  const hook = _hook
-  const attrs = model?.attributes ?? {}
-  const errors: Record<string, string[]> = {}
-  for (const [field, def] of Object.entries(attrs as Record<string, any>)) {
-    const rule: any = def?.validation?.rule
-    if (!rule || typeof rule.validate !== 'function') continue
-    const present = Object.prototype.hasOwnProperty.call(data, field)
-    if (!present && hook === 'updating') continue
-    const value = normalizeValidationValue(rule, present ? data[field] : undefined)
-    const result = rule.validate(value)
-    if (!result?.valid && Array.isArray(result?.errors) && result.errors.length > 0) {
-      errors[field] = result.errors.map((e: any) =>
-        def?.validation?.message?.[e?.code] ?? e?.message ?? 'invalid',
-      )
-    }
-  }
-  return Object.keys(errors).length === 0 ? { valid: true } : { valid: false, errors }
 }
 
 // Naive English pluralization for hasMany relation names. Matches

--- a/storage/framework/core/orm/src/auto-crud.ts
+++ b/storage/framework/core/orm/src/auto-crud.ts
@@ -339,6 +339,50 @@ export function applyCasts(
 }
 
 /**
+ * Run each declared `validation.rule` against a write payload.
+ *
+ * Returns `{ valid: true }` or `{ valid: false, errors }`. Per-attribute custom
+ * messages from `validation.message` override the rule's default text.
+ *
+ * Fields the caller never sent are skipped on the `updating` hook, so a partial
+ * update does not trip a `required` rule on a sibling field it never touched.
+ *
+ * Lives here rather than in `../routes.ts` so BOTH write paths can reach it.
+ * It used to be a local function in that module, which meant the declared rules
+ * ran on the generated REST routes and nowhere else: `Model.create()`,
+ * `.update()` and `.save()` went straight to the driver, and an over-length
+ * value first got noticed by Postgres as a 22001, surfacing as a 500 on
+ * whichever endpoint performed the write (stacksjs/stacks#2233). Importing it
+ * from `routes.ts` was not an option — that module registers routes on import.
+ */
+export type WriteValidationResult =
+  | { valid: true }
+  | { valid: false, errors: Record<string, string[]> }
+
+export function validateWriteBody(
+  data: Record<string, any>,
+  model: any,
+  hook: 'creating' | 'updating',
+): WriteValidationResult {
+  const attrs = model?.attributes ?? {}
+  const errors: Record<string, string[]> = {}
+  for (const [field, def] of Object.entries(attrs as Record<string, any>)) {
+    const rule: any = def?.validation?.rule
+    if (!rule || typeof rule.validate !== 'function') continue
+    const present = Object.prototype.hasOwnProperty.call(data, field)
+    if (!present && hook === 'updating') continue
+    const value = normalizeValidationValue(rule, present ? data[field] : undefined)
+    const result = rule.validate(value)
+    if (!result?.valid && Array.isArray(result?.errors) && result.errors.length > 0) {
+      errors[field] = result.errors.map((e: any) =>
+        def?.validation?.message?.[e?.code] ?? e?.message ?? 'invalid',
+      )
+    }
+  }
+  return Object.keys(errors).length === 0 ? { valid: true } : { valid: false, errors }
+}
+
+/**
  * A route path with every parameter name flattened to `{}`.
  *
  * The "user routes win" guard compared paths literally, so an app's own

--- a/storage/framework/core/orm/src/define-model.ts
+++ b/storage/framework/core/orm/src/define-model.ts
@@ -6,6 +6,7 @@ import { snakeCase } from '@stacksjs/strings'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { toCursorPaginator, toPaginator, toSimplePaginator } from './paginator'
 import { enrichPaginatorUrls, resolveCursorArgs, resolvePageArgs } from './paginator-request'
+import { validateWriteBody } from './auto-crud'
 
 /**
  * Event-suppression scope. When the current async context's store reports
@@ -39,6 +40,57 @@ function eventsAreSuppressed(): boolean {
  */
 export function withoutEvents<T>(fn: () => T | Promise<T>): Promise<T> {
   return Promise.resolve(eventSuppression.run({ suppressed: true }, fn as () => Promise<T>))
+}
+
+/**
+ * Validation-suppression scope, the same shape as {@link withoutEvents}.
+ *
+ * Declared `validation.rule`s run on every direct write. A bulk import or a
+ * backfill sometimes needs to land rows that predate a rule, so this is the
+ * escape hatch — deliberately an explicit scope rather than a per-call
+ * `{ validate: false }`, so skipping validation is a visible decision about a
+ * block of code rather than an option buried in one call site.
+ */
+const validationSuppression = new AsyncLocalStorage<{ suppressed: boolean }>()
+
+function validationIsSuppressed(): boolean {
+  return validationSuppression.getStore()?.suppressed === true
+}
+
+/**
+ * Run a callback with model validation suppressed for its entire duration.
+ *
+ * @example
+ * ```ts
+ * await User.withoutValidation(async () => {
+ *   for (const row of legacyRows) await User.create(row) // rules do not run
+ * })
+ * ```
+ */
+export function withoutValidation<T>(fn: () => T | Promise<T>): Promise<T> {
+  return Promise.resolve(validationSuppression.run({ suppressed: true }, fn as () => Promise<T>))
+}
+
+/**
+ * Thrown when a direct write fails a declared `validation.rule`.
+ *
+ * Carries `status = 422` and a per-field `errors` map, matching the shape the
+ * generated REST routes already return, so a handler that catches this can
+ * respond with the same body it would have produced through auto-CRUD. It is
+ * duck-typed by `mapWriteError`, which preserves any integer `status` in
+ * 400-599 — so an over-length value now surfaces as a 422 instead of the
+ * driver's raw 22001 becoming a 500 (stacksjs/stacks#2233).
+ */
+export class ModelValidationError extends Error {
+  readonly status = 422
+  readonly errors: Record<string, string[]>
+
+  constructor(modelName: string, errors: Record<string, string[]>) {
+    const fields = Object.keys(errors).join(', ')
+    super(`${modelName} validation failed: ${fields}`)
+    this.name = 'ModelValidationError'
+    this.errors = errors
+  }
 }
 
 // Extended model definition that provides proper contextual typing for factory callbacks.
@@ -1554,6 +1606,60 @@ function wrapWritesWithMassAssignment(baseModel: Record<string, unknown>, defini
   }
 }
 
+/**
+ * Enforce declared `validation.rule`s on every direct write.
+ *
+ * The rules were only ever run by the generated REST routes
+ * (`routes.ts` → `validateWriteBody`). The direct model API — `create`,
+ * `update`, `save`, `firstOrCreate`, `updateOrCreate` — went through
+ * mass-assignment filtering and casts but never touched the declared rules, so
+ * the same model got no width, type or enum enforcement when written from code
+ * rather than over HTTP. The database was the first thing to notice, and on
+ * Postgres an over-length varchar is a hard 22001 that surfaces as a 500 on
+ * whichever endpoint performed the write (stacksjs/stacks#2233).
+ *
+ * Applied LAST in `defineModel`'s wrapper chain, which makes it the OUTERMOST
+ * wrapper and therefore the first to run. That is deliberate: `validateWriteBody`
+ * (and its `normalizeValidationValue`) is written against pre-cast input — an
+ * ISO date string, not a `Date` — because the REST path validates the raw JSON
+ * body. Validating after the cast wrapper would hand the rules values they were
+ * never designed to see.
+ *
+ * `create` validates with the `creating` hook (absent fields are missing
+ * values); `update` with `updating`, which skips fields the caller did not
+ * send, so a partial update cannot trip a `required` rule on an untouched
+ * sibling. `firstOrCreate` / `updateOrCreate` inherit it through the `create`
+ * they call internally.
+ */
+function wrapWritesWithValidation(baseModel: Record<string, unknown>, definition: BQBModelDefinition): void {
+  const modelName = String((definition as any)?.name ?? baseModel.name ?? 'Model')
+
+  const check = (data: unknown, hook: 'creating' | 'updating'): void => {
+    if (validationIsSuppressed()) return
+    if (!data || typeof data !== 'object' || Array.isArray(data)) return
+    const result = validateWriteBody(data as Record<string, any>, definition, hook)
+    if (!result.valid)
+      throw new ModelValidationError(modelName, result.errors)
+  }
+
+  const origCreate = baseModel.create
+  if (typeof origCreate === 'function') {
+    baseModel.create = async function (this: unknown, data: Record<string, unknown>, ...rest: unknown[]) {
+      check(data, 'creating')
+      return await (origCreate as Function).call(this, data, ...rest)
+    }
+  }
+
+  // `update(id, data)` — the id is the first argument here, unlike `create`.
+  const origUpdate = baseModel.update
+  if (typeof origUpdate === 'function') {
+    baseModel.update = async function (this: unknown, id: unknown, data: Record<string, unknown>, ...rest: unknown[]) {
+      check(data, 'updating')
+      return await (origUpdate as Function).call(this, id, data, ...rest)
+    }
+  }
+}
+
 function wrapQueryMethodsWithCasts(baseModel: Record<string, unknown>, casts: Record<string, CastType | CasterInterface>) {
   // Read-side casts are handled inside `wrapModelInstance` so the proxy
   // (and its `toJSON`/`update`/etc. methods) survives. Wrapping reads here
@@ -1716,6 +1822,8 @@ export type StacksModelStatic<TDef extends ModelDefinition> = OrmModelStatic<TDe
   forceCreate: (data: Record<string, unknown>) => ReturnType<OrmModelStatic<TDef>['create']>
   delete: (id: number | string) => Promise<boolean>
   withoutEvents: <T>(fn: () => T | Promise<T>) => Promise<T>
+  /** Run `fn` with declared `validation.rule`s suppressed (bulk imports, backfills). */
+  withoutValidation: <T>(fn: () => T | Promise<T>) => Promise<T>
 }
 
 export function defineModel<const TDef extends ModelDefinition>(definition: TDef): StacksModelStatic<TDef> {
@@ -1805,6 +1913,25 @@ export function defineModel<const TDef extends ModelDefinition>(definition: TDef
   if (useAuditDecl) {
     const auditOpts = resolveAuditOptions(useAuditDecl)
     applyAudit(baseModel, definition.name, definition.primaryKey || 'id', auditOpts)
+  }
+
+  // Declared `validation.rule`s, enforced on direct writes (#2233). Applied
+  // last of the write wrappers so it is the OUTERMOST one and runs first,
+  // against the caller's pre-cast, pre-encryption input — which is what
+  // `validateWriteBody` is written for, since the REST path validates a raw
+  // JSON body.
+  //
+  // It has to come BEFORE the `*Quietly` loop below: that loop captures
+  // whichever `create`/`update` exists when it runs, so applying validation
+  // afterwards would leave `createQuietly` unvalidated. Quiet means "no
+  // events", never "no rules".
+  wrapWritesWithValidation(baseModel, defWithHooks as BQBModelDefinition)
+
+  // `Model.withoutValidation(fn)` — the escape hatch for bulk imports and
+  // backfills carrying rows that predate a rule. Bound to the model for the
+  // same discoverability reason as `withoutEvents`.
+  ;(baseModel as any).withoutValidation = function <T>(fn: () => T | Promise<T>): Promise<T> {
+    return withoutValidation(fn)
   }
 
   // Static-level event suppression helpers. `Model.withoutEvents(fn)`

--- a/storage/framework/core/orm/tests/model-validation.test.ts
+++ b/storage/framework/core/orm/tests/model-validation.test.ts
@@ -1,0 +1,178 @@
+/**
+ * stacksjs/stacks#2233 — declared `validation.rule`s ran on the generated REST
+ * routes and nowhere else. `Model.create()` / `.update()` went through
+ * mass-assignment filtering and casts but never touched the rules, so the same
+ * model got no width, type or enum enforcement when written from code rather
+ * than over HTTP, and the database was the first thing to notice. On Postgres
+ * an over-length varchar insert is a hard 22001, which surfaces as a 500 on
+ * whichever endpoint performed the write.
+ *
+ * These cover the enforcement wrapper directly against a stub model, so no
+ * database or live ORM boot is involved.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { schema } from '@stacksjs/validation'
+import { validateWriteBody } from '../src/auto-crud'
+import { defineModel } from '../src/define-model'
+
+const model = {
+  name: 'PageView',
+  attributes: {
+    path: { fillable: true, validation: { rule: schema.string().max(255) } },
+    country: { fillable: true, validation: { rule: schema.string().max(2) } },
+    title: { fillable: true, validation: { rule: schema.string().max(255) } },
+  },
+}
+
+describe('validateWriteBody on the direct write path (#2233)', () => {
+  it('rejects a value wider than the declared column', () => {
+    // The exact failure from the report: an over-length path reaching the
+    // page_views insert, where Postgres answers 22001 and the beacon 500s.
+    const result = validateWriteBody({ path: 'x'.repeat(256) }, model, 'creating')
+
+    expect(result.valid).toBe(false)
+    if (!result.valid)
+      expect(Object.keys(result.errors)).toContain('path')
+  })
+
+  it('accepts a value at exactly the declared width', () => {
+    expect(validateWriteBody({ path: 'x'.repeat(255) }, model, 'creating').valid).toBe(true)
+  })
+
+  it('checks every declared attribute, not just the first', () => {
+    const result = validateWriteBody({ path: 'ok', country: 'TOO_LONG' }, model, 'creating')
+
+    expect(result.valid).toBe(false)
+    if (!result.valid)
+      expect(Object.keys(result.errors)).toEqual(['country'])
+  })
+
+  describe('partial-update semantics', () => {
+    it('skips fields the caller did not send on update', () => {
+      // A partial update must not trip a rule on an untouched sibling —
+      // otherwise every `.update()` would have to resend the whole row.
+      expect(validateWriteBody({ path: 'ok' }, model, 'updating').valid).toBe(true)
+    })
+
+    it('still checks the fields the caller DID send on update', () => {
+      expect(validateWriteBody({ country: 'TOO_LONG' }, model, 'updating').valid).toBe(false)
+    })
+
+    it('does not skip absent fields on create', () => {
+      // `creating` evaluates absent fields as missing values, which is how a
+      // `required` rule can fire at all.
+      const required = {
+        name: 'Site',
+        attributes: { domain: { fillable: true, validation: { rule: schema.string().required() } } },
+      }
+      expect(validateWriteBody({}, required, 'updating').valid).toBe(true)
+      expect(validateWriteBody({}, required, 'creating').valid).toBe(false)
+    })
+  })
+
+  it('is a no-op for a model that declares no rules', () => {
+    expect(validateWriteBody({ anything: 1 }, { name: 'Bare', attributes: { a: { fillable: true } } }, 'creating').valid)
+      .toBe(true)
+    expect(validateWriteBody({ x: 1 }, { name: 'Empty' }, 'creating').valid).toBe(true)
+  })
+})
+
+describe('ModelValidationError shape', () => {
+  it('carries a 422 and a per-field errors map', async () => {
+    // Duck-typed by `mapWriteError`, which preserves any integer `status` in
+    // 400-599 — so this surfaces as a 422 rather than the driver error's 500.
+    const { ModelValidationError } = await import('../src/define-model')
+    const err = new ModelValidationError('PageView', { path: ['too long'] })
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err.status).toBe(422)
+    expect(err.errors).toEqual({ path: ['too long'] })
+    expect(err.message).toContain('PageView')
+    expect(err.message).toContain('path')
+  })
+
+  it('maps to a 422 through the auto-CRUD write-error mapper', async () => {
+    const { mapWriteError } = await import('../src/auto-crud')
+    const { ModelValidationError } = await import('../src/define-model')
+
+    const mapped = mapWriteError(new ModelValidationError('PageView', { path: ['too long'] }), 'PageView', 'create')
+
+    expect(mapped.status).toBe(422)
+  })
+})
+
+describe('a real defineModel enforces its rules on create/update', () => {
+  // The assertion that actually matters: the helper above being correct means
+  // nothing unless `defineModel`'s wrapper chain calls it. No database is
+  // touched — validation runs before any driver call, which is the point.
+  const Probe: any = defineModel({
+    name: 'ProbeView',
+    table: 'probe_views',
+    attributes: {
+      path: { fillable: true, validation: { rule: schema.string().max(10) } },
+    },
+  } as any)
+
+  it('create() throws a 422-shaped ModelValidationError instead of reaching the driver', async () => {
+    const err = await Probe.create({ path: 'x'.repeat(50) }).then(() => null, (e: any) => e)
+
+    expect(err).not.toBeNull()
+    expect(err.name).toBe('ModelValidationError')
+    expect(err.status).toBe(422)
+    expect(Object.keys(err.errors)).toEqual(['path'])
+  })
+
+  it('update() throws for a field the caller did send', async () => {
+    const err = await Probe.update(1, { path: 'x'.repeat(50) }).then(() => null, (e: any) => e)
+
+    expect(err).not.toBeNull()
+    expect(err.name).toBe('ModelValidationError')
+  })
+
+  it('exposes withoutValidation on the model', () => {
+    expect(typeof Probe.withoutValidation).toBe('function')
+  })
+
+  it('withoutValidation actually lets the over-length write through', async () => {
+    // Proves the wrapper consults the suppression scope, not merely that the
+    // scope exists. It gets past validation and then fails at the driver (no
+    // table here) — a DIFFERENT error, which is exactly the evidence wanted.
+    const err = await Probe.withoutValidation(() => Probe.create({ path: 'x'.repeat(50) }))
+      .then(() => null, (e: any) => e)
+
+    expect(err?.name).not.toBe('ModelValidationError')
+  })
+
+  it('createQuietly is validated too — quiet means no events, not no rules', async () => {
+    // The `*Quietly` helpers capture whichever `create` exists when they are
+    // installed, so this fails if the validation wrapper is applied after them.
+    const err = await Probe.createQuietly({ path: 'x'.repeat(50) }).then(() => null, (e: any) => e)
+
+    expect(err).not.toBeNull()
+    expect(err.name).toBe('ModelValidationError')
+  })
+})
+
+describe('withoutValidation escape hatch', () => {
+  it('suppresses rules for the duration of the callback, then restores', async () => {
+    const { withoutValidation } = await import('../src/define-model')
+    const seen: boolean[] = []
+
+    // The scope is AsyncLocalStorage-backed, so nested awaits inherit it and
+    // the surrounding code is unaffected once it returns.
+    await withoutValidation(async () => {
+      await Promise.resolve()
+      seen.push(true)
+    })
+
+    expect(seen).toEqual([true])
+    // Rules still evaluate normally outside the scope.
+    expect(validateWriteBody({ path: 'x'.repeat(256) }, model, 'creating').valid).toBe(false)
+  })
+
+  it('returns the callback result', async () => {
+    const { withoutValidation } = await import('../src/define-model')
+    expect(await withoutValidation(async () => 'done')).toBe('done')
+  })
+})


### PR DESCRIPTION
Closes #2233.

## The bug

Every attribute can declare `validation.rule`. The generated REST routes run them (`routes.ts:827`, `:901`). The **direct** model API never did — `create`, `update`, `save` go through mass-assignment filtering and casts and stop there.

So the same model gets no width, type or enum enforcement when written from code rather than over HTTP, and the database is the first thing to notice. On Postgres an over-length varchar is a hard 22001, which surfaces as a 500 on whichever endpoint performed the write.

The consequence in the reporting app: `PageView` declares `.max(255)` on its path/referrer/title columns and `.max(2)` on country, and the ingest route re-derives every one of those widths by hand — the exact duplication the declaration exists to remove.

## The fix

`validateWriteBody` moves from `routes.ts` into `src/auto-crud.ts` so both paths share one implementation. (Importing it from `routes.ts` was never an option — that module registers routes on import.)

A `wrapWritesWithValidation` wrapper enforces it on `create` and `update`; `firstOrCreate` / `updateOrCreate` inherit it through the `create` they call internally.

Two ordering details that are load-bearing:

- **Applied last in the chain**, making it outermost and first to run. `validateWriteBody` and its `normalizeValidationValue` are written against **pre-cast** input — an ISO date string, not a `Date` — because the REST path validates a raw JSON body. Validating after the cast wrapper would hand the rules values they were never designed to see.
- **Applied before the `*Quietly` loop**, which captures whichever `create` exists when it runs. Applying validation after it would leave `createQuietly` unvalidated. Quiet means no events, never no rules. There is a test for exactly this.

Partial-update semantics are unchanged: `update` uses the `updating` hook, which skips fields the caller did not send, so a partial write cannot trip a `required` rule on an untouched sibling.

## Error shape (the issue's ask 5, for free)

Failures throw `ModelValidationError` with `status = 422` and a per-field `errors` map matching the REST body. `mapWriteError` already preserves any integer status in 400-599, so an over-length write degrades as a 422 instead of a driver error becoming a 500. That falls out of validating *before* the driver rather than after it.

## Escape hatch (ask 3)

`Model.withoutValidation(fn)` — an explicit AsyncLocalStorage scope mirroring the existing `withoutEvents`, for bulk imports and backfills carrying rows that predate a rule. A scope rather than a per-call `{ validate: false }` so skipping rules is a visible decision about a block of code rather than an option buried in one call site.

## Not addressed

**Ask 4, a declarable `truncate` cast.** Clipping silently is a materially different contract from rejecting, and picking it for everyone is not something this change should decide. Worth its own issue.

## Tests

`core/orm/tests/model-validation.test.ts`, 16 pass. Beyond the helper-level cases, the ones that matter:

- a **real `defineModel`**: `create()` throws a 422-shaped `ModelValidationError` with the offending field, never reaching the driver
- `update()` throws for a field the caller did send
- **`createQuietly` is validated too** — fails if the wrapper is applied after the `*Quietly` loop
- **`withoutValidation` actually lets the over-length write through** — asserted by it failing with a *different* error (the driver, no table), which is the evidence that the wrapper consults the scope rather than the scope merely existing
- partial-update: absent fields skipped on `updating`, evaluated on `creating`
- no-op for models declaring no rules

`core/orm` + `core/database`: 2109 pass, 0 fail. Typecheck at baseline (15 local, pre-existing), lint clean.

Note: `WriteValidationResult` is a named type because pickier's unused-parameter analysis mis-reads a multi-line union return annotation and flags the still-used `data` — the same false positive the original code worked around with a `_data` alias and an inline disable, both now unnecessary.