### PR TITLE
fix(database): stop migrate:regenerate deleting the schema it is not regenerating

### DIFF
--- a/storage/framework/core/buddy/src/commands/migrate.ts
+++ b/storage/framework/core/buddy/src/commands/migrate.ts
@@ -1,5 +1,6 @@
 import type { CLI, MigrateOptions } from '@stacksjs/types'
 import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { relative } from 'node:path'
 import process from 'node:process'
 import { confirm, intro, log, onUnknownSubcommand, outro, text } from "@stacksjs/cli"
 import { Action } from '@stacksjs/enums'
@@ -1122,26 +1123,56 @@ export function migrate(buddy: CLI): void {
         process.exit(ExitCode.FatalError)
       }
 
-      const { files, removed, preserved, models } = plan.value
+      const { files, removed, preserved, preservedOutOfScope, models, modelRoots } = plan.value
+
       // Preserved files are the ones no rerun can recreate, so they are the
       // only part of this plan a user cannot undo by running the command
-      // again. List them by name rather than as a count (stacksjs/stacks#2234).
-      const preservedBlock = preserved.length === 0
+      // again. List them by name rather than as a count (stacksjs/stacks#2234),
+      // and split the two reasons, because they call for opposite responses:
+      // an unmarked file is someone's work, an out-of-scope one is a table this
+      // app's models no longer describe (stacksjs/stacks#2255).
+      const outOfScope = new Set(preservedOutOfScope)
+      const unmarked = preserved.filter(f => !outOfScope.has(f))
+
+      const unmarkedBlock = unmarked.length === 0
         ? ''
         : `
-  • ${preserved.length} file(s) carry no @generated marker and will be KEPT:
-${preserved.map(f => `      ${f}`).join('\n')}
+  • ${unmarked.length} file(s) carry no @generated marker and will be KEPT:
+${unmarked.map(f => `      ${f}`).join('\n')}
     Hand-authored migrations cannot be regenerated, so they are never deleted.
     If these are output from a Stacks version that predated the marker, re-run
     with --replace-unmarked to replace them too.`
+
+      // Capped, unlike the unmarked list: an app that narrowed its model scope
+      // can have seventy of these, and scrolling the confirmation prompt off
+      // the screen is its own kind of unreadable.
+      const OUT_OF_SCOPE_SHOWN = 20
+      const outOfScopeMore = preservedOutOfScope.length - OUT_OF_SCOPE_SHOWN
+      const outOfScopeBlock = preservedOutOfScope.length === 0
+        ? ''
+        : `
+  • ${preservedOutOfScope.length} file(s) describe tables this corpus does not rebuild, and will be KEPT:
+${preservedOutOfScope.slice(0, OUT_OF_SCOPE_SHOWN).map(f => `      ${f}`).join('\n')}${outOfScopeMore > 0 ? `\n      ... and ${outOfScopeMore} more` : ''}
+    Nothing in scope regenerates these, so removing them would leave the app
+    with no definition for those tables at all. If they belong to framework
+    models your app relies on without declaring (users, jobs, payments, ...),
+    either publish them with \`buddy publish model <Name>\` or set
+    database.models.includeFrameworkDefaults, then regenerate again.`
+
+      // The roots that actually contributed. Saying "app/Models and the
+      // framework defaults" unconditionally was wrong for every app that has
+      // models of its own (stacksjs/stacks#2255).
+      const rootList = modelRoots.length === 0
+        ? 'no model directory'
+        : modelRoots.map(root => relative(process.cwd(), root) || root).join(' and ')
 
       // eslint-disable-next-line no-console
       console.log(`
   Regenerate plan: ${target}
   ─────────────────────────────────────────────
-  • ${models} model(s) read from app/Models and the framework defaults
+  • ${models} model(s) read from ${rootList}
   • ${files.length} migration file(s) will be written
-  • ${removed.length} existing file(s) will be removed${preservedBlock}
+  • ${removed.length} existing file(s) will be removed${unmarkedBlock}${outOfScopeBlock}
   • These files are tracked in git, so review with \`git diff\` afterwards
   ─────────────────────────────────────────────
 `)

--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -50,6 +50,7 @@ import { frameworkManagedColumns, withoutManagedColumnDrops, withoutManagedColum
 import { acquireMigrationLock } from './migration-lock'
 import { relativeMigrationDirectory, resolveMigrationDirectory } from './migration-path'
 import { migrateNotificationTables } from './notification-tables'
+import { traitTableNames } from './trait-tables'
 
 // Use environment variables via @stacksjs/env for proper type coercion
 import { env as envVars } from '@stacksjs/env'
@@ -194,20 +195,45 @@ function configureQueryBuilder(
   resetConnection()
 }
 
-export function prepareMigrationModelsDir(): { modelsDir: string, skip: boolean, excludedTables: string[] } {
+export function prepareMigrationModelsDir(): {
+  modelsDir: string
+  skip: boolean
+  /**
+   * Tables owned by framework default models that are out of scope. Reported to
+   * the user, so it stays limited to the models — see {@link protectedTables}
+   * for what actually suppresses a drop.
+   */
+  excludedTables: string[]
+  /**
+   * Every table the generator has no authority to drop.
+   *
+   * {@link excludedTables} plus the polymorphic trait tables. The trait tables
+   * need saying separately because `declaredTableName` reads a model's OWN
+   * table and nothing else: the framework's `Post` declares `taggable_models`
+   * and `categorizable_models` as `belongsToMany` pivots, so when `Post` leaves
+   * scope those two enter the diff as tables the app deleted, while the models
+   * exclusion set never hears about them (stacksjs/stacks#2255).
+   *
+   * They would be dropped and then recreated empty by `migrateTraitTables()` in
+   * the same `buddy migrate` — data loss with no schema change to show for it.
+   */
+  protectedTables: string[]
+} {
   const sources = resolveModelSources()
+  const excludedTables = sources?.excludedTables ?? []
   return {
     modelsDir: sources?.dir ?? path.userModelsPath(),
     skip: !sources,
-    excludedTables: sources?.excludedTables ?? [],
+    excludedTables,
+    protectedTables: [...new Set([...excludedTables, ...traitTableNames()])],
   }
 }
 
 const DROP_TABLE_RE = /^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?["'`]?(\w+)["'`]?/i
 
 /**
- * Drop the generated `DROP TABLE`s for framework defaults that are simply out
- * of scope, rather than deleted.
+ * Drop the generated `DROP TABLE`s for tables that are simply out of the
+ * generator's scope, rather than deleted.
  *
  * The generator diffs the model set against the stored snapshot, so the first
  * run after framework defaults stop being merged (stacksjs/stacks#2220) sees
@@ -216,19 +242,26 @@ const DROP_TABLE_RE = /^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?["'`]?(\w+)["'`]?/i
  * table" is not "destroy this table"; the same distinction
  * `withoutManagedColumnDropSql` draws for framework-managed columns.
  *
- * Self-limiting: the snapshot advances to the narrowed model set at the end of
- * the same run, so the drops are never proposed again. A table an app really
- * does want gone is still dropped by hand, the way it always was.
+ * Two kinds of table qualify, both supplied via `prepareMigrationModelsDir`'s
+ * `protectedTables`: framework defaults left out of scope, and the polymorphic
+ * trait tables, which arrive in the snapshot as pivots of a framework model and
+ * would be recreated empty moments later by `migrateTraitTables`
+ * (stacksjs/stacks#2255).
+ *
+ * Self-limiting for the first kind: the snapshot advances to the narrowed model
+ * set at the end of the same run, so those drops are never proposed again. A
+ * table an app really does want gone is still dropped by hand, the way it
+ * always was.
  */
-export function withoutExcludedTableDropSql(
+export function withoutProtectedTableDropSql(
   statements: string[],
-  excludedTables: readonly string[],
+  protectedTables: readonly string[],
   operations: readonly MigrationOperation[],
 ): { statements: string[], removed: string[] } {
-  if (excludedTables.length === 0)
+  if (protectedTables.length === 0)
     return { statements, removed: [] }
 
-  const excluded = new Set(excludedTables.map(table => table.toLowerCase()))
+  const excluded = new Set(protectedTables.map(table => table.toLowerCase()))
   const normalize = (sql: string): string => sql.replace(/\s+/g, ' ').trim().replace(/;$/, '')
   const dropped = new Set(
     operations
@@ -1669,7 +1702,7 @@ export async function previewPendingMigrations(options: GenerateMigrationsOption
   try {
     configureQueryBuilder()
     const dialect = getDialect()
-    const { modelsDir, skip, excludedTables } = prepareMigrationModelsDir()
+    const { modelsDir, skip, protectedTables } = prepareMigrationModelsDir()
     if (skip)
       return []
     const { applyRenames, fromDb } = resolveGenerateOptions(options)
@@ -1682,12 +1715,12 @@ export async function previewPendingMigrations(options: GenerateMigrationsOption
       fromDb,
     })
     let operations = result.operations ?? []
-    // Out-of-scope framework defaults are never dropped (see
-    // `withoutExcludedTableDropSql`), so they must not appear in the
-    // confirmation gate either — sixty phantom drops would train the user to
-    // approve a prompt that is, on any other run, worth reading.
-    if (excludedTables.length > 0) {
-      const excluded = new Set(excludedTables.map(table => table.toLowerCase()))
+    // Protected tables are never dropped (see `withoutProtectedTableDropSql`),
+    // so they must not appear in the confirmation gate either — sixty phantom
+    // drops would train the user to approve a prompt that is, on any other run,
+    // worth reading.
+    if (protectedTables.length > 0) {
+      const excluded = new Set(protectedTables.map(table => table.toLowerCase()))
       operations = operations.filter(
         (op: MigrationOperation) => !(op.kind === 'drop_table' && excluded.has(op.table.toLowerCase())),
       )
@@ -1877,7 +1910,7 @@ export async function generateMigrations(options: GenerateMigrationsOptions = {}
     }
     const storedPlan = readStoredMigrationPlan(getQbDialect())
 
-    const { modelsDir, skip, excludedTables } = prepareMigrationModelsDir()
+    const { modelsDir, skip, excludedTables, protectedTables } = prepareMigrationModelsDir()
     if (skip) {
       log.debug('No app/Models directory found; using committed framework migrations')
       return ok('Migrations generated')
@@ -1926,14 +1959,15 @@ export async function generateMigrations(options: GenerateMigrationsOptions = {}
     }
 
     // Same idea one level up: framework defaults that are out of scope because
-    // this app has its own models must not be read as tables the app deleted.
+    // this app has its own models must not be read as tables the app deleted,
+    // and neither must the trait pivots that left scope alongside them.
     // Said out loud rather than at debug — an app upgrading into #2220's fix
     // sees its table count fall by sixty, and should know why nothing dropped.
-    if (result.hasChanges && sqlStatements.length > 0 && excludedTables.length > 0) {
-      const filtered = withoutExcludedTableDropSql(sqlStatements, excludedTables, result.operations ?? [])
+    if (result.hasChanges && sqlStatements.length > 0 && protectedTables.length > 0) {
+      const filtered = withoutProtectedTableDropSql(sqlStatements, protectedTables, result.operations ?? [])
       if (filtered.removed.length > 0) {
         log.info(
-          `[migration] Left ${filtered.removed.length} framework-default table(s) in place rather than dropping them. `
+          `[migration] Left ${filtered.removed.length} framework-owned table(s) in place rather than dropping them. `
           + `They are no longer generated because app/Models defines this app's schema; the tables and their data are untouched. `
           + `Set database.models.includeFrameworkDefaults to keep generating them (stacksjs/stacks#2220).`,
         )
@@ -2208,21 +2242,136 @@ export function isGeneratedMigration(dir: string, file: string): boolean {
   }
 }
 
+/**
+ * The tables a statement ACTS ON — the target of a CREATE/ALTER/DROP TABLE or
+ * a CREATE INDEX.
+ *
+ * Deliberately not "every table the statement mentions". A `REFERENCES users`
+ * in a foreign key makes `users` a table the statement depends on, not one it
+ * changes, and counting it would tie half the corpus to whatever table the app
+ * happens to point its foreign keys at.
+ */
+export function tablesOperatedOn(sql: string): string[] {
+  const tables = new Set<string>()
+
+  for (const statement of sqlStatementsOf(sql)) {
+    const stmt = statement.trim()
+    const direct = stmt.match(/^(?:CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?|ALTER\s+TABLE|DROP\s+TABLE(?:\s+IF\s+EXISTS)?|TRUNCATE\s+TABLE)\s+["'`]?(\w+)["'`]?/i)
+    if (direct?.[1]) {
+      tables.add(direct[1].toLowerCase())
+      continue
+    }
+
+    const index = stmt.match(/^CREATE\s+(?:UNIQUE\s+)?INDEX(?:\s+IF\s+NOT\s+EXISTS)?\s+\S+\s+ON\s+["'`]?(\w+)["'`]?/i)
+    if (index?.[1])
+      tables.add(index[1].toLowerCase())
+  }
+
+  return [...tables]
+}
+
+/** The tables a set of generated statements creates, lowercased. */
+export function createdTablesOf(statements: readonly string[]): string[] {
+  const tables = new Set<string>()
+  for (const statement of statements) {
+    const match = statement.trim().match(/^CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`]?(\w+)["'`]?/i)
+    if (match?.[1])
+      tables.add(match[1].toLowerCase())
+  }
+  return [...tables]
+}
+
+/**
+ * Which existing migrations describe tables the incoming corpus does NOT
+ * rebuild.
+ *
+ * This is the predicate `regenerateMigrationCorpus` needs and, until
+ * stacksjs/stacks#2255, did not have. #2234 established the rule — never
+ * delete a migration this run cannot recreate — and implemented it as "does
+ * the file carry the `@generated` marker". That was a sound proxy while the
+ * generator's model scope was fixed. Once #2220 made framework defaults a
+ * fallback rather than a merge, it stopped being one: in an app with its own
+ * `app/Models`, the migrations for `users`, `jobs`, `failed_jobs`, `payments`,
+ * `subscribers` and `teams` all carry the marker and are all outside the
+ * scope of any rerun. Regenerating deleted them, and the result looked clean —
+ * one tidy file per model — right up until the next deploy dropped the users
+ * table.
+ *
+ * So ask the question directly instead of by proxy: does the corpus about to
+ * be written contain every table this file touches? A file is recreatable only
+ * if it does. Anything else is preserved, whoever wrote it.
+ *
+ * A file whose SQL names no table at all (a bare `SELECT 1;` stub, a
+ * `CREATE TYPE`) is preserved too — the same "cannot prove it is ours" bias
+ * `isGeneratedMigration` takes, for the same reason.
+ */
+export function migrationsOutsideCorpus(
+  dir: string,
+  files: readonly string[],
+  corpusTables: readonly string[],
+): string[] {
+  const rebuilt = new Set(corpusTables.map(table => table.toLowerCase()))
+
+  return files.filter((file) => {
+    let contents: string
+    try {
+      contents = readFileSync(join(dir, file), 'utf8')
+    }
+    catch {
+      return true
+    }
+
+    const touched = tablesOperatedOn(contents)
+    if (touched.length === 0)
+      return true
+
+    return touched.some(table => !rebuilt.has(table))
+  })
+}
+
+/** The leading ordinal in a migration filename, or 0 when it has none. */
+function migrationOrdinal(file: string): number {
+  const match = file.match(/^(\d+)/)
+  return match ? Number(match[1]) : 0
+}
+
 export interface RegeneratedCorpus {
   dialect: string
   /** How many model definitions fed the generation. */
   models: number
+  /**
+   * The model roots that actually contributed, absolute.
+   *
+   * Reported because the plan used to claim it had read "app/Models and the
+   * framework defaults" unconditionally, which since #2220 is false whenever an
+   * app has models of its own — and the count sitting next to that sentence was
+   * the only hint that the defaults had contributed nothing
+   * (stacksjs/stacks#2255).
+   */
+  modelRoots: string[]
   /** Files that would be (or were) written, in order. */
   files: Array<{ name: string, statements: number }>
   /** Existing .sql files that would be (or were) removed. */
   removed: string[]
   /**
-   * Existing .sql files kept because nothing here can recreate them: they
-   * carry no `@generated` marker, so they were either hand-authored or emitted
-   * before the marker existed. Callers should show these to the user — a
-   * corpus written before this marker shipped will list every file here.
+   * Existing .sql files kept because nothing here can recreate them — for
+   * either reason: they carry no `@generated` marker (hand-authored, or
+   * emitted before the marker existed), or they describe a table outside this
+   * corpus. Callers should show these to the user; a corpus written before the
+   * marker shipped will list every file here.
    */
   preserved: string[]
+  /**
+   * The subset of {@link preserved} kept for the second reason: the corpus
+   * does not rebuild the tables these files describe.
+   *
+   * Worth separating in the UI, because the two mean opposite things. An
+   * unmarked file is someone's work the generator must not touch; an
+   * out-of-scope file is the framework's own schema going unregenerated, and
+   * that usually means the model that owned it is no longer in scope
+   * (stacksjs/stacks#2255).
+   */
+  preservedOutOfScope: string[]
   /** The directory operated on. */
   dir: string
 }
@@ -2286,7 +2435,10 @@ export async function regenerateMigrationCorpus(options: {
     )
     const dir = options.dir ?? migrationDirectory(dialect)
 
-    const sources = resolveModelSources()
+    // `forceStage` because of the sentinel written just below: it goes into
+    // `sources.dir`, and that has to be a directory this call owns rather than
+    // the app's own `app/Models` (stacksjs/stacks#2255).
+    const sources = resolveModelSources({ forceStage: true })
     if (!sources) {
       return err(new Error(
         'No models found. Define models in app/Models, or ensure the framework defaults at '
@@ -2307,8 +2459,10 @@ export async function regenerateMigrationCorpus(options: {
     //
     // bun-query-builder reads `.qb-migrations.<dialect>.json` from the models
     // directory as a starting state, so an empty plan there means "assume
-    // nothing exists". The staging directory is ours and is rebuilt on every
-    // call, so this cannot leak into the user's project.
+    // nothing exists". Writing it is only safe because of the `forceStage`
+    // above: the staging directory is ours and is rebuilt on every call, so
+    // this cannot leak into the user's project. Drop that flag and the sentinel
+    // lands in `app/Models` (stacksjs/stacks#2255).
     try {
       writeFileSync(
         join(sources.dir, `.qb-migrations.${dialect}.json`),
@@ -2377,25 +2531,39 @@ export async function regenerateMigrationCorpus(options: {
     }
     catch { /* directory does not exist yet */ }
 
-    // Only files this generator wrote may be deleted. Everything else is
-    // preserved: a hand-authored migration has no model to be rebuilt from, so
-    // deleting it is unrecoverable, and "rebuild from the models" was never a
-    // licence to remove work the models do not describe
-    // (stacksjs/stacks#2234). `--replace-unmarked` opts back into the old
-    // sweep for a corpus that predates the marker and is known to be entirely
-    // generator output.
-    const removed = options.replaceUnmarked
+    // Two independent reasons to keep a file, and a file only gets deleted if
+    // neither applies.
+    //
+    // 1. It carries no `@generated` marker, so a person wrote it and no rerun
+    //    can bring it back (stacksjs/stacks#2234). `--replace-unmarked` waives
+    //    this for a corpus that predates the marker.
+    // 2. It describes a table this corpus does not rebuild
+    //    (stacksjs/stacks#2255). No flag waives this one: `--replace-unmarked`
+    //    means "these unmarked files are generator output", not "delete the
+    //    schema for tables you are not regenerating".
+    const outOfScope = new Set(migrationsOutsideCorpus(dir, existing, createdTablesOf(statements)))
+    const deletable = options.replaceUnmarked
       ? existing
       : existing.filter(file => isGeneratedMigration(dir, file))
+    const removed = deletable.filter(file => !outOfScope.has(file))
     const preserved = existing.filter(file => !removed.includes(file))
+    const preservedOutOfScope = preserved.filter(file => outOfScope.has(file))
+
+    // Numbering continues past whatever is preserved rather than restarting at
+    // 1. The corpus runs in filename order, so a preserved
+    // `0000000076-create-users-table.sql` alongside a fresh
+    // `0000000001-create-orders-table.sql` would try to add the orders foreign
+    // key seventy-five files before its target existed. Nothing preserved means
+    // nothing to order against, and numbering starts at 1 as it always has.
+    const startAt = preserved.reduce((max, file) => Math.max(max, migrationOrdinal(file)), 0) + 1
 
     const files = groups.map((group, index) => ({
-      name: `${String(index + 1).padStart(10, '0')}-${group.label}.sql`,
+      name: `${String(startAt + index).padStart(10, '0')}-${group.label}.sql`,
       statements: group.statements.length,
     }))
 
     if (options.dryRun)
-      return ok({ dialect, models: sources.models.length, files, removed, preserved, dir })
+      return ok({ dialect, models: sources.models.length, modelRoots: sources.roots, files, removed, preserved, preservedOutOfScope, dir })
 
     mkdirSync(dir, { recursive: true })
 
@@ -2409,7 +2577,7 @@ export async function regenerateMigrationCorpus(options: {
       writeFileSync(join(dir, files[index]!.name), `${GENERATED_MIGRATION_MARKER}\n${body}`)
     })
 
-    return ok({ dialect, models: sources.models.length, files, removed, preserved, dir })
+    return ok({ dialect, models: sources.models.length, modelRoots: sources.roots, files, removed, preserved, preservedOutOfScope, dir })
   }
   catch (error) {
     return err(handleError('Migration regeneration failed', error))

--- a/storage/framework/core/database/src/model-sources.ts
+++ b/storage/framework/core/database/src/model-sources.ts
@@ -234,6 +234,20 @@ export function resolveModelSources(options: {
   frameworkRoot?: string
   /** Force the merge on or off, bypassing config and env. */
   includeFrameworkDefaults?: boolean
+  /**
+   * Always stage, even when a single flat root could be read directly.
+   *
+   * For callers that WRITE into the resolved directory. bun-query-builder reads
+   * `.qb-migrations.<dialect>.json` from the models directory as a previous
+   * state, and `regenerateMigrationCorpus` writes one there to force a full
+   * emit. On the fast path that directory is the app's own `app/Models`, so the
+   * sentinel landed in the user's source tree and stayed — and a later generate
+   * with no model snapshot would read it back as "no tables exist" and re-emit
+   * the entire schema. Unreachable before #2220, because an app with models of
+   * its own always had two roots to merge and therefore always staged
+   * (stacksjs/stacks#2255).
+   */
+  forceStage?: boolean
 } = {}): ResolvedModelSources | null {
   const userRoot = options.userRoot ?? path.userModelsPath()
   const frameworkRoot = options.frameworkRoot ?? path.frameworkPath('defaults/app/Models')
@@ -289,7 +303,7 @@ export function resolveModelSources(options: {
   // so the common userland-only project keeps reading its own directory.
   const onlyUser = contributing.length === 0
   const allFlat = models.every(m => basename(join(m.file, '..')) === basename(onlyUser ? userRoot : frameworkRoot))
-  if (roots.length === 1 && allFlat) {
+  if (!options.forceStage && roots.length === 1 && allFlat) {
     return { dir: roots[0]!, models, roots, staged: false, shadowed, excluded, excludedTables }
   }
 

--- a/storage/framework/core/database/tests/model-sources.test.ts
+++ b/storage/framework/core/database/tests/model-sources.test.ts
@@ -16,7 +16,7 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { prepareMigrationModelsDir, withoutExcludedTableDropSql } from '../src/migrations'
+import { prepareMigrationModelsDir, withoutProtectedTableDropSql } from '../src/migrations'
 import { cleanupModelStaging, resolveModelSources } from '../src/model-sources'
 
 const TMP = join(import.meta.dir, '.tmp-model-sources')
@@ -92,7 +92,7 @@ describe('resolveModelSources', () => {
 
     expect(resolved.excluded.map(m => m.name).sort()).toEqual(['Cart', 'PrintDevice'])
     // Derived exactly as the generator derives them, so the drop suppression
-    // in `withoutExcludedTableDropSql` can match what bqb emits.
+    // in `withoutProtectedTableDropSql` can match what bqb emits.
     expect(resolved.excludedTables).toEqual(['carts', 'print_devices'])
   })
 
@@ -167,7 +167,7 @@ describe('resolveModelSources', () => {
   })
 })
 
-describe('withoutExcludedTableDropSql', () => {
+describe('withoutProtectedTableDropSql', () => {
   // The narrowing in #2220 removes ~62 tables from the model set at once. The
   // generator diffs against the stored snapshot, so without this the very
   // first `generate:migrations` after upgrading proposes dropping all of them.
@@ -180,7 +180,7 @@ describe('withoutExcludedTableDropSql', () => {
 
   it('drops the DROP for an out-of-scope framework table', () => {
     const statements = [`DROP TABLE "carts"`, `CREATE TABLE "projects" (id INTEGER)`]
-    const result = withoutExcludedTableDropSql(statements, ['carts'], [op('carts', `DROP TABLE "carts"`)])
+    const result = withoutProtectedTableDropSql(statements, ['carts'], [op('carts', `DROP TABLE "carts"`)])
 
     expect(result.statements).toEqual([`CREATE TABLE "projects" (id INTEGER)`])
     expect(result.removed).toEqual([`DROP TABLE "carts"`])
@@ -189,7 +189,7 @@ describe('withoutExcludedTableDropSql', () => {
   it('leaves a drop of a table the app actually owns alone', () => {
     // A model the user deleted must still generate its drop.
     const statements = [`DROP TABLE "old_projects"`]
-    const result = withoutExcludedTableDropSql(statements, ['carts'], [op('old_projects', `DROP TABLE "old_projects"`)])
+    const result = withoutProtectedTableDropSql(statements, ['carts'], [op('old_projects', `DROP TABLE "old_projects"`)])
 
     expect(result.statements).toEqual(statements)
     expect(result.removed).toEqual([])
@@ -199,7 +199,7 @@ describe('withoutExcludedTableDropSql', () => {
     // Postgres appends CASCADE and MySQL uses backticks, so the operation's
     // `sql` is not always byte-identical to the emitted statement.
     const statements = [`DROP TABLE IF EXISTS \`coupons\``, `DROP TABLE IF EXISTS "carts" CASCADE`]
-    const result = withoutExcludedTableDropSql(statements, ['coupons', 'carts'], [])
+    const result = withoutProtectedTableDropSql(statements, ['coupons', 'carts'], [])
 
     expect(result.statements).toEqual([])
     expect(result.removed).toHaveLength(2)
@@ -207,7 +207,7 @@ describe('withoutExcludedTableDropSql', () => {
 
   it('is a no-op when nothing was excluded', () => {
     const statements = [`DROP TABLE "carts"`]
-    expect(withoutExcludedTableDropSql(statements, [], [op('carts', `DROP TABLE "carts"`)]).statements)
+    expect(withoutProtectedTableDropSql(statements, [], [op('carts', `DROP TABLE "carts"`)]).statements)
       .toEqual(statements)
   })
 
@@ -216,7 +216,7 @@ describe('withoutExcludedTableDropSql', () => {
       `ALTER TABLE "carts" ADD COLUMN note VARCHAR(255)`,
       `DELETE FROM "carts"`,
     ]
-    expect(withoutExcludedTableDropSql(statements, ['carts'], []).statements).toEqual(statements)
+    expect(withoutProtectedTableDropSql(statements, ['carts'], []).statements).toEqual(statements)
   })
 })
 

--- a/storage/framework/core/database/tests/regenerate-scope.test.ts
+++ b/storage/framework/core/database/tests/regenerate-scope.test.ts
@@ -1,0 +1,243 @@
+/**
+ * stacksjs/stacks#2255 — `buddy migrate` and `buddy migrate:regenerate`
+ * disagreed about which models define the schema, and the disagreement was
+ * destructive in the regenerate direction.
+ *
+ * The reporting app had 22 models in `app/Models`, 96 committed migrations, and
+ * used the framework's auth, queue and payment tables without declaring models
+ * for them. `migrate:regenerate --dry-run` proposed removing 95 files and
+ * writing 22: the removed set included `users`, `jobs`, `failed_jobs`,
+ * `payments`, `subscribers` and `teams`. The output looked clean — one tidy
+ * file per model — so committing it was the natural next step, and the next
+ * deploy would have dropped the users table.
+ *
+ * The rule was already right. #2234 established it: never delete a migration
+ * this run cannot recreate. It was implemented as "does the file carry the
+ * `@generated` marker", a sound proxy while the generator's model scope was
+ * fixed, and no longer one after #2220 made the framework defaults a fallback
+ * rather than a merge. These tests hold the predicate to the question it was
+ * always standing in for: does the corpus about to be written contain this
+ * table?
+ *
+ * The second half covers the same narrowing seen from `buddy migrate`, where
+ * it surfaced as two proposed drops of trait pivot tables.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  createdTablesOf,
+  GENERATED_MIGRATION_MARKER,
+  migrationsOutsideCorpus,
+  prepareMigrationModelsDir,
+  tablesOperatedOn,
+  withoutProtectedTableDropSql,
+} from '../src/migrations'
+import { cleanupModelStaging, resolveModelSources } from '../src/model-sources'
+import { traitTableNames } from '../src/trait-tables'
+
+const TMP = join(import.meta.dir, '.tmp-regenerate-scope')
+
+function write(name: string, body: string): void {
+  mkdirSync(TMP, { recursive: true })
+  writeFileSync(join(TMP, name), `${GENERATED_MIGRATION_MARKER}\n${body}`)
+}
+
+afterEach(() => {
+  rmSync(TMP, { recursive: true, force: true })
+  cleanupModelStaging()
+})
+
+describe('tablesOperatedOn', () => {
+  it('reads the target of a create, alter, drop and index', () => {
+    expect(tablesOperatedOn('CREATE TABLE users (id INTEGER);')).toEqual(['users'])
+    expect(tablesOperatedOn('ALTER TABLE posts ADD COLUMN title VARCHAR(255);')).toEqual(['posts'])
+    expect(tablesOperatedOn('DROP TABLE IF EXISTS carts;')).toEqual(['carts'])
+    expect(tablesOperatedOn('CREATE UNIQUE INDEX posts_slug ON posts (slug);')).toEqual(['posts'])
+  })
+
+  it('handles quoted identifiers and IF NOT EXISTS', () => {
+    expect(tablesOperatedOn('CREATE TABLE IF NOT EXISTS "failed_jobs" (id INTEGER);')).toEqual(['failed_jobs'])
+    expect(tablesOperatedOn('CREATE TABLE `jobs` (id INTEGER);')).toEqual(['jobs'])
+  })
+
+  it('does NOT count a foreign key target as a table the file operates on', () => {
+    // This is the distinction the whole predicate rests on. Almost every app
+    // table references `users`; if that counted, almost nothing would ever be
+    // classified as regenerable and the command would stop doing its job.
+    const sql = 'CREATE TABLE orders (id INTEGER, user_id INTEGER, FOREIGN KEY (user_id) REFERENCES users(id));'
+
+    expect(tablesOperatedOn(sql)).toEqual(['orders'])
+  })
+
+  it('collects every table across a multi-statement file', () => {
+    const sql = 'CREATE TABLE a (id INTEGER);\nCREATE TABLE b (id INTEGER);\nALTER TABLE a ADD COLUMN x INTEGER;\n'
+
+    expect(tablesOperatedOn(sql).sort()).toEqual(['a', 'b'])
+  })
+
+  it('returns nothing for SQL that names no table', () => {
+    expect(tablesOperatedOn('SELECT 1;')).toEqual([])
+    expect(tablesOperatedOn(`CREATE TYPE status_type AS ENUM ('a', 'b');`)).toEqual([])
+  })
+})
+
+describe('createdTablesOf', () => {
+  it('reports only tables a statement creates', () => {
+    const statements = [
+      'CREATE TABLE users (id INTEGER)',
+      'ALTER TABLE users ADD COLUMN email VARCHAR(255)',
+      'CREATE TABLE IF NOT EXISTS "posts" (id INTEGER)',
+      'CREATE INDEX posts_slug ON posts (slug)',
+    ]
+
+    expect(createdTablesOf(statements).sort()).toEqual(['posts', 'users'])
+  })
+})
+
+describe('migrationsOutsideCorpus (#2255)', () => {
+  it('preserves the framework tables from the report', () => {
+    // The app's own models are in scope; the framework tables it relies on
+    // without declaring are not.
+    write('0000000076-create-users-table.sql', 'CREATE TABLE users (id INTEGER);')
+    write('0000000028-create-jobs-table.sql', 'CREATE TABLE jobs (id INTEGER);')
+    write('0000000044-create-payments-table.sql', 'CREATE TABLE payments (id INTEGER);')
+    write('0000000090-create-orders-table.sql', 'CREATE TABLE orders (id INTEGER);')
+
+    const outside = migrationsOutsideCorpus(
+      TMP,
+      [
+        '0000000028-create-jobs-table.sql',
+        '0000000044-create-payments-table.sql',
+        '0000000076-create-users-table.sql',
+        '0000000090-create-orders-table.sql',
+      ],
+      ['orders'],
+    )
+
+    expect(outside).toEqual([
+      '0000000028-create-jobs-table.sql',
+      '0000000044-create-payments-table.sql',
+      '0000000076-create-users-table.sql',
+    ])
+  })
+
+  it('lets go of a file whose table the corpus rebuilds', () => {
+    write('0000000001-create-orders-table.sql', 'CREATE TABLE orders (id INTEGER);')
+
+    expect(migrationsOutsideCorpus(TMP, ['0000000001-create-orders-table.sql'], ['orders'])).toEqual([])
+  })
+
+  it('lets go of an ALTER on an in-scope table', () => {
+    // The regenerated CREATE TABLE is a full emit, so it already contains what
+    // this ALTER added. Preserving it would replay a column that exists.
+    write('0000000002-alter-orders-columns.sql', 'ALTER TABLE orders ADD COLUMN total INTEGER;')
+
+    expect(migrationsOutsideCorpus(TMP, ['0000000002-alter-orders-columns.sql'], ['orders'])).toEqual([])
+  })
+
+  it('preserves a file that touches an out-of-scope table alongside an in-scope one', () => {
+    // Mixed files are kept. Preserving something regenerable is redundant;
+    // deleting something unregenerable is unrecoverable, so the tie goes to
+    // keeping it.
+    write('0000000003-mixed.sql', 'ALTER TABLE orders ADD COLUMN x INTEGER;\nALTER TABLE users ADD COLUMN y INTEGER;')
+
+    expect(migrationsOutsideCorpus(TMP, ['0000000003-mixed.sql'], ['orders'])).toEqual(['0000000003-mixed.sql'])
+  })
+
+  it('preserves a file whose SQL names no table at all', () => {
+    // 40 files in the shipped corpus are `SELECT 1;` stubs. Nothing here can
+    // prove they are regenerable, so they stay.
+    write('0000000004-auto-misc.sql', 'SELECT 1;')
+
+    expect(migrationsOutsideCorpus(TMP, ['0000000004-auto-misc.sql'], ['orders'])).toEqual(['0000000004-auto-misc.sql'])
+  })
+
+  it('preserves a file it cannot read', () => {
+    expect(migrationsOutsideCorpus(TMP, ['no-such-file.sql'], ['orders'])).toEqual(['no-such-file.sql'])
+  })
+
+  it('preserves everything when the corpus creates nothing', () => {
+    write('0000000001-create-orders-table.sql', 'CREATE TABLE orders (id INTEGER);')
+
+    expect(migrationsOutsideCorpus(TMP, ['0000000001-create-orders-table.sql'], [])).toEqual([
+      '0000000001-create-orders-table.sql',
+    ])
+  })
+
+  it('is case-insensitive about table names', () => {
+    write('0000000001-create-orders-table.sql', 'CREATE TABLE Orders (id INTEGER);')
+
+    expect(migrationsOutsideCorpus(TMP, ['0000000001-create-orders-table.sql'], ['ORDERS'])).toEqual([])
+  })
+})
+
+describe('forceStage keeps regeneration out of app/Models (#2255)', () => {
+  it('stages even when a single flat root could be read directly', () => {
+    // `regenerateMigrationCorpus` writes a `.qb-migrations.<dialect>.json`
+    // sentinel into the resolved directory to force a full emit. Before #2220
+    // an app with models of its own always had two roots to merge and so always
+    // staged; now it takes the fast path, and without `forceStage` the sentinel
+    // is written into the app's own source tree. bun-query-builder reads that
+    // file back as "no tables exist" whenever the model snapshot is missing.
+    const user = join(TMP, 'models')
+    mkdirSync(user, { recursive: true })
+    writeFileSync(join(user, 'Project.ts'), `export default { name: 'Project' }\n`)
+
+    const direct = resolveModelSources({ userRoot: user, frameworkRoot: join(TMP, 'absent') })!
+    expect(direct.staged).toBe(false)
+    expect(direct.dir).toBe(user)
+
+    const staged = resolveModelSources({ userRoot: user, frameworkRoot: join(TMP, 'absent'), forceStage: true })!
+    expect(staged.staged).toBe(true)
+    expect(staged.dir).not.toBe(user)
+    expect(readdirSync(staged.dir)).toEqual(['Project.ts'])
+  })
+
+  it('still reports the roots that contributed, not the staging directory', () => {
+    // The plan banner reads `roots`, so staging must not make it claim the
+    // models came from somewhere under storage/framework.
+    const user = join(TMP, 'models')
+    mkdirSync(user, { recursive: true })
+    writeFileSync(join(user, 'Project.ts'), `export default { name: 'Project' }\n`)
+
+    const staged = resolveModelSources({ userRoot: user, frameworkRoot: join(TMP, 'absent'), forceStage: true })!
+
+    expect(staged.roots).toEqual([user])
+  })
+})
+
+describe('trait tables are never dropped (#2255)', () => {
+  it('prepareMigrationModelsDir protects every trait table', () => {
+    // `taggable_models` and `categorizable_models` reach the snapshot as
+    // belongsToMany pivots of the framework's Post model, so they leave scope
+    // with it — while `excludedTables`, which reads a model's own `table:`,
+    // never hears about them.
+    const { protectedTables } = prepareMigrationModelsDir()
+
+    for (const table of traitTableNames())
+      expect(protectedTables).toContain(table)
+  })
+
+  it('suppresses the two drops the report saw', () => {
+    const statements = [
+      `DROP TABLE "categorizable_models"`,
+      `DROP TABLE "taggable_models"`,
+      `CREATE TABLE "orders" (id INTEGER)`,
+    ]
+
+    const result = withoutProtectedTableDropSql(statements, traitTableNames(), [])
+
+    expect(result.removed).toHaveLength(2)
+    expect(result.statements).toEqual([`CREATE TABLE "orders" (id INTEGER)`])
+  })
+
+  it('still drops a table that is genuinely gone', () => {
+    // The suppression is scoped to framework-owned tables, not a blanket
+    // "never drop anything".
+    const statements = [`DROP TABLE "old_projects"`]
+
+    expect(withoutProtectedTableDropSql(statements, traitTableNames(), []).statements).toEqual(statements)
+  })
+})


### PR DESCRIPTION
Closes #2255.

`buddy migrate` and `buddy migrate:regenerate` disagreed about which models define the schema, and the disagreement was destructive in the regenerate direction. On the reporting app (22 models in `app/Models`, 96 committed migrations, framework auth/queue/payment tables it never declared models for) `migrate:regenerate --dry-run` proposed removing 95 files and writing 22. The removed set included `users`, `jobs`, `failed_jobs`, `payments`, `subscribers` and `teams`.

The output looked clean, one tidy file per model, which is what made it dangerous: committing it was the natural next step and the next deploy would have dropped the user table.

Three faults, all fallout from #2220 narrowing the generator's model scope. All three are mine, from #2221.

## 1. The deletion predicate was a proxy that stopped holding

#2234 set the rule: never delete a migration this run cannot recreate. It was implemented as *"does the file carry the `@generated` marker"*, which was sound while the model scope was fixed and stopped being sound the moment the framework defaults became a fallback rather than a merge. Every one of those framework migrations carries the marker, and none of them is in scope for a rerun.

So ask the question directly instead of by proxy: **does the corpus about to be written contain every table this file operates on?**

`tablesOperatedOn` reads the target of a `CREATE`/`ALTER`/`DROP TABLE` or a `CREATE INDEX`, and deliberately ignores foreign key `REFERENCES` targets. Counting those would classify almost every app table as unregenerable, because almost every app table points at `users`.

No flag waives this. `--replace-unmarked` means "these unmarked files are generator output", not "delete the schema for tables you are not regenerating".

## 2. Numbering restarted at 1 regardless of what was preserved

With framework migrations now surviving, a preserved `0000000044-create-users-table.sql` next to a fresh `0000000001-create-orders-table.sql` would add the orders foreign key forty-three files before its target existed. Numbering continues past the highest preserved ordinal, and still starts at 1 when nothing is preserved.

## 3. `buddy migrate` proposed dropping `taggable_models` and `categorizable_models`

These are the two destructive changes in the issue. They reach the snapshot as `belongsToMany` pivots of the framework's `Post` model, so they leave scope with it, while `excludedTables` only ever knew about a model's own `table:`.

`migrateTraitTables()` recreates both on the very next migrate, so the drop is destructive *and* immediately undone. `prepareMigrationModelsDir` now reports `protectedTables` (excluded model tables plus `traitTableNames()`) alongside `excludedTables`, and the suppression reads the former. `excludedTables` stays as-is for the messaging, which is genuinely about models.

## Also: a sentinel leaking into `app/Models`

Found while reproducing this, same root cause, so it is fixed here.

`regenerateMigrationCorpus` writes a `.qb-migrations.<dialect>.json` sentinel into the resolved models directory to force a full emit rather than a delta, and its comment asserted the staging directory made that safe. Since #2220, an app with flat models of its own takes `resolveModelSources`' fast path, where the resolved directory **is** `app/Models`. The sentinel landed in the user's source tree and was never removed, and bun-query-builder reads that path back as a legacy previous state whenever the model snapshot is missing:

```js
let U = join(modelsDir, `.qb-migrations.${dialect}.json`)
if (existsSync(U)) { /* "Comparing with legacy state file" */ }
```

A stale `{tables: []}` there means "assume nothing exists", so a later generate re-emits the entire schema. Regeneration now passes `forceStage`.

## Verification

Against this repo's own 173-file corpus, copied to a scratch dir and stamped with the marker so it matches the reporting app's (which was generated on 0.70.294, after #2248):

```
corpus on disk: 173
BEFORE this fix, would remove: 173
AFTER  this fix, removes:      0 (none)
preserved: 173 (out of scope: 173)

  users        before: DELETED   after: kept
  jobs         before: DELETED   after: kept
  failed_jobs  before: DELETED   after: kept
  payments     before: DELETED   after: kept
  subscribers  before: DELETED   after: kept
  teams        before: DELETED   after: kept
```

And the other direction, so the command has not simply stopped working:

```
removes: 0000000200-create-missions-table.sql, 0000000201-alter-sites-columns.sql
preserved: 173
writes: ...-create-missions-table.sql, ...-create-sites-table.sql
```

The sentinel now lands in `storage/framework/runtime/model-sources/`, not `app/Models`.

19 new tests in `database/tests/regenerate-scope.test.ts`. Full local core sweep at the `browser-extension cache charts defaults queue` baseline. Typecheck 13, matching main exactly (measured by stashing this branch's changes and re-running, because two `SupportedDialect` errors in `core/database` flicker between runs and I did not want to attribute them to this diff).

Note that GitHub Actions has not been running CI on this repo, so this was verified locally.