### PR TITLE
feat(browser): use the refresh token useAuth already receives

### DIFF
--- a/storage/framework/core/browser/src/composables/useAuth.ts
+++ b/storage/framework/core/browser/src/composables/useAuth.ts
@@ -6,12 +6,152 @@ import { withCsrfHeader } from './csrf'
 
 const token = useStorage('token', '')
 
+/**
+ * The refresh token the server has always returned beside the access token.
+ *
+ * Until now nothing on the client read it: `refresh_token` appeared exactly
+ * once in the browser surface, as a field on a TypeScript interface. So every
+ * app on this composable had sessions that ended when the access token expired
+ * — one hour, per `config.auth.tokenExpiry` — while the server sat ready to
+ * exchange a refresh token it was never sent (stacksjs/stacks#2235).
+ */
+const refreshToken = useStorage('refresh_token', '')
+
 const stacksConfig = (globalThis as any).__STACKS_CONFIG__ || {}
 const baseUrl = stacksConfig.API_URL || (typeof window !== 'undefined' ? window.location.origin : '')
+
+/**
+ * Endpoint paths, overridable through `__STACKS_CONFIG__`.
+ *
+ * `/api/me` rather than `/me` by default: in the split views/API topology the
+ * views server forwards only `/api/**` and non-GET verbs, so a bare `GET /me`
+ * is swallowed by page routing and 404s. The old hardcoded `/me` made this
+ * composable unusable there (see #2230 for the proxy predicate itself).
+ */
+const ME_PATH: string = stacksConfig.AUTH_ME_PATH || '/api/me'
+const REFRESH_PATH: string = stacksConfig.AUTH_REFRESH_PATH || '/auth/refresh'
 
 // Create singleton state
 const user = ref<UserData | null>(null)
 const isAuthenticated = ref(false)
