### PR TITLE
feat(validation): let a client check an Action's own rules

### DIFF
--- a/storage/framework/core/buddy/tests/password-policy.test.ts
+++ b/storage/framework/core/buddy/tests/password-policy.test.ts
@@ -1,0 +1,108 @@
+// One password policy, in one place (stacksjs/stacks#2226).
+//
+// The framework shipped three numbers for one product concept: RegisterAction
+// and LoginAction accepted six characters, the User model declared six, and
+// PasswordResetAction hand-checked eight inside handle() — not in a
+// `validations:` block at all, so nothing that reads declared rules could see
+// it.
+//
+// This walks the declaration sites rather than restating the number, so a
+// fourth one added later fails here instead of in somebody's signup form.
+
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+} from '../../../defaults/app/password-policy'
+
+const DEFAULTS = join(import.meta.dir, '../../../defaults/app')
+
+/**
+ * Source with `//` comments removed.
+ *
+ * Asserting "this string does not appear" against raw source is a trap: the
+ * comment explaining WHY the code is gone contains the string, so the check
+ * fails on the very commit that fixes it.
+ */
+function code(source: string): string {
+  return source.replace(/\/\/.*$/gm, '')
+}
+
+const read = (relative: string): string => readFileSync(join(DEFAULTS, relative), 'utf8')
+
+/** The `password:` entry of a `validations:` block, isolated from its siblings. */
+function passwordRuleOf(source: string): string {
+  const start = source.indexOf('password: {')
+  if (start === -1)
+    return ''
+  return source.slice(start, source.indexOf('},', start))
+}
+
+const REGISTER = read('Actions/Auth/RegisterAction.ts')
+const LOGIN = read('Actions/Auth/LoginAction.ts')
+const RESET = read('Actions/Password/PasswordResetAction.ts')
+const USER = read('Models/User.ts')
+
+describe('the policy is declared once (#2226)', () => {
+  it('is a sane minimum', () => {
+    // Not a tautology check: 8 is what the reset path already enforced, and
+    // dropping below it would be a silent weakening of the only rule that was
+    // protecting anything.
+    expect(PASSWORD_MIN_LENGTH).toBeGreaterThanOrEqual(8)
+    expect(PASSWORD_MAX_LENGTH).toBe(255)
+  })
+
+  it('the paths that SET a password all reference it', () => {
+    for (const [name, source] of [['RegisterAction', REGISTER], ['PasswordResetAction', RESET], ['User model', USER]] as const) {
+      expect(`${name}: ${source.includes('PASSWORD_MIN_LENGTH')}`).toBe(`${name}: true`)
+    }
+  })
+
+  it('none of them hardcodes a number instead', () => {
+    // The failure mode being prevented: someone types the digit rather than
+    // importing the constant, and the four drift apart again. Scoped to the
+    // password rule — a sibling field's own `min()` is not this test's business.
+    for (const [name, source] of [['RegisterAction', REGISTER], ['PasswordResetAction', RESET], ['User model', USER]] as const) {
+      const hardcoded = /\.min\((\d+)\)/.exec(passwordRuleOf(code(source)))
+      expect(`${name}: ${hardcoded?.[1] ?? 'none'}`).toBe(`${name}: none`)
+    }
+  })
+})
+
+describe('sign-in does not enforce the creation policy (#2226)', () => {
+  it('LoginAction requires presence, not length', () => {
+    // The trap in "make them all agree": applying a creation rule to
+    // authentication locks out every account created under a shorter one. They
+    // get a 422 before their credentials are checked, telling them their own
+    // password is too short.
+    expect(LOGIN).toContain('schema.string().min(1)')
+    expect(LOGIN).not.toContain('PASSWORD_MIN_LENGTH')
+  })
+})
+
+describe('the reset path declares its rule (#2226)', () => {
+  it('no longer hand-checks the length inside handle()', () => {
+    // `password.length < 8` was invisible to everything that reads
+    // `validations:`, which is why it could drift from the others unnoticed.
+    expect(code(RESET)).not.toContain('password.length <')
+    expect(RESET).toContain('validations:')
+  })
+
+  it('still checks confirmation by hand, because that is cross-field', () => {
+    // Declared rules see one field at a time, so this one legitimately stays.
+    expect(RESET).toContain('password !== passwordConfirmation')
+  })
+})
+
+describe('seeded users satisfy the rule they are seeded against (#2226)', () => {
+  it('the User factory password is long enough', () => {
+    const factory = /factory:\s*\(\)\s*=>\s*'([^']*)'/.exec(
+      USER.slice(USER.indexOf('password: {')),
+    )
+
+    expect(factory?.[1]).toBeDefined()
+    expect(factory![1].length).toBeGreaterThanOrEqual(PASSWORD_MIN_LENGTH)
+  })
+})

