### PR TITLE
fix(router): emit one validation-failure envelope

### DIFF
--- a/storage/framework/core/orm/routes.ts
+++ b/storage/framework/core/orm/routes.ts
@@ -802,7 +802,7 @@ for (const [modelName, model] of Object.entries(models)) {
         // schema.string().required().email() }` per attribute — without this
         // call, those declarations were dead documentation.
         const v = validateWriteBody(data, model, 'creating')
-        if (!v.valid) return jsonResponse({ error: 'Validation failed', errors: v.errors }, 422)
+        if (!v.valid) return jsonResponse({ success: false, message: 'Validation failed', errors: v.errors }, 422)
 
         // Add timestamps if model uses them
         if (model.traits?.useTimestamps !== false) {
@@ -876,7 +876,7 @@ for (const [modelName, model] of Object.entries(models)) {
         // Run declared validation rules. Partial updates only validate fields
         // the caller actually sent — see validateWriteBody for the rule.
         const v = validateWriteBody(data, model, 'updating')
-        if (!v.valid) return jsonResponse({ error: 'Validation failed', errors: v.errors }, 422)
+        if (!v.valid) return jsonResponse({ success: false, message: 'Validation failed', errors: v.errors }, 422)
 
         // 404 fast if the row doesn't exist — previously the UPDATE silently
         // matched zero rows and we returned the request body as if it had

--- a/storage/framework/core/router/src/stacks-router.ts
+++ b/storage/framework/core/router/src/stacks-router.ts
@@ -8,6 +8,7 @@
 import type { Server } from 'bun'
 import type { ActionValidations, ValidationResult } from '@stacksjs/actions'
 import type { ActionHandler, EnhancedRequest, Route, ServerOptions } from '@stacksjs/bun-router'
+import { response } from '@stacksjs/bun-router'
 import { Middleware } from './middleware'
 // Side-import the EnhancedRequest module augmentation so every `req._foo`
 // and `req.input(...)` access in this file type-checks without `as any`
@@ -1517,6 +1518,29 @@ function resolveStringHandler(handlerPath: string): Promise<RouteHandlerFn> {
  * Resolve a string handler to an actual handler function
  * Supports user overrides: checks user's app/ first, then falls back to defaults
  */
+/**
+ * The one 422 body a failed `validations:` block produces.
+ *
+ * This path used to hand-build `{ error: 'Validation failed', errors }`, which
+ * made it the only error response in the framework without a `message`. Every
+ * other one — `response.error()`, `unauthorized()`, `forbidden()`,
+ * `notFound()`, and `validationError()` itself — goes through bun-router's
+ * `response.error`, which emits `{ success: false, message, errors }`. So a
+ * client correctly reading `data.message` got `undefined` for the one response
+ * type forms hit most, and showed its own fallback string instead: a 5-character
+ * password on `/login` reported "Invalid email or password" for a 422
+ * (stacksjs/stacks#2227).
+ *
+ * Delegating rather than hand-building is the point: the envelope is defined in
+ * exactly one place, so this path cannot drift from it again. A named helper
+ * rather than an inline call so `createValidationErrorResponse` in
+ * `error-handler.ts` — a third shape, nesting `errors` under `details` — has an
+ * obvious thing to be reconciled with.
+ */
+function validationFailureResponse(errors: Record<string, string[]>): Response {
+  return response.validationError(errors) as Response
+}
+
 async function resolveStringHandlerUncached(handlerPath: string): Promise<RouteHandlerFn> {
   assertSafeHandlerPath(handlerPath)
   let modulePath = handlerPath
@@ -1623,16 +1647,7 @@ async function resolveStringHandlerUncached(handlerPath: string): Promise<RouteH
         if (action.validations) {
           const validationResult = await validateActionInput(req, action.validations)
           if (!validationResult.valid) {
-            // Positional status (not `{ status: 422 }`) — bun-router's
-            // `Response.json` macro had a positional-only signature for a
-            // while (see stacksjs/stacks#1857 for the historical bite).
-            // The macro is dual-shape now, but defensive positional usage
-            // keeps the validation failure path working even if a project
-            // resolves to an older `@stacksjs/bun-router`.
-            return Response.json(
-              { error: 'Validation failed', errors: validationResult.errors },
-              { status: 422 },
-            )
+            return validationFailureResponse(validationResult.errors)
           }
         }
 

--- a/storage/framework/core/router/tests/validation-envelope.test.ts
+++ b/storage/framework/core/router/tests/validation-envelope.test.ts
@@ -1,0 +1,83 @@
+/**
+ * stacksjs/stacks#2227 — a validation failure came back in three different
+ * shapes depending on which code path produced it, and the one an Action's
+ * `validations:` block produced automatically was the odd one out: it used
+ * `error` where everything else uses `message`, and omitted `message` entirely.
+ *
+ * A client correctly reading `data.message` — which is right for
+ * `response.unauthorized()`, `forbidden()`, `error()` and `validationError()` —
+ * got `undefined` for the response type forms hit most, and fell back to its own
+ * hand-written string. In the reporting app a 5-character password on `/login`
+ * failed `min(6)` and the visitor was told "Invalid email or password." for a
+ * 422 that was not even a 401.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { response } from '@stacksjs/bun-router'
+
+/** The envelope every error response in the framework is supposed to use. */
+async function bodyOf(res: Response): Promise<Record<string, unknown>> {
+  return await res.json() as Record<string, unknown>
+}
+
+describe('the canonical error envelope', () => {
+  it('is { success: false, message, errors } for a validation failure', async () => {
+    const res = response.validationError({ email: ['is required'] }) as Response
+
+    expect(res.status).toBe(422)
+    expect(await bodyOf(res)).toEqual({
+      success: false,
+      message: 'Validation failed',
+      errors: { email: ['is required'] },
+    })
+  })
+
+  it('uses `message` across every other error helper too', async () => {
+    // This is why `message` is the right key: four helpers already agree on it,
+    // and the automatic 422 was the only dissenter.
+    for (const res of [
+      response.unauthorized('nope') as Response,
+      response.forbidden('nope') as Response,
+      response.notFound('nope') as Response,
+      response.error('nope', 400) as Response,
+    ]) {
+      const body = await bodyOf(res)
+      expect(body.message).toBe('nope')
+      expect(body.success).toBe(false)
+      // The key the automatic 422 used to carry instead.
+      expect(body).not.toHaveProperty('error')
+    }
+  })
+})
+
+describe('the automatic 422 emitted for an Action `validations:` block', () => {
+  // The router path now delegates to `response.validationError` rather than
+  // hand-building a body, so it cannot drift from the envelope again. Asserted
+  // against the source, since exercising it needs a booted router + action.
+  const src = new URL('../src/stacks-router.ts', import.meta.url).pathname
+
+  it('delegates instead of hand-building the body', async () => {
+    const text = await Bun.file(src).text()
+
+    expect(text).toContain('return response.validationError(errors) as Response')
+    expect(text).toContain('return validationFailureResponse(validationResult.errors)')
+  })
+
+  it('no longer emits the `error`-keyed shape', async () => {
+    const text = await Bun.file(src).text()
+
+    // The exact literal that made this path the odd one out.
+    expect(text).not.toContain('{ error: \'Validation failed\', errors:')
+  })
+})
+
+describe('the auto-CRUD write path agrees', () => {
+  it('emits the same envelope as the router', async () => {
+    // Two more emitters of the old shape lived here. Leaving them would have
+    // meant fixing the router and still shipping two shapes.
+    const text = await Bun.file(new URL('../../orm/routes.ts', import.meta.url).pathname).text()
+
+    expect(text).not.toContain('{ error: \'Validation failed\', errors:')
+    expect(text).toContain('{ success: false, message: \'Validation failed\', errors:')
+  })
+})


### PR DESCRIPTION
Closes #2227.

## The bug

```ts
// core/router/src/stacks-router.ts — the automatic path
return Response.json(
  { error: 'Validation failed', errors: validationResult.errors },
  { status: 422 },
)
```

That is the only error response in the framework without a `message`. Every other one goes through bun-router's `response.error`, which emits `{ success: false, message, errors }` — `unauthorized()`, `forbidden()`, `notFound()`, `error()` and `validationError()` all agree.

So a client correctly reading `data.message` gets `undefined` for the response type forms hit most, and falls back to its own hand-written string:

```ts
const data: AuthResponse = await res.json()
if (!res.ok)
  error.set(data.message || 'Invalid email or password.')
```

A 5-character password on `/login` fails `min(6)`, returns **422**, and the visitor is told **"Invalid email or password."** — wrong, unactionable, and not even the right status class.

## The fix

The router path calls `response.validationError(...)` instead of hand-building a body. The envelope is defined in exactly one place, so this path cannot drift from it again.

The auto-CRUD write path had **two more** emitters of the same old shape (`orm/routes.ts:832`, `:906`). Fixing only the router would have left two shapes shipping, which is the actual complaint, so those are aligned too.

## Breaking change, scoped

A client reading `body.error` from an automatic 422 will now find `body.message`. That is the key every other error response has always used.

Worth noting the framework's own client parser is unaffected: `browser/src/composables/request-error.ts` already accepts **both** `message` and `error`, so anything using it keeps working and now gets the better field.

## On the issue's other asks

- **#2, reconcile `createValidationErrorResponse`** (`error-handler.ts:574`, a third shape nesting `errors` under `details`) — not touched here. It is on a different path and deserves its own look at whether it should be deleted in favour of this one rather than reshaped. The new helper is named rather than inlined specifically so that reconciliation has an obvious target.
- **#3, a typed `ValidationErrorResponse` export**, and **#4, wiring into `useForm`** — follow-on work; both want the envelope settled first, which this does.

## Tests

`core/router/tests/validation-envelope.test.ts`, 5 pass:
- the canonical envelope is exactly `{ success: false, message, errors }` at 422
- **four other helpers already use `message`** and carry no `error` key — which is the evidence that `message` is right and the automatic 422 was the dissenter
- the router path delegates rather than hand-builds, and the old `error`-keyed literal is gone
- the auto-CRUD path emits the same envelope

`core/router` (sharded as CI runs it): 126 + 171 pass, 0 fail. `core/orm`: 1388 pass, 0 fail. Typecheck at baseline, lint clean.