### PR TITLE
fix(orm): stop warning about deliberately public read routes

### DIFF
--- a/storage/framework/core/orm/routes.ts
+++ b/storage/framework/core/orm/routes.ts
@@ -483,12 +483,18 @@ for (const [modelName, model] of Object.entries(models)) {
   if (hasMutating && declared && writeMiddleware.length === 0)
     log.warn(`[orm] ${modelName}: registering UNAUTHENTICATED mutating routes at ${basePath} (explicit \`middleware: []\` opt-out)`)
 
-  // Reads get the same treatment. An anonymous read endpoint is how a customer
-  // list leaks, and until now it was the silent default — so when an app opts
-  // back into it, say so at boot with the same volume as the write warning.
+  // Anonymous reads are recorded, not warned about.
+  //
+  // They warranted a warning while they were the silent DEFAULT — that was the
+  // #2224 hazard. Now that reads default to `auth`, an open read route only
+  // exists because a model asked for it in as many words, and asking is
+  // legitimate: every public catalog does it. The framework's own 15 catalog
+  // models declare it, so warning here meant 15 lines on every boot about
+  // behaviour that is working as intended, which is how a warning stops being
+  // read at all. `debug` keeps it available to anyone auditing the surface.
   const hasRead = ['index', 'show'].some(r => enabledRoutes.includes(r))
   if (hasRead && declared && readMiddleware0.length === 0)
-    log.warn(`[orm] ${modelName}: registering UNAUTHENTICATED read routes at ${basePath} (explicit \`middleware\` opt-out) — anyone can list this table`)
+    log.debug(`[orm] ${modelName}: registering public read routes at ${basePath} (declared \`middleware.read: []\`)`)
 
   // Row-scoped resource? (explicit `ownership`, or a model with a team_id
   // column that's auto-team-scoped). If so its index/show handlers below


### PR DESCRIPTION
Follow-up to #2224, fixing noise I introduced there.

## What went wrong

#2224 added a boot warning whenever a model registers unauthenticated read routes:

```
[orm] Product: registering UNAUTHENTICATED read routes at /api/products (explicit `middleware` opt-out) — anyone can list this table
[orm] Post: ...
[orm] Tag: ...
(x15)
```

That warning was right while anonymous reads were the **silent default** — the entire hazard was that nobody could see them. It is wrong now that reads default to `auth`: an open read route exists only because a model asked for it in as many words, and asking is legitimate. Every public catalog does it.

The framework's own 15 catalog models declare exactly that, so this printed 15 lines on every boot about behaviour working as intended. I caught it running `docs:artifacts:check` on an unrelated branch.

A warning that always fires is one people stop reading — and that would have cost the real signal the **write-side** warning still carries, which is the one that matters.

## The change

`log.warn` → `log.debug`, with the message reworded from an alarm to a record (`registering public read routes ... (declared middleware.read: [])`). Still available to anyone auditing the public surface.

The write-side warning is untouched. An explicit `middleware: []` opening mutations is rare and genuinely worth interrupting for.

## Verification

`bun run docs:artifacts:check` on `main`: **15** such warnings. With this: **0**.

`core/orm`: 1388 pass, 0 fail. Lint clean.