--- a/storage/framework/core/router/src/stacks-router.ts
+++ b/storage/framework/core/router/src/stacks-router.ts
@@ -1541,6 +1541,70 @@ function validationFailureResponse(errors: Record<string, string[]>): Response {
   return response.validationError(errors) as Response
 }
 
+/**
+ * Whether this request is asking "would this be accepted?" rather than
+ * "do this" (stacksjs/stacks#2226).
+ *
+ * An Action's `validations:` block was a server-only artifact: nothing could
+ * read it from a template or a client script, so every form in every app
+ * retyped the rules in the browser and the two copies drifted. The framework's
+ * own defaults demonstrated it — the browser refused a 7-character password
+ * that `POST /register` would have accepted.
+ *
+ * Rather than serialise the rules (a `schema.*` chain is a live object with
+ * no faithful JSON projection), the client asks the real endpoint to run the
+ * real rules and stops short of the side effect. Same shape as Laravel
+ * Precognition, and deliberately header-compatible with it.
+ *
+ * `?_validate=1` is accepted too: a header cannot be set on a plain form
+ * submission or a `<script client>` block using a bare fetch shorthand, and
+ * requiring one would have put this out of reach of the simplest caller.
+ */
+export function precognitionRequest(req: EnhancedRequest): { only: string[] } | null {
+  const header = req.headers?.get?.('Precognition')
+  const viaHeader = typeof header === 'string' && header.toLowerCase() === 'true'
+
+  let viaQuery = false
+  try {
+    viaQuery = new URL(req.url).searchParams.get('_validate') === '1'
+  }
+  catch {
+    viaQuery = false
+  }
+
+  if (!viaHeader && !viaQuery)
+    return null
+
+  // `Precognition-Validate-Only: email,password` narrows the run to the fields
+  // the form has actually touched, which is what makes validate-on-blur usable:
+  // without it, blurring the first field reports every later field as empty.
+  const only = (req.headers?.get?.('Precognition-Validate-Only') ?? '')
+    .split(',')
+    .map(field => field.trim())
+    .filter(Boolean)
+
+  return { only }
+}
+
+/**
+ * The "nothing to report" answer to a precognition request. 204 rather than an
+ * empty 200 so a client cannot mistake it for the action's real result.
+ *
+ * `Vary` because the same URL and method now has two different answers
+ * depending on a request header — without it a shared cache is entitled to
+ * serve this 204 to a caller that meant to submit.
+ */
+export function precognitionSuccess(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Precognition': 'true',
+      'Precognition-Success': 'true',
+      'Vary': 'Precognition, Precognition-Validate-Only',
+    },
+  })
+}
+
 async function resolveStringHandlerUncached(handlerPath: string): Promise<RouteHandlerFn> {
   assertSafeHandlerPath(handlerPath)
   let modulePath = handlerPath
@@ -1641,6 +1705,29 @@ async function resolveStringHandlerUncached(handlerPath: string): Promise<RouteH
       ;(req as any)._requestValidationRules = action.validations
         ?? modelValidationRules(action.modelDefinition ?? action.model)
       try {
+        // A precognition request answers "would this be accepted?" and must
+        // never reach handle() — that is the whole point, and it is why this
+        // returns before authorize/before/handle rather than after validation
+        // falls through. An action with no validations still returns early:
+        // running the handler because there was nothing to check would make
+        // the probe itself the side effect (#2226).
+        const precognition = precognitionRequest(req)
+        if (precognition) {
+          if (!action.validations)
+            return precognitionSuccess()
+
+          const rules = precognition.only.length > 0
+            ? Object.fromEntries(
+                Object.entries(action.validations).filter(([field]) => precognition.only.includes(field)),
+              )
+            : action.validations
+
+          const precognitionResult = await validateActionInput(req, rules)
+          return precognitionResult.valid
+            ? precognitionSuccess()
+            : validationFailureResponse(precognitionResult.errors)
+        }
+
         // Validate action input if validations are defined. Always returns
         // JSON — validation failures are 100% an API-shape signal and HTML
         // pages would be useless here.

--- a/storage/framework/core/router/tests/precognition.test.ts
+++ b/storage/framework/core/router/tests/precognition.test.ts
@@ -1,0 +1,195 @@
+// Asking "would this be accepted?" without doing it (stacksjs/stacks#2226).
+//
+// An Action's `validations:` block was a server-only artifact — nothing could
+// read it from a template or a client script — so every form in every app
+// retyped the rules in the browser and the two copies drifted. The framework's
+// own defaults proved the failure mode: the browser refused a 7-character
+// password that `POST /register` would have accepted.
+//
+// Rather than serialise a `schema.*` chain (a live object with no faithful JSON
+// projection), the client asks the real endpoint to run the real rules and stop
+// before the side effect. Header-compatible with Laravel Precognition.
+//
+// The property that matters most is the negative one: a probe must never reach
+// handle(). A validate-only mode that still registers the user is worse than no
+// validate-only mode at all — and that one is asserted structurally, because
+// driving a real route needs a booted app, a database and an auth stack that
+// this package's tests do not have.
+
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { schema } from '@stacksjs/validation'
+import { precognitionRequest, precognitionSuccess, validateActionInput } from '../src/stacks-router'
+
+/** Minimal stand-in for the shape `precognitionRequest` reads. */
+function request(url: string, headers: Record<string, string> = {}): any {
+  return { url, headers: new Headers(headers) }
+}
+
+describe('recognising a precognition request (#2226)', () => {
+  it('is not one by default', () => {
+    expect(precognitionRequest(request('http://localhost/register'))).toBeNull()
+  })
+
+  it('the Precognition header opts in', () => {
+    expect(precognitionRequest(request('http://localhost/register', { Precognition: 'true' })))
+      .toEqual({ only: [] })
+  })
+
+  it('the header is case-insensitive in its value', () => {
+    expect(precognitionRequest(request('http://localhost/register', { Precognition: 'True' })))
+      .toEqual({ only: [] })
+  })
+
+  it('a header that is not "true" does not opt in', () => {
+    // `Precognition: false` must mean what it says, not merely "present".
+    expect(precognitionRequest(request('http://localhost/register', { Precognition: 'false' })))
+      .toBeNull()
+  })
+
+  it('?_validate=1 opts in too', () => {
+    // A header cannot be set on a plain form submission, and requiring one puts
+    // this out of reach of the simplest caller.
+    expect(precognitionRequest(request('http://localhost/register?_validate=1')))
+      .toEqual({ only: [] })
+  })
+
+  it('another query value does not', () => {
+    expect(precognitionRequest(request('http://localhost/register?_validate=0'))).toBeNull()
+  })
+
+  it('survives a malformed url instead of throwing', () => {
+    // `new URL` throws on a relative url, and a throw here would take down
+    // every request rather than just this check.
+    expect(precognitionRequest({ url: '/register', headers: new Headers() } as any)).toBeNull()
+  })
+})
+
+describe('narrowing to the touched fields (#2226)', () => {
+  it('parses the field list', () => {
+    // Validate-on-blur is unusable without this: blurring the first field would
+    // otherwise report every later field as empty.
+    const probe = precognitionRequest(request('http://localhost/register', {
+      'Precognition': 'true',
+      'Precognition-Validate-Only': 'email,password',
+    }))
+
+    expect(probe).toEqual({ only: ['email', 'password'] })
+  })
+
+  it('tolerates spacing and trailing separators', () => {
+    const probe = precognitionRequest(request('http://localhost/register', {
+      'Precognition': 'true',
+      'Precognition-Validate-Only': ' email , , password, ',
+    }))
+
+    expect(probe).toEqual({ only: ['email', 'password'] })
+  })
+})
+
+describe('the success answer (#2226)', () => {
+  const res = precognitionSuccess()
+
+  it('is 204, not an empty 200', () => {
+    // A 200 with no body is indistinguishable from the action having run and
+    // returned nothing.
+    expect(res.status).toBe(204)
+  })
+
+  it('says what it was', () => {
+    expect(res.headers.get('Precognition-Success')).toBe('true')
+  })
+
+  it('varies on the headers that change the answer', () => {
+    // Same URL, same method, two different answers — without Vary a shared
+    // cache may serve this 204 to a caller that meant to submit.
+    expect(res.headers.get('Vary')).toContain('Precognition')
+  })
+})
+
+describe('narrowed validation runs the real rules (#2226)', () => {
+  // The point of the whole mechanism: the browser gets the server's answer, not
+  // a retyped approximation of it.
+  const rules = {
+    email: { rule: schema.string().email(), message: 'Email must be a valid email address.' },
+    password: { rule: schema.string().min(8).max(255), message: 'Password must be between 8 and 255 characters.' },
+  }
+
+  // `getRequestInput` reads `req.jsonBody`, which `parseRequestBody` has
+  // already populated by the time any action handler runs — the raw stream is
+  // long consumed. The precognition branch sits in the same handler as the
+  // ordinary validation pass, so it sees exactly this input.
+  function payload(body: Record<string, unknown>): any {
+    const req = new Request('http://localhost/register', { method: 'POST' }) as any
+    req.jsonBody = body
+    return req
+  }
+
+  it('rejects the password the browser used to accept', async () => {
+    // Seven characters: refused by the app's hand-written copy, accepted by
+    // RegisterAction's own min(6). This is the drift the issue reported.
+    const result = await validateActionInput(payload({ email: 'a@b.com', password: '1234567' }), rules as any)
+    expect(result.valid).toBeFalse()
+    expect(result.errors.password).toBeDefined()
+  })
+
+  it('accepts one that satisfies the policy', async () => {
+    const result = await validateActionInput(payload({ email: 'a@b.com', password: '12345678' }), rules as any)
+    expect(result.valid).toBeTrue()
+  })
+
+  it('a narrowed run only reports the named field', async () => {
+    // Only `password` is submitted; validating just that field must not report
+    // the absent email — which is what makes validate-on-blur usable.
+    const narrowed = { password: rules.password }
+    const result = await validateActionInput(payload({ password: 'short' }), narrowed as any)
+    expect(result.valid).toBeFalse()
+    expect(Object.keys(result.errors)).toEqual(['password'])
+  })
+
+  it('the full rule set reports the other field too', async () => {
+    // The control for the narrowing above: same request, unnarrowed rules.
+    // Without it, the previous test passes even if narrowing does nothing.
+    //
+    // `email` must be spelled `.required()` here, because a bare
+    // `schema.string().email()` PASSES on an absent value — which is worth
+    // knowing on its own: RegisterAction and LoginAction both declare email
+    // that way, so a POST with no email at all clears validation today.
+    const strict = {
+      email: { rule: schema.string().required().email(), message: 'Email must be a valid email address.' },
+      password: rules.password,
+    }
+
+    const result = await validateActionInput(payload({ password: 'short' }), strict as any)
+    expect(Object.keys(result.errors).sort()).toEqual(['email', 'password'])
+  })
+
+  it('an absent value clears a rule that is not required', async () => {
+    // Pinning the surprise above so it is a documented property rather than
+    // something the next person rediscovers through a test they think is broken.
+    const result = await validateActionInput(payload({}), rules as any)
+    expect(result.valid).toBeTrue()
+  })
+})
+
+describe('a precognition request never reaches the handler (#2226)', () => {
+  const source = readFileSync(join(import.meta.dir, '../src/stacks-router.ts'), 'utf8')
+
+  it('returns before authorize, before and handle', () => {
+    const at = (needle: string): number => source.indexOf(needle)
+    const precognition = at('const precognition = precognitionRequest(req)')
+
+    expect(precognition).toBeGreaterThan(-1)
+    expect(precognition).toBeLessThan(at('typeof action.authorize === \'function\''))
+    expect(precognition).toBeLessThan(at('typeof action.before === \'function\''))
+    expect(precognition).toBeLessThan(at('await action.handle(req)'))
+  })
+
+  it('returns early even when the action declares no validations', () => {
+    // Otherwise a probe at an action with no rules falls through and runs it —
+    // the probe becomes the side effect, which is the exact failure this is
+    // meant to prevent.
+    expect(source).toContain('if (!action.validations)')
+  })
+})

--- a/storage/framework/defaults/app/Actions/Auth/LoginAction.ts
+++ b/storage/framework/defaults/app/Actions/Auth/LoginAction.ts
@@ -3,6 +3,7 @@ import { Auth, createTwoFactorChallenge, getTwoFactorState } from '@stacksjs/aut
 import { User } from '@stacksjs/orm'
 import { response } from '@stacksjs/router'
 import { schema } from '@stacksjs/validation'
+import { PASSWORD_MAX_LENGTH, PASSWORD_PRESENCE_MESSAGE } from '../../password-policy'
 
 export default new Action({
   name: 'LoginAction',
@@ -14,9 +15,14 @@ export default new Action({
       rule: schema.string().email(),
       message: 'Email must be a valid email address.',
     },
+    // Presence only, NOT the creation policy. Enforcing a minimum length on
+    // sign-in locks out every account created under a shorter one: the user is
+    // told their own password is too short, with a 422 raised before the
+    // credentials are ever checked. The policy belongs on the paths that SET a
+    // password (#2226).
     password: {
-      rule: schema.string().min(6).max(255),
-      message: 'Password must be between 6 and 255 characters.',
+      rule: schema.string().min(1).max(PASSWORD_MAX_LENGTH),
+      message: PASSWORD_PRESENCE_MESSAGE,
     },
   },
 

--- a/storage/framework/defaults/app/Actions/Auth/RegisterAction.ts
+++ b/storage/framework/defaults/app/Actions/Auth/RegisterAction.ts
@@ -3,6 +3,7 @@ import { Auth, register } from '@stacksjs/auth'
 import { dispatch } from '@stacksjs/events'
 import { response } from '@stacksjs/router'
 import { schema } from '@stacksjs/validation'
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH, PASSWORD_POLICY_MESSAGE } from '../../password-policy'
 
 export default new Action({
   name: 'RegisterAction',
@@ -15,8 +16,8 @@ export default new Action({
       message: 'Email must be a valid email address.',
     },
     password: {
-      rule: schema.string().min(6).max(255),
-      message: 'Password must be between 6 and 255 characters.',
+      rule: schema.string().min(PASSWORD_MIN_LENGTH).max(PASSWORD_MAX_LENGTH),
+      message: PASSWORD_POLICY_MESSAGE,
     },
     name: {
       rule: schema.string().min(2).max(255),

--- a/storage/framework/defaults/app/Actions/Password/PasswordResetAction.ts
+++ b/storage/framework/defaults/app/Actions/Password/PasswordResetAction.ts
@@ -1,30 +1,52 @@
 import { Action } from '@stacksjs/actions'
 import { passwordResets, RateLimiter } from '@stacksjs/auth'
 import { response } from '@stacksjs/router'
+import { schema } from '@stacksjs/validation'
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH, PASSWORD_POLICY_MESSAGE } from '../../password-policy'
 
 export default new Action({
   name: 'PasswordResetAction',
   description: 'Password Reset',
   method: 'POST',
+
+  // Declared rather than hand-checked (#2226). `password.length < 8` inside
+  // handle() was invisible to everything that reads `validations:` — the
+  // client could not ask for it, and it drifted from the six every other
+  // password declaration used. Declaring it also means this endpoint answers a
+  // precognition probe, so a reset form can check the field on blur without
+  // spending a reset token to find out.
+  validations: {
+    email: {
+      rule: schema.string().required().email(),
+      message: 'Email must be a valid email address.',
+    },
+    token: {
+      rule: schema.string().required().min(1),
+      message: 'A reset token is required.',
+    },
+    password: {
+      rule: schema.string().required().min(PASSWORD_MIN_LENGTH).max(PASSWORD_MAX_LENGTH),
+      message: PASSWORD_POLICY_MESSAGE,
+    },
+  },
+
   async handle(request) {
     const token = request.get('token')
     const password = request.get('password')
     const passwordConfirmation = request.get('password_confirmation')
     const email = request.get('email')
 
-    // Validate required fields
+    // Kept as a floor for direct invocation: `validations:` only runs when this
+    // action is reached through the router, and a test or a queued job calling
+    // handle() straight would otherwise pass undefined into resetPassword.
     if (!token || !password || !email) {
       return response.error('Missing required fields', 422)
     }
 
-    // Validate password confirmation
+    // Cross-field, so it cannot live in `validations:` — those rules see one
+    // field at a time. Length and format are declared up there instead.
     if (password !== passwordConfirmation) {
       return response.error('Password confirmation does not match', 422)
-    }
-
-    // Validate password strength (minimum 8 characters)
-    if (password.length < 8) {
-      return response.error('Password must be at least 8 characters', 422)
     }
 
     // Rate limit password reset attempts by email

--- a/storage/framework/defaults/app/Models/User.ts
+++ b/storage/framework/defaults/app/Models/User.ts
@@ -3,6 +3,7 @@ import { defineModel } from '@stacksjs/orm'
 import { makeHash } from '@stacksjs/security'
 // soon, these will be auto-imported
 import { schema } from '@stacksjs/validation'
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from '../password-policy'
 
 export default defineModel({
   name: 'User', // defaults to the sanitized file name
@@ -98,15 +99,17 @@ export default defineModel({
       hidden: true,
       fillable: true,
       validation: {
-        rule: schema.string().required().min(6).max(255),
+        rule: schema.string().required().min(PASSWORD_MIN_LENGTH).max(PASSWORD_MAX_LENGTH),
         message: {
           required: 'Password is required',
-          min: 'Password must have a minimum of 6 characters',
-          max: 'Password must have a maximum of 255 characters',
+          min: `Password must have a minimum of ${PASSWORD_MIN_LENGTH} characters`,
+          max: `Password must have a maximum of ${PASSWORD_MAX_LENGTH} characters`,
         },
       },
 
-      factory: () => '123456',
+      // Must satisfy the rule above, or seeded users fail their own model's
+      // validation. `123456` did once the minimum moved to 8 (#2226).
+      factory: () => 'password1234',
     },
 
     avatar: {

--- a/storage/framework/defaults/app/password-policy.ts
+++ b/storage/framework/defaults/app/password-policy.ts
@@ -1,0 +1,46 @@
+/**
+ * One password policy, in one place (stacksjs/stacks#2226).
+ *
+ * The framework shipped three numbers for one product concept: `RegisterAction`
+ * and `LoginAction` accepted six characters, the `User` model declared six, and
+ * `PasswordResetAction` hand-checked eight with `password.length < 8` — not in a
+ * `validations:` block at all, so it could not even be read by the machinery
+ * that reads the others.
+ *
+ * Apps then retyped the rule again in the browser, because an Action's
+ * `validations:` was unreachable from a template. That is how a real app ended
+ * up refusing a 7-character password in the browser that `POST /register` would
+ * have accepted.
+ *
+ * Change the policy here and every declaration follows. An app that wants a
+ * different one edits this file, which is scaffolded into it.
+ */
+
+/**
+ * Minimum length for a NEW password.
+ *
+ * Eight, because that is what the password-reset path already enforced and it
+ * is the weaker of the two that was actually protecting anything. Raising the
+ * registration minimum only affects accounts created from now on.
+ */
+export const PASSWORD_MIN_LENGTH = 8
+
+/**
+ * Maximum length. Also the `varchar` width the User model's column derives
+ * from, so lowering it is a migration, not just a rule change.
+ */
+export const PASSWORD_MAX_LENGTH = 255
+
+export const PASSWORD_POLICY_MESSAGE
+  = `Password must be between ${PASSWORD_MIN_LENGTH} and ${PASSWORD_MAX_LENGTH} characters.`
+
+/**
+ * What a sign-in must require: that a password was supplied, and nothing more.
+ *
+ * Deliberately NOT the policy above. Applying a creation rule to authentication
+ * locks out every account created under a previous, shorter policy — they would
+ * get a 422 before their credentials were ever checked, with a message telling
+ * them their own password is too short. The policy belongs on the paths that
+ * SET a password.
+ */
+export const PASSWORD_PRESENCE_MESSAGE = 'Password is required.'


### PR DESCRIPTION
Closes #2226. Covers asks 1 and 2; 3 and 4 deliberately not attempted, reasons below.

### Ask 2 — the client can run the server's rules

Rather than serialise a rule set (ask 3), the client asks the real endpoint to run the real rules and stop before the side effect. Header-compatible with Laravel Precognition:

```
Precognition: true
Precognition-Validate-Only: email,password
```

`?_validate=1` also opts in — a header can't be set on a plain form submission, and requiring one puts this out of reach of the simplest caller.

- **204** on success, not an empty 200 (which is indistinguishable from the action having run and returned nothing).
- **The same 422 envelope** a real submission produces, so a client parses one shape (#2227 settled what that shape is).
- **`Vary: Precognition, …`** — same URL and method, two answers depending on a request header.
- **Returns before `authorize`/`before`/`handle`, including when the action declares no validations.** Falling through there would make the probe itself the side effect, which is worse than having no validate-only mode at all.

### Ask 1 — one password policy

Three numbers for one concept: Register and Login at 6, the `User` model at 6, `PasswordResetAction` hand-checking 8 with `password.length` **inside `handle()`** — not in a `validations:` block, so nothing that reads declared rules could see it. That's why it drifted unnoticed.

They now share `PASSWORD_MIN_LENGTH`. The reset path declares its rule, which also means that endpoint answers a precognition probe instead of spending a reset token to tell you the password was short.

**I did not follow ask 1 exactly, and this is the bit to review.** It says to use one rule in `RegisterAction`, `LoginAction`, `PasswordResetAction` and the `User` model. Putting the creation policy on `LoginAction` locks out every account created under the older 6-character rule — a 422 *before* credentials are checked, telling the user their own password is too short. Sign-in requires presence only; the policy belongs on the paths that **set** a password.

Also: the issue states the default `User` model declares 8. It declares **6** (`defaults/app/Models/User.ts:101`) — the 8 was analyticshq's own model. So the framework's odd-one-out was the reset path, not the model.

The `User` factory moves off `123456`, which no longer satisfies the model's own rule and would have failed seeding.

### Found on the way, not fixed here

`schema.string().email()` **passes on an absent value** — only `.required()` rejects it. `RegisterAction` and `LoginAction` both declare email that way, so a POST with no email at all clears validation today and falls into `handle()`. There's a test pinning this as a known property rather than leaving it to be rediscovered.

I left it alone on purpose: this PR already changes which requests 422 on the auth endpoints (the password minimum), and bundling a second behaviour change into the same endpoints makes it harder to reason about and to revert. Worth its own issue — happy to file it.

### Asks 3 and 4 not done

Ask 3 (a `toJSON()` projection of a `schema.*` chain) and ask 4 (`useForm({ action: 'RegisterAction' })`) are a different piece of work: a faithful projection has to survive every validator the chain can hold, and a partial one is worse than none because the client silently disagrees with the server about the rules it can't represent. Ask 2 is what the issue itself calls the minimum viable, and it has no such failure mode — the answer always comes from the real rules.

### Tests

26 tests across two files. The precognition ones drive real detection and real `validateActionInput`; the never-reaches-handle ordering is asserted structurally, because driving a route needs a booted app, a database and an auth stack this package's tests don't have — flagging that as the one property proven by construction rather than by execution.

Router + buddy suites: 612 pass / 0 fail. `buddy lint` clean.
