### PR TITLE
fix(ci): restore core-package test discovery after the bunfig test root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,16 @@ jobs:
       # shards the suite passes 283/283. The shard split is a workaround for
       # the runner, not for a product bug — the three REAL failures it was
       # hiding are fixed (route middleware registry leaking across files).
+      #
+      # The leading `./` is load-bearing. bunfig.toml sets `[test] root =
+      # "tests"` so a bare `bun test` does not walk `pantry/` and exhaust file
+      # descriptors (85ebd37886). A bare path argument is then treated as a
+      # FILTER applied within that root, so `bun test storage/...` matches
+      # nothing and exits non-zero — which would have reported all ~81 core
+      # packages as failing. bun says so itself: "To treat ... as a path, run
+      # bun test ./<path>". Running from the package directory would also work
+      # (`root` is cwd-relative) but breaks tests that resolve repo-root
+      # paths, e.g. orm's sensitive-api-security.test.ts.
       - name: Core tests (all packages)
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: |
@@ -171,13 +181,13 @@ jobs:
             if [ "$pkg" = "router" ]; then
               for shard in 1/2 2/2; do
                 echo "::group::core/$pkg (shard $shard)"
-                bun test "$dir" --shard="$shard" || failed="$failed $pkg[$shard]"
+                bun test "./$dir" --shard="$shard" || failed="$failed $pkg[$shard]"
                 echo "::endgroup::"
               done
               continue
             fi
             echo "::group::core/$pkg"
-            bun test "$dir" || failed="$failed $pkg"
+            bun test "./$dir" || failed="$failed $pkg"
             echo "::endgroup::"
           done
           if [ -n "$failed" ]; then


### PR DESCRIPTION
The `test` job on `main` is currently reporting **~81 core packages as failing** instead of the handful that genuinely do. It was already red, which is exactly why this went unnoticed.

## What happened

`bunfig.toml` gained `[test] root = "tests"` in 85ebd37886 ("look for tests where the tests are"). That fix is sound and the reasoning in its comment is right — without it a bare `bun test` walks `pantry/`, follows a few hundred symlinks, exhausts file descriptors, and unrelated tests start failing `EBADF`.

The consequence it did not account for: **once a root is set, a bare path argument is treated as a FILTER applied within that root, not as a path.**

```
$ bun test storage/framework/core/strings/tests
The following filters did not match any test files in --cwd="…/stacks"
43 files were searched
```

So every iteration of this loop matched nothing and exited non-zero.

## Measured

Running CI's exact loop locally against the same tree:

| | result |
|---|---|
| `bun test "$dir"` (main today) | **81 packages listed as failing** |
| `bun test "./$dir"` (this PR) | `browser-extension cache charts defaults queue` — the 5 that actually fail on this machine |

## The fix

A leading `./`. bun says so in its own error output:

> note: To treat the "storage/framework/core/strings/tests/case.test.ts" filter as a path, run "bun test ./storage/framework/core/strings/tests/case.test.ts"

## The alternative I rejected

Running from inside each package (`cd "$(dirname "$dir")" && bun test tests`) also restores discovery, because `root` is cwd-relative — I verified it works even for the 77 of 81 packages that have no bunfig of their own.

But it breaks tests that resolve repo-root paths. `orm/tests/sensitive-api-security.test.ts` scandirs `storage/framework/defaults/app/Models` and ENOENTs from a package cwd:

```
error: ENOENT: no such file or directory, scandir
  '…/core/orm/storage/framework/defaults/app/Models'
```

Keeping cwd at the repo root is the option that leaves both working. `orm` goes from `1402 pass / 2 fail` (package cwd) to `1404 pass / 0 fail` (repo root, with `./`).

## Note on the bunfig comment

It says "A package under `storage/framework/core/*` with tests of its own carries its own bunfig and is unaffected." That holds for **4 of the 81** packages with tests (`cms`, `commerce`, `composables`, `error-handling`). The other 77 rely on the root config, which is why the blast radius was everything. Worth correcting there separately, or folding into this — happy to do either.

The reason for the `./` is documented inline in the workflow so the next bunfig change has a chance of catching it.