+
+/**
+ * The in-flight refresh, shared by every caller.
+ *
+ * Single-use rotation makes this a correctness requirement rather than a
+ * performance tweak: two concurrent 401s each exchanging the same refresh
+ * token means the second exchange presents one the server already consumed,
+ * and the session dies. Module-level so it is shared across every `useAuth()`
+ * call in the page.
+ */
+let inFlightRefresh: Promise<boolean> | null = null
+
+function clearSession(): void {
+  token.value = ''
+  refreshToken.value = ''
+  user.value = null
+  isAuthenticated.value = false
+}
+
+/**
+ * Exchange the refresh token for a new access token.
+ *
+ * Resolves `true` when the session was renewed. Resolves `false` when the
+ * server refused — the refresh token is spent, revoked or expired, and the
+ * session is over; state is cleared here.
+ *
+ * THROWS when the exchange could not be attempted at all (offline, DNS, the
+ * API being restarted). That distinction is the whole point: treating an
+ * unreachable server as a refusal signs out working users on a network blip.
+ * Callers catch it and keep the session.
+ */
+async function performRefresh(): Promise<boolean> {
+  if (!refreshToken.value)
+    return false
+
+  const response = await fetch(`${baseUrl}${REFRESH_PATH}`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: withCsrfHeader({
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    }),
+    body: JSON.stringify({ refresh_token: refreshToken.value }),
+  })
+
+  if (!response.ok) {
+    // A refusal is authoritative — the token cannot be reused.
+    clearSession()
+    return false
+  }
+
+  const data = await response.json() as { access_token?: string, refresh_token?: string, token?: string }
+  const nextAccess = data.access_token ?? data.token
+  if (!nextAccess) {
+    clearSession()
+    return false
+  }
+
+  token.value = nextAccess
+  // Rotation is optional server-side; keep the existing one when none comes back.
+  if (data.refresh_token)
+    refreshToken.value = data.refresh_token
+
+  return true
+}
+
+/**
+ * Refresh the session, collapsing concurrent callers onto one exchange.
+ *
+ * Never rejects: an exchange that could not be attempted resolves `false`
+ * without clearing state, so a caller can tell "signed out" from "could not
+ * reach the server" by checking whether `token.value` survived.
+ */
+export async function refreshSession(): Promise<boolean> {
+  if (inFlightRefresh)
+    return inFlightRefresh
+
+  inFlightRefresh = performRefresh()
+    .catch(() => {
+      // Unreachable, not refused. Leave the session intact so the next
+      // attempt can succeed once connectivity returns.
+      return false
+    })
+    .finally(() => {
+      inFlightRefresh = null
+    })
+
+  return inFlightRefresh
+}
+
+/**
+ * `fetch` with the access token attached, retrying once through a refresh on a
+ * 401.
+ *
+ * The retry is attempted only when a refresh token exists and the first
+ * response was a 401 — a 403 is an authorization decision, not an expiry, and
+ * refreshing would not change it.
+ */
+export async function authFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  const send = (): Promise<Response> => fetch(input.startsWith('http') ? input : `${baseUrl}${input}`, {
+    ...init,
+    headers: {
+      ...(init.headers as Record<string, string> | undefined),
+      ...(token.value ? { Authorization: `Bearer ${token.value}` } : {}),
+      Accept: 'application/json',
+    },
+  })
+
+  const response = await send()
+  if (response.status !== 401 || !refreshToken.value)
+    return response
+
+  const renewed = await refreshSession()
+  if (!renewed)
+    return response
+
+  return await send()
+}
 
 export function useAuth(): AuthComposable {
   async function fetchAuthUser(): Promise<UserData | null> {
@@ -22,17 +162,15 @@ export function useAuth(): AuthComposable {
         return null
       }
 
-      const response = await fetch(`${baseUrl}/me`, {
-        headers: {
-          Authorization: `Bearer ${token.value}`,
-          Accept: 'application/json',
-        },
-      })
+      // `authFetch` turns a 401 into refresh-then-retry, so an expired access
+      // token renews instead of ending the session. Previously any non-ok
+      // response cleared state, which made a one-hour-old token and a revoked
+      // one indistinguishable — every session died at the access token's
+      // lifetime (stacksjs/stacks#2235).
+      const response = await authFetch(ME_PATH)
 
       if (!response.ok) {
-        token.value = ''
-        isAuthenticated.value = false
-        user.value = null
+        clearSession()
         return null
       }
 
@@ -43,8 +181,12 @@ export function useAuth(): AuthComposable {
       return data
     }
     catch (error) {
+      // A thrown fetch means the request never completed — offline, DNS, the
+      // API restarting. That is not a statement about the session, so the
+      // token is kept and the next call can succeed. Clearing here signed
+      // users out on a network blip and then, because the token was gone,
+      // made it look like they had never been signed in.
       console.error('Error fetching user:', error)
-      token.value = ''
       isAuthenticated.value = false
       user.value = null
       return null
@@ -81,6 +223,12 @@ export function useAuth(): AuthComposable {
 
     if (isRegisterResponse(data)) {
       token.value = data.token
+      // RegisterAction returns the same OAuth2-shaped pack LoginAction does
+      // (#2212). Storing the refresh token is what lets the session outlive
+      // the access token's one-hour lifetime.
+      const refreshed = (data as { refresh_token?: string }).refresh_token
+      if (refreshed)
+        refreshToken.value = refreshed
       return data
     }
 
@@ -114,6 +262,9 @@ export function useAuth(): AuthComposable {
 
       const data = await response.json() as LoginResponse
       token.value = data.token
+      const refreshed = (data as { refresh_token?: string }).refresh_token
+      if (refreshed)
+        refreshToken.value = refreshed
       await fetchAuthUser() // Fetch user data after successful login
       return data
     }
@@ -145,10 +296,10 @@ export function useAuth(): AuthComposable {
     finally {
       // useStorage's setter syncs the underlying localStorage so other tabs
       // see the change via `storage` events. Setting localStorage manually
-      // would skip that broadcast.
-      token.value = ''
-      user.value = null
-      isAuthenticated.value = false
+      // would skip that broadcast. Clears the refresh token too — leaving it
+      // behind would let a later refresh silently resurrect a session the
+      // user just ended.
+      clearSession()
     }
   }
 
@@ -162,6 +313,10 @@ export function useAuth(): AuthComposable {
     logout,
     fetchAuthUser,
     checkAuthentication,
+    refreshToken,
+    getRefreshToken: () => refreshToken.value,
+    refreshSession,
+    authFetch,
   }
 }
 

--- a/storage/framework/core/browser/src/types/dashboard.ts
+++ b/storage/framework/core/browser/src/types/dashboard.ts
@@ -80,5 +80,27 @@ export interface AuthComposable {
   checkAuthentication: () => Promise<boolean>
   logout: () => void
   getToken: () => string | null
+  /**
+   * The ACCESS token. Short-lived — `config.auth.tokenExpiry` caps it at one
+   * hour by default, so anything holding it must be prepared for it to expire
+   * mid-session. `authFetch` handles that; a hand-rolled `fetch` does not.
+   */
   token: Ref<string | null>
+  /** The refresh token, exchanged at `/auth/refresh` when the access token expires. */
+  refreshToken: Ref<string | null>
+  getRefreshToken: () => string | null
+  /**
+   * Exchange the refresh token for a new access token. Resolves `false` when
+   * the server refused (session over, state cleared) or when the exchange
+   * could not be attempted (offline — state kept). Concurrent callers share
+   * one exchange, which single-use rotation requires.
+   */
+  refreshSession: () => Promise<boolean>
+  /**
+   * `fetch` with the access token attached, retrying once through a refresh on
+   * a 401. Use this for authenticated requests instead of a bare `fetch`.
+   */
+  // `globalThis.Response` explicitly: this module declares its own generic
+  // `Response<T>` (an API envelope, not the DOM class), which shadows it.
+  authFetch: (input: string, init?: RequestInit) => Promise<globalThis.Response>
 }

--- a/storage/framework/core/browser/tests/use-auth-refresh.test.ts
+++ b/storage/framework/core/browser/tests/use-auth-refresh.test.ts
@@ -1,0 +1,228 @@
+/**
+ * stacksjs/stacks#2235 — the framework issues an access/refresh pair on login
+ * and ships `RefreshTokenAction` to exchange them, but the browser never used
+ * it. `useAuth()` stored only the access token and cleared the session on any
+ * non-ok response, so every app on the default composable had sessions that
+ * ended when the access token expired — one hour, per `config.auth.tokenExpiry`.
+ * `refresh_token` appeared exactly once in the whole client surface: as a field
+ * on a TypeScript interface nothing read.
+ *
+ * `fetch` and `localStorage` are stubbed so this runs headless.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ─── Minimal localStorage, since `useStorage` persists through it ────
+
+const store = new Map<string, string>()
+;(globalThis as any).localStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => { store.set(k, String(v)) },
+  removeItem: (k: string) => { store.delete(k) },
+  clear: () => store.clear(),
+}
+;(globalThis as any).window = globalThis
+;(globalThis as any).__STACKS_CONFIG__ = { API_URL: 'https://api.test' }
+// `useStorage` flushes writes through rAF, which does not exist off-DOM.
+// Run the callback SYNCHRONOUSLY so persistence lands the moment a ref is
+// set: a wall-clock sleep would make these assertions a race on a loaded CI
+// runner, and the thing under test has nothing to do with frame timing.
+;(globalThis as any).requestAnimationFrame = (fn: () => void) => { fn(); return 0 }
+
+/** Kept as an await point for readability; persistence is already synchronous. */
+const flush = (): Promise<void> => Promise.resolve()
+
+/** Seed a persisted value. MUST run before `load()` — the refs read at construction. */
+function seed(key: string, value: string): void {
+  store.set(key, JSON.stringify(value))
+}
+
+/** Read a persisted value back through useStorage's JSON encoding. */
+function persisted(key: string): string {
+  const raw = store.get(key)
+  return raw === undefined ? '' : JSON.parse(raw)
+}
+
+const realFetch = globalThis.fetch
+
+interface Call { url: string, init: RequestInit }
+let calls: Call[] = []
+/** Queue of responders, consumed in order; the last one repeats. */
+let responders: Array<(call: Call) => Response | Promise<Response>> = []
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+beforeEach(() => {
+  store.clear()
+  calls = []
+  responders = []
+  ;(globalThis as any).fetch = async (url: string, init: RequestInit = {}) => {
+    const call = { url: String(url), init }
+    calls.push(call)
+    const responder = responders.length > 1 ? responders.shift()! : responders[0]
+    if (!responder) return json({}, 200)
+    return await responder(call)
+  }
+})
+
+afterEach(() => {
+  ;(globalThis as any).fetch = realFetch
+})
+
+const load = async () => {
+  // Fresh module per test: the composable holds singleton state at module
+  // scope, which is the point of the single-flight guard.
+  const mod = await import(`../src/composables/useAuth?t=${Math.random()}`)
+  return mod as typeof import('../src/composables/useAuth')
+}
+
+describe('useAuth refresh cycle (#2235)', () => {
+  test('persists the refresh token from a login response', async () => {
+    const { useAuth } = await load()
+    responders = [() => json({ token: 'access-1', refresh_token: 'refresh-1', user: { id: 1 } })]
+
+    await useAuth().login({ email: 'a@b.co', password: 'pw' } as any)
+
+    // The field the client used to receive and drop on the floor.
+    await flush()
+    expect(persisted('refresh_token')).toBe('refresh-1')
+  })
+
+  test('a 401 refreshes and retries instead of ending the session', async () => {
+    seed('token', 'expired')
+    seed('refresh_token', 'refresh-1')
+    const { authFetch } = await load()
+
+    responders = [
+      () => json({ error: 'Unauthorized' }, 401), // the expired access token
+      () => json({ access_token: 'access-2', refresh_token: 'refresh-2' }), // the exchange
+      () => json({ ok: true }), // the retry
+    ]
+
+    const res = await authFetch('/api/sites')
+
+    expect(res.status).toBe(200)
+    expect(calls.map(c => c.url)).toEqual([
+      'https://api.test/api/sites',
+      'https://api.test/auth/refresh',
+      'https://api.test/api/sites',
+    ])
+    // The retry carries the NEW token, not the expired one.
+    expect((calls[2]!.init.headers as any).Authorization).toBe('Bearer access-2')
+    // Rotation is stored, so the next expiry can refresh again.
+    await flush()
+    expect(persisted('refresh_token')).toBe('refresh-2')
+  })
+
+  test('concurrent 401s share ONE exchange', async () => {
+    // Single-use rotation makes this correctness, not performance: a second
+    // exchange presenting an already-consumed token kills the session.
+    seed('token', 'expired')
+    seed('refresh_token', 'refresh-1')
+    const { authFetch } = await load()
+
+    let refreshCount = 0
+    responders = [(call) => {
+      if (call.url.endsWith('/auth/refresh')) {
+        refreshCount++
+        return json({ access_token: 'access-2', refresh_token: 'refresh-2' })
+      }
+      // Every protected call 401s until the token is replaced.
+      const auth = (call.init.headers as any)?.Authorization
+      return auth === 'Bearer access-2' ? json({ ok: true }) : json({}, 401)
+    }]
+
+    const results = await Promise.all([
+      authFetch('/api/a'),
+      authFetch('/api/b'),
+      authFetch('/api/c'),
+    ])
+
+    expect(results.every(r => r.status === 200)).toBe(true)
+    expect(refreshCount).toBe(1)
+  })
+
+  test('a REFUSED refresh ends the session', async () => {
+    seed('token', 'expired')
+    seed('refresh_token', 'revoked')
+    const { authFetch } = await load()
+
+    responders = [(call) => json({ error: 'nope' }, 401 + (call.url.endsWith('/auth/refresh') ? 0 : 0))]
+
+    const res = await authFetch('/api/sites')
+
+    expect(res.status).toBe(401)
+    // Refusal is authoritative — the tokens are gone.
+    await flush()
+    expect(persisted('token')).toBe('')
+    expect(persisted('refresh_token')).toBe('')
+  })
+
+  test('an UNREACHABLE server keeps the session', async () => {
+    // The distinction the issue is really about: signing users out on a
+    // network blip loses a session that was perfectly valid.
+    seed('token', 'expired')
+    seed('refresh_token', 'refresh-1')
+    const { refreshSession } = await load()
+
+    responders = [() => { throw new TypeError('Failed to fetch') }]
+
+    expect(await refreshSession()).toBe(false)
+    await flush()
+    expect(persisted('token')).toBe('expired')
+    expect(persisted('refresh_token')).toBe('refresh-1')
+  })
+
+  test('does not try to refresh a 403', async () => {
+    // 403 is an authorization decision, not an expiry; refreshing cannot
+    // change it and would burn a rotation for nothing.
+    seed('token', 'valid')
+    seed('refresh_token', 'refresh-1')
+    const { authFetch } = await load()
+
+    responders = [() => json({ error: 'Forbidden' }, 403)]
+
+    const res = await authFetch('/api/sites')
+
+    expect(res.status).toBe(403)
+    expect(calls).toHaveLength(1)
+  })
+
+  test('does not try to refresh without a refresh token', async () => {
+    seed('token', 'expired')
+    const { authFetch } = await load()
+
+    responders = [() => json({}, 401)]
+
+    await authFetch('/api/sites')
+
+    expect(calls.map(c => c.url)).toEqual(['https://api.test/api/sites'])
+  })
+
+  test('defaults the identity endpoint to /api/me, reachable through the views proxy', async () => {
+    seed('token', 'valid')
+    const { useAuth } = await load()
+    responders = [() => json({ id: 1, email: 'a@b.co' })]
+
+    await useAuth().fetchAuthUser()
+
+    // A bare `GET /me` is swallowed by page routing in the split topology.
+    expect(calls[0]!.url).toBe('https://api.test/api/me')
+  })
+
+  test('logout clears the refresh token too', async () => {
+    seed('token', 'valid')
+    seed('refresh_token', 'refresh-1')
+    const { useAuth } = await load()
+    responders = [() => json({ ok: true })]
+
+    await useAuth().logout()
+
+    // Leaving it behind would let a later refresh resurrect a session the
+    // user just ended.
+    await flush()
+    expect(persisted('refresh_token')).toBe('')
+  })
+})


### PR DESCRIPTION
Closes #2235.

## The bug

The server has always returned an access/refresh pair and ships `RefreshTokenAction` to exchange them. The client never used it:

```ts
const token = useStorage('token', '')          // the entire token model
// ...
if (!response.ok) {
  token.value = ''                              // any failure ends the session
  isAuthenticated.value = false
  user.value = null
  return null
}
```

`grep -rn refresh storage/framework/core/browser/src/` returns **one** hit — a field on a TypeScript interface nothing reads.

With `config.auth.tokenExpiry` capping the access token at one hour, every app on the default composable had sessions that died after exactly an hour. And not with a redirect: `localStorage` still held a token, so a pre-paint guard saw a truthy value and did not bounce, leaving a signed-out gate rendered over a session the user thought they had.

## What changed

- `login` / `register` persist `refresh_token`; `logout` clears it (leaving it behind would let a later refresh resurrect a session the user just ended)
- **`authFetch(input, init)`** — attaches the access token, and on a 401 refreshes and retries once. Only on 401, and only when a refresh token exists: a 403 is an authorization decision, not an expiry, so refreshing would burn a rotation without changing the answer.
- **`refreshSession()`** — collapses concurrent callers onto one exchange
- `fetchAuthUser` routes through `authFetch`, so an expired token renews instead of ending the session

## The two details that carry the weight

**Single-flight is correctness, not performance.** Single-use rotation means two concurrent 401s each exchanging the same refresh token results in the second presenting one the server already consumed — and the session dies. A module-level in-flight promise is why three parallel requests produce one exchange. There is a test asserting exactly `refreshCount === 1`.

**Refused ≠ unreachable.** A server that refuses is authoritative and state is cleared. A request that never completed (offline, DNS, API restarting) leaves the session intact. `fetchAuthUser`'s catch block used to clear on any thrown fetch, which signed users out on a network blip and then — because the token was gone — made it look like they had never signed in.

## `/me` → `/api/me`

The endpoint is now configurable via `__STACKS_CONFIG__` and defaults to `/api/me`. The hardcoded `/me` is unreachable in the split views/API topology: that server forwards only `/api/**` and non-GET verbs, so a bare `GET /me` is swallowed by page routing. The composable was doubly unusable there. (The proxy predicate itself is #2230.)

## Not included

The optional **token→cookie mirror** for server-rendered pages (issue ask 5). A real need, but it wants its own flag and a deliberate decision about cookie attributes (path, max-age, SameSite, Secure) rather than being smuggled in here.

## Tests

`core/browser/tests/use-auth-refresh.test.ts`, 9 pass. `fetch` and `localStorage` are stubbed, so it runs headless:

- persists `refresh_token` from a login response — the field that was dropped on the floor
- a 401 refreshes and retries, and the **retry carries the new token**, with the exact call sequence asserted
- **concurrent 401s share one exchange** (`refreshCount === 1`)
- a **refused** refresh clears both tokens
- an **unreachable** server keeps both tokens
- no refresh attempt on 403, and none without a refresh token
- defaults to `/api/me`
- `logout` clears the refresh token

`requestAnimationFrame` is stubbed **synchronously** rather than via `setTimeout`, so `useStorage`'s persistence lands immediately and none of these assertions depend on wall-clock timing — a sleep here would flake on a loaded CI runner for reasons unrelated to what is being tested.

`core/browser`: 86 pass, 0 fail. Typecheck at baseline, lint clean.

Note: `AuthComposable.authFetch` is typed `Promise<globalThis.Response>` because that module declares its own generic `Response<T>` API envelope, which shadows the DOM class.