### PR TITLE
fix(env): let resetPrivateKeyCache actually reset the environment

### DIFF
--- a/storage/framework/core/env/src/plugin.ts
+++ b/storage/framework/core/env/src/plugin.ts
@@ -159,12 +159,25 @@ export function resolvePrivateKey(options: { env?: string, cwd?: string } = {}):
 }
 
 /**
- * Clear the cached private key. Needed after key rotation and between tests
- * that swap `DOTENV_PRIVATE_KEY*` or `APP_ENV`.
+ * Clear the cached private key AND the recorded environment. Needed after key
+ * rotation and between tests that swap `DOTENV_PRIVATE_KEY*` or `APP_ENV`.
+ *
+ * `loadedEnvName` has to go with it. It deliberately outranks `APP_ENV` in
+ * {@link activeEnvName} — an env file that has been read owns the keys for
+ * anything decrypted afterwards — so leaving it set means a later
+ * `APP_ENV` swap is silently ignored, which is the one thing this function
+ * exists to make possible. Whether it happened to be set at all depended on
+ * which test file ran first in the process, so the env proxy's decryption
+ * tests passed or failed on file ordering and CI went red on roughly half of
+ * all runs (stacksjs/stacks#2259).
+ *
+ * Test-only: nothing outside `core/env/tests` calls this, so clearing the
+ * recorded environment cannot affect a running app.
  */
 export function resetPrivateKeyCache(): void {
   cachedKeyEnv = null
   cachedPrivateKey = undefined
+  loadedEnvName = undefined
 }
 
 /**

--- a/storage/framework/core/env/tests/plugin-decrypt-precedence.test.ts
+++ b/storage/framework/core/env/tests/plugin-decrypt-precedence.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
 import { encryptValue, generateKeypair } from '../src/crypto'
-import { autoLoadEnv, decryptEnvValue, loadEnv, resetPrivateKeyCache, resolvePrivateKey } from '../src/plugin'
+import { activeEnvName, autoLoadEnv, decryptEnvValue, loadEnv, resetPrivateKeyCache, resolvePrivateKey } from '../src/plugin'
 
 // Bun natively loads `.env` / `.env.<mode>` into process.env before any
 // preload script runs, and it knows nothing about dotenvx-style encryption.
@@ -212,5 +212,63 @@ describe('resolvePrivateKey / decryptEnvValue - .env.keys discovery', () => {
 
   test('passes non-encrypted values through unchanged', () => {
     expect(decryptEnvValue('plain-value', { env: 'production', cwd: dir })).toBe('plain-value')
+  })
+})
+
+// stacksjs/stacks#2259 — `activeEnvName` puts `loadedEnvName` above `APP_ENV`
+// on purpose: an env file that has been read owns the keys for anything
+// decrypted afterwards. `resetPrivateKeyCache` did not clear it, so once
+// anything in the process had called `autoLoadEnv`, a later `APP_ENV` swap was
+// silently ignored — the one thing that function exists to make possible.
+//
+// It surfaced as CI flake rather than a failure. Whether `loadedEnvName` was
+// set depended on which test file bun happened to run first, so the env proxy's
+// three decryption tests passed or failed on file ordering and `core/env` went
+// red on roughly half of all runs, on main as well as on PRs.
+describe('resetPrivateKeyCache clears the recorded environment (#2259)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'env-reset-'))
+    resetPrivateKeyCache()
+  })
+
+  afterEach(() => {
+    resetPrivateKeyCache()
+    rmSync(dir, { recursive: true, force: true })
+    delete process.env.APP_ENV
+    delete process.env.DOTENV_PRIVATE_KEY_STAGING
+  })
+
+  test('an APP_ENV swap takes effect after autoLoadEnv has latched an environment', () => {
+    const staging = generateKeypair()
+    writeFileSync(join(dir, '.env.development'), 'SOME_VALUE=development')
+
+    // Latch `loadedEnvName = 'development'`, exactly as any earlier test file
+    // (or a real boot) would.
+    process.env.APP_ENV = 'development'
+    autoLoadEnv({ cwd: dir, quiet: true })
+
+    // Now become staging, the way the env proxy's own tests do.
+    process.env.APP_ENV = 'staging'
+    process.env.DOTENV_PRIVATE_KEY_STAGING = staging.privateKey
+    delete process.env.NODE_ENV
+    resetPrivateKeyCache()
+
+    expect(activeEnvName()).toBe('staging')
+    expect(resolvePrivateKey({ cwd: dir })).toBe(staging.privateKey)
+  })
+
+  test('without the reset, the latched environment still wins', () => {
+    // The precedence itself is deliberate and must not regress: a loaded env
+    // file keeps owning key resolution until something explicitly resets.
+    writeFileSync(join(dir, '.env.development'), 'SOME_VALUE=development')
+    process.env.APP_ENV = 'development'
+    autoLoadEnv({ cwd: dir, quiet: true })
+
+    process.env.APP_ENV = 'staging'
+    delete process.env.NODE_ENV
+
+    expect(activeEnvName()).toBe('development')
   })
 })


### PR DESCRIPTION
Closes #2259.

CI's `test` job reported `core/env` red on roughly half of all runs, **on main as much as on PRs**, always the same three env-proxy decryption tests, always with `no usable private key was found for the "development" environment` even though each of those tests sets `APP_ENV = 'test'`.

I hit it disambiguating #2257 and it cost real time, because telling it apart from a genuine regression means pulling the failing-package list off both the PR run and a main run at the same SHA.

## It is not random

It is file-order dependent, and reproduces every time:

```
$ bun test ./storage/framework/core/env/tests/plugin-decrypt-precedence.test.ts \
           ./storage/framework/core/env/tests/env-proxy.test.ts
 20 pass
 3 fail

$ bun test ./storage/framework/core/env/tests/env-proxy.test.ts \
           ./storage/framework/core/env/tests/plugin-decrypt-precedence.test.ts
 23 pass
 0 fail
```

## Cause

`activeEnvName()` ranks `loadedEnvName` above `APP_ENV`. That ordering is deliberate and correct: an env file that has been read owns the keys for anything decrypted afterwards, so a later `APP_ENV` mutation must not silently repoint key resolution at an environment whose file was never loaded.

`resetPrivateKeyCache()` did not clear it:

```ts
export function resetPrivateKeyCache(): void {
  cachedKeyEnv = null
  cachedPrivateKey = undefined
}
```

while its own docblock promised it was *"needed after key rotation and between tests that swap `DOTENV_PRIVATE_KEY*` or `APP_ENV`"*. An `APP_ENV` swap is precisely what it could not deliver.

Bun runs a package's test files in one process, so once `plugin-decrypt-precedence.test.ts` called `autoLoadEnv()` and latched `loadedEnvName = 'development'`, every later `APP_ENV` swap in that process was ignored. Whether that file ran before or after `env-proxy.test.ts` decided whether `core/env` passed.

## Fix

One line, plus the docblock explaining why it belongs there. Safe because nothing outside `core/env/tests` calls `resetPrivateKeyCache`, so no running app can observe it, and the precedence itself is untouched.

Two regression tests:

- an `APP_ENV` swap takes effect after `autoLoadEnv` has latched an environment (fails without the fix, confirmed by reverting the line)
- **without** the reset, the latched environment still wins, so the fix cannot be misread as a licence to let `APP_ENV` outrank a loaded env file

`core/env`: 206 pass, 0 fail, in both file orders. Full local core sweep at baseline.