### PR TITLE
feat(stx-serve): one request object, built once, for both servers

### DIFF
--- a/storage/framework/core/actions/src/dev/views.ts
+++ b/storage/framework/core/actions/src/dev/views.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { existsSync } from 'node:fs'
-import { config, overridesReady, resolveViewPatterns } from '@stacksjs/config'
+import type { RequestContextSnapshot } from '@stacksjs/config'
+import { config, installRequestContext, overridesReady, parseCookieHeader, resolveViewPatterns } from '@stacksjs/config'
 import { log } from '@stacksjs/logging'
 import { projectPath } from '@stacksjs/path'
 import { seedCsrfPageResponse } from './csrf'
@@ -30,13 +31,7 @@ import { exitWithParent } from './exit-with-parent'
  *      own cookie during SSR.
  */
 
-interface StacksRequestContext {
-  cookies: Record<string, string>
-  url: string
-  locale: string
-}
-
-const requestStore = new AsyncLocalStorage<StacksRequestContext>()
+const requestStore = new AsyncLocalStorage<RequestContextSnapshot>()
 
 // Stable global so server-script blocks (which run inside stx serve's
 // fetch handler but without the raw Request) can read cookies.
@@ -46,32 +41,16 @@ const requestStore = new AsyncLocalStorage<StacksRequestContext>()
 // different async continuation), so we ALSO stash the context on a plain global
 // (`__stxServeContext`) — the same mechanism `__stxServeSearch` already relies
 // on — and fall back to it when the ALS store is empty.
-function currentRequestContext(): StacksRequestContext | undefined {
-  return requestStore.getStore() ?? (globalThis as { __stxServeContext?: StacksRequestContext }).__stxServeContext
+function currentRequestContext(): RequestContextSnapshot | undefined {
+  return requestStore.getStore() ?? (globalThis as { __stxServeContext?: RequestContextSnapshot }).__stxServeContext
 }
-;(globalThis as any).requestContext = {
-  cookie(name: string): string | null {
-    return currentRequestContext()?.cookies?.[name] ?? null
-  },
-  url(): string {
-    return currentRequestContext()?.url ?? ''
-  },
-  /** Just the query string, including the leading `?`. Mirrors production. */
-  search(): string {
-    const url = currentRequestContext()?.url
-    if (!url)
-      return ''
 
-    const mark = url.indexOf('?')
-    return mark === -1 ? '' : url.slice(mark)
-  },
-  locale(): string {
-    // 'en' rather than 'de' as the fallback: this is what a page sees when
-    // the request carried no locale at all, and the framework has no reason
-    // to assume German.
-    return currentRequestContext()?.locale ?? 'en'
-  },
-}
+// Built by the shared factory, not by hand. Two hand-written installers is how
+// production ended up returning the query string from `url()` and having no
+// `locale()` at all — both dev-only-passing bugs that reached a box (#2232).
+// Only the snapshot source differs between the servers, and that is the
+// argument.
+installRequestContext(currentRequestContext)
 
 // Do not outlive `./buddy dev`. See exit-with-parent.ts.
 exitWithParent()
@@ -91,24 +70,9 @@ catch {
   await startDefaultServer()
 }
 
+/** Byte-identical to the production server's copy, so both now share one. */
 function parseCookies(req: Request): Record<string, string> {
-  const out: Record<string, string> = {}
-  const header = req.headers.get('cookie') || ''
-  if (!header)
-    return out
-  for (const part of header.split(';')) {
-    const trimmed = part.trim()
-    const eq = trimmed.indexOf('=')
-    if (eq === -1)
-      continue
-    const k = trimmed.slice(0, eq).trim()
-    const v = trimmed.slice(eq + 1).trim()
-    if (!k)
-      continue
-    try { out[k] = decodeURIComponent(v) }
-    catch { out[k] = v }
-  }
-  return out
+  return parseCookieHeader(req.headers.get('cookie'))
 }
 
 async function startDefaultServer() {
@@ -277,10 +241,21 @@ async function startDefaultServer() {
       // boundary, so we additionally stash a plain global (read as a fallback by
       // requestContext, mirroring __stxServeSearch).
       const locale = await applyRequestLocale(req)
-      const ctx: StacksRequestContext = { cookies: parseCookies(req), url: req.url, locale }
+      // `search` and `path` alongside `url`: production's snapshot carries them,
+      // and a dev snapshot that did not meant `requestContext.path()` answered
+      // differently under `buddy dev` than on the box — the same class of
+      // divergence that produced the url()/locale() incidents (#2232).
+      const ctx: RequestContextSnapshot = {
+        cookies: parseCookies(req),
+        url: req.url,
+        path: url.pathname,
+        search: url.search,
+        host: url.host,
+        locale,
+      }
 
       ;(globalThis as { __stxServeSearch?: string }).__stxServeSearch = url.search
-      ;(globalThis as { __stxServeContext?: StacksRequestContext }).__stxServeContext = ctx
+      ;(globalThis as { __stxServeContext?: RequestContextSnapshot }).__stxServeContext = ctx
 
       requestStore.enterWith(ctx)
       return null

--- a/storage/framework/core/buddy/src/production-server.ts
+++ b/storage/framework/core/buddy/src/production-server.ts
@@ -1,7 +1,9 @@
+import type { RequestContextSnapshot } from '@stacksjs/config'
 import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
+import { installRequestContext, parseCookieHeader } from '@stacksjs/config'
 import { log } from '@stacksjs/logging'
 
 /**
@@ -28,60 +30,43 @@ import { log } from '@stacksjs/logging'
  * that precedent instead of a mechanism that demonstrably doesn't work
  * in this server.
  */
-;(globalThis as any).requestContext = {
-  cookie(name: string): string | null {
-    // stx builds a per-request snapshot and refreshes this mirror
-    // immediately before each server script runs, so it is the accurate
-    // source even when a concurrent request has already moved on. The
-    // hook-set global below is the fallback for stx versions that predate
-    // it. Preferring the snapshot matters most for the thing cookies are
-    // usually carrying: whoever is signed in.
-    const snapshot = (globalThis as { __stxServeContext?: { cookies?: Record<string, string> } }).__stxServeContext
-    if (snapshot?.cookies && name in snapshot.cookies)
-      return snapshot.cookies[name] ?? null
+/**
+ * Where this server's snapshot comes from.
+ *
+ * stx builds a per-request snapshot and refreshes `__stxServeContext`
+ * immediately before each server script runs, so it is the accurate source even
+ * when a concurrent request has already moved on. The two hook-set globals are
+ * the fallback for stx versions that predate it. Preferring the snapshot
+ * matters most for the thing cookies usually carry: whoever is signed in.
+ *
+ * This function is the ONLY thing that differs from the dev server now — the
+ * object itself is built by the shared factory, so production can no longer
+ * quietly grow a different `url()` or lose `locale()` (#2232).
+ */
+function productionRequestSnapshot(): RequestContextSnapshot | undefined {
+  const snapshot = (globalThis as { __stxServeContext?: RequestContextSnapshot }).__stxServeContext
+  const legacyCookies = (globalThis as { __stxServeCookies?: Record<string, string> }).__stxServeCookies
+  const legacySearch = (globalThis as { __stxServeSearch?: string }).__stxServeSearch
 
-    const cookies = (globalThis as { __stxServeCookies?: Record<string, string> }).__stxServeCookies
-    return cookies?.[name] ?? null
-  },
-  // The full request URL, as the dev server has always returned — production
-  // used to return only the query string, so a page that did
-  // `new URL(requestContext.url())` worked in development and threw on the
-  // box. `search()` is the query string for callers that only want that.
-  url(): string {
-    const snapshot = (globalThis as { __stxServeContext?: { url?: string, search?: string } }).__stxServeContext
-    return snapshot?.url || snapshot?.search || (globalThis as { __stxServeSearch?: string }).__stxServeSearch || ''
-  },
-  search(): string {
-    const snapshot = (globalThis as { __stxServeContext?: { search?: string } }).__stxServeContext
-    return snapshot?.search ?? (globalThis as { __stxServeSearch?: string }).__stxServeSearch ?? ''
-  },
-  // The dev server has always exposed this; production had not, so a page
-  // that branched on the locale worked under `buddy dev` and threw
-  // "requestContext.locale is not a function" on the box.
-  locale(): string {
-    const snapshot = (globalThis as { __stxServeContext?: { locale?: string | null } }).__stxServeContext
-    return snapshot?.locale ?? 'en'
-  },
+  if (!snapshot && !legacyCookies && legacySearch === undefined)
+    return undefined
+
+  return {
+    ...snapshot,
+    cookies: snapshot?.cookies ?? legacyCookies ?? {},
+    // `url` used to fall back to the query string here, which is exactly how
+    // `new URL(requestContext.url())` came to work in dev and throw on the box.
+    // Kept as a last resort only because an old snapshot has nothing better.
+    url: snapshot?.url || snapshot?.search || legacySearch || '',
+    search: snapshot?.search ?? legacySearch ?? '',
+  }
 }
 
+installRequestContext(productionRequestSnapshot)
+
+/** Byte-identical to the dev server's copy, so both now share one. */
 function parseCookies(req: Request): Record<string, string> {
-  const out: Record<string, string> = {}
-  const header = req.headers.get('cookie') || ''
-  if (!header)
-    return out
-  for (const part of header.split(';')) {
-    const trimmed = part.trim()
-    const eq = trimmed.indexOf('=')
-    if (eq === -1)
-      continue
-    const k = trimmed.slice(0, eq).trim()
-    const v = trimmed.slice(eq + 1).trim()
-    if (!k)
-      continue
-    try { out[k] = decodeURIComponent(v) }
-    catch { out[k] = v }
-  }
-  return out
+  return parseCookieHeader(req.headers.get('cookie'))
 }
 
 /**

--- a/storage/framework/core/config/src/index.ts
+++ b/storage/framework/core/config/src/index.ts
@@ -13,4 +13,12 @@ export { FRAMEWORK_DEFAULTS } from './defaults'
 export { validateConfig, reportConfigIssues, type ConfigValidationIssue } from './validators'
 export { feature, enableFeature, disableFeature, resetFeature, listFeatures } from './features'
 export { resolveViewPatterns, type DefaultViewsSetting, type ViewPatternResolution } from './views'
+export {
+  createRequestContext,
+  installRequestContext,
+  parseCookieHeader,
+  useRequestEvent,
+  type RequestContextSnapshot,
+  type StacksRequestContext,
+} from './request-context'
 export * from './capabilities'

--- a/storage/framework/core/config/src/request-context.ts
+++ b/storage/framework/core/config/src/request-context.ts
@@ -1,0 +1,227 @@
+/**
+ * One request object for `<script server>` blocks (stacksjs/stacks#2232).
+ *
+ * `requestContext` was installed twice — once by the dev views server, once by
+ * the production server — with two different backings, two different sets of
+ * methods, and no shared type. Both installers were `(globalThis as any)`, so
+ * nothing could catch a divergence. Two already shipped:
+ *
+ *   - production's `url()` returned only the query string, so a page doing
+ *     `new URL(requestContext.url())` worked in dev and threw on the box
+ *   - production had no `locale()` at all, so a page that branched on locale
+ *     threw "requestContext.locale is not a function" on the box
+ *
+ * Both were found by an end-to-end test, not by inspection, because there was
+ * nothing to inspect against.
+ *
+ * A shared TYPE would only have made those detectable. A shared FACTORY makes
+ * them impossible: each server supplies a snapshot reader and gets the same
+ * object built the same way. The only thing a server still chooses is where
+ * the snapshot comes from, which is the one thing that genuinely differs (dev
+ * has AsyncLocalStorage available; production established it does not survive
+ * into stx-serve's render).
+ *
+ * Home of convenience: `@stacksjs/config` is the only package both the dev
+ * server (`@stacksjs/actions`) and the production server (`@stacksjs/buddy`)
+ * already depend on. It is not conceptually config, and moving it later is a
+ * re-export away.
+ */
+
+/**
+ * What a server knows about the request in flight.
+ *
+ * Every field optional: a snapshot is assembled by whichever server booted, an
+ * older stx may not populate all of them, and a standalone or SSG render has no
+ * request at all. Readers below supply a shaped empty value rather than
+ * throwing, so a page never needs `typeof requestContext !== 'undefined'`.
+ */
+export interface RequestContextSnapshot {
+  cookies?: Record<string, string>
+  url?: string
+  path?: string
+  search?: string
+  locale?: string | null
+  params?: Record<string, string>
+  ip?: string
+  host?: string
+}
+
+/** What a `<script server>` block sees as `requestContext`. */
+export interface StacksRequestContext {
+  /** One cookie by name, or null. */
+  cookie: (name: string) => string | null
+  /** Every cookie on the request. */
+  cookies: () => Record<string, string>
+  /** The full request URL. Safe to hand to `new URL()`. */
+  url: () => string
+  /** Path only, no query. */
+  path: () => string
+  /** Query string including the leading `?`, or ''. */
+  search: () => string
+  /** Query parameters, parsed. */
+  query: () => Record<string, string>
+  /** Route parameters for the matched page. */
+  params: () => Record<string, string>
+  /** Resolved locale, defaulting to 'en'. */
+  locale: () => string
+  /** Client IP, or '' when the server did not resolve one. */
+  ip: () => string
+  /** Host header, or ''. */
+  host: () => string
+}
+
+/**
+ * Parse a `Cookie` header into a record.
+ *
+ * Was copy-pasted into both servers; identical in both, which is the mild case
+ * of the same problem this module exists to fix.
+ */
+export function parseCookieHeader(header: string | null | undefined): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!header)
+    return out
+
+  for (const part of header.split(';')) {
+    const trimmed = part.trim()
+    const eq = trimmed.indexOf('=')
+    if (eq === -1)
+      continue
+
+    const key = trimmed.slice(0, eq).trim()
+    if (!key)
+      continue
+
+    const value = trimmed.slice(eq + 1).trim()
+    try {
+      out[key] = decodeURIComponent(value)
+    }
+    catch {
+      // A malformed percent-escape is the sender's problem, not a reason to
+      // drop the cookie — keep the raw value.
+      out[key] = value
+    }
+  }
+
+  return out
+}
+
+/**
+ * Build the object both servers publish as `globalThis.requestContext`.
+ *
+ * `read` is called per access rather than captured, because the snapshot is
+ * replaced between requests — capturing it would pin the first request's
+ * cookies onto every later one.
+ */
+export function createRequestContext(read: () => RequestContextSnapshot | undefined): StacksRequestContext {
+  const snapshot = (): RequestContextSnapshot => read() ?? {}
+
+  const searchOf = (): string => {
+    const direct = snapshot().search
+    if (direct)
+      return direct
+
+    // Derived rather than required: an older stx snapshot carries only `url`.
+    const url = snapshot().url ?? ''
+    const mark = url.indexOf('?')
+    return mark === -1 ? '' : url.slice(mark)
+  }
+
+  return {
+    cookie: (name: string) => snapshot().cookies?.[name] ?? null,
+    cookies: () => snapshot().cookies ?? {},
+
+    // The FULL url. Production used to return the query string here, which is
+    // why `new URL(requestContext.url())` threw on the box and nowhere else.
+    url: () => snapshot().url ?? '',
+
+    path: () => {
+      const direct = snapshot().path
+      if (direct)
+        return direct
+
+      const url = snapshot().url ?? ''
+      if (!url)
+        return ''
+
+      try {
+        return new URL(url).pathname
+      }
+      catch {
+        // Relative url: everything up to the query is the path.
+        const mark = url.indexOf('?')
+        return mark === -1 ? url : url.slice(0, mark)
+      }
+    },
+
+    search: searchOf,
+
+    query: () => {
+      const out: Record<string, string> = {}
+      const search = searchOf()
+      if (!search)
+        return out
+
+      new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+        .forEach((value, key) => { out[key] = value })
+
+      return out
+    },
+
+    params: () => snapshot().params ?? {},
+
+    // 'en' rather than the framework's configured default: this is what a page
+    // sees when the request carried no locale at all, and guessing a non-English
+    // one would be worse than saying so.
+    locale: () => snapshot().locale ?? 'en',
+
+    ip: () => snapshot().ip ?? '',
+    host: () => snapshot().host ?? '',
+  }
+}
+
+/**
+ * Install the context as the `requestContext` global and return it.
+ *
+ * Both servers call exactly this, so neither can publish a differently-shaped
+ * object by accident.
+ */
+export function installRequestContext(read: () => RequestContextSnapshot | undefined): StacksRequestContext {
+  const context = createRequestContext(read)
+  ;(globalThis as { requestContext?: StacksRequestContext }).requestContext = context
+  return context
+}
+
+/**
+ * The single accessor (#2232 ask 4), for callers who would rather have one
+ * object than reach for ambient globals.
+ *
+ * Always returns something: with no request in flight every field is its empty
+ * value, so a standalone or SSG render reads `useRequestEvent().query.site` and
+ * gets `undefined` instead of a ReferenceError.
+ */
+export function useRequestEvent(): {
+  url: string
+  path: string
+  search: string
+  query: Record<string, string>
+  cookies: Record<string, string>
+  params: Record<string, string>
+  locale: string
+  ip: string
+  host: string
+} {
+  const context = (globalThis as { requestContext?: StacksRequestContext }).requestContext
+    ?? createRequestContext(() => undefined)
+
+  return {
+    url: context.url(),
+    path: context.path(),
+    search: context.search(),
+    query: context.query(),
+    cookies: context.cookies(),
+    params: context.params(),
+    locale: context.locale(),
+    ip: context.ip(),
+    host: context.host(),
+  }
+}

--- a/storage/framework/core/config/tests/request-context.test.ts
+++ b/storage/framework/core/config/tests/request-context.test.ts
@@ -1,0 +1,196 @@
+// One request object for `<script server>` blocks (stacksjs/stacks#2232).
+//
+// `requestContext` was installed twice — dev and production — with two
+// backings, two sets of methods, and no shared type. Both installers were
+// `(globalThis as any)`, so nothing could catch a divergence, and two shipped:
+// production's `url()` returned only the query string (so `new URL(...)` threw
+// on the box), and production had no `locale()` at all.
+//
+// A shared type would only have made those detectable. A shared factory makes
+// them impossible, so these tests exercise the factory both servers now call
+// and then assert that neither still builds its own.
+
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { createRequestContext, parseCookieHeader, useRequestEvent } from '../src/request-context'
+
+const FULL = {
+  cookies: { session: 'abc', theme: 'dark' },
+  url: 'https://example.com/dashboard?range=30d&site=7',
+  path: '/dashboard',
+  search: '?range=30d&site=7',
+  locale: 'de',
+  params: { id: '7' },
+  ip: '203.0.113.9',
+  host: 'example.com',
+}
+
+describe('reading a request (#2232)', () => {
+  const ctx = createRequestContext(() => FULL)
+
+  it('returns the full url, not the query string', () => {
+    // The exact production incident: `new URL(requestContext.url())` worked in
+    // dev and threw on the box.
+    expect(ctx.url()).toBe(FULL.url)
+    expect(() => new URL(ctx.url())).not.toThrow()
+  })
+
+  it('exposes locale', () => {
+    // The other incident: "requestContext.locale is not a function".
+    expect(ctx.locale()).toBe('de')
+  })
+
+  it('reads one cookie and all of them', () => {
+    expect(ctx.cookie('session')).toBe('abc')
+    expect(ctx.cookie('absent')).toBeNull()
+    expect(ctx.cookies()).toEqual(FULL.cookies)
+  })
+
+  it('parses the query', () => {
+    expect(ctx.query()).toEqual({ range: '30d', site: '7' })
+  })
+
+  it('exposes path, params, ip and host', () => {
+    expect(ctx.path()).toBe('/dashboard')
+    expect(ctx.params()).toEqual({ id: '7' })
+    expect(ctx.ip()).toBe('203.0.113.9')
+    expect(ctx.host()).toBe('example.com')
+  })
+})
+
+describe('an older or partial snapshot still answers (#2232)', () => {
+  it('derives search from url when the snapshot has only url', () => {
+    // An stx that predates the richer snapshot carries `url` alone.
+    const ctx = createRequestContext(() => ({ url: 'https://example.com/a?x=1' }))
+    expect(ctx.search()).toBe('?x=1')
+    expect(ctx.query()).toEqual({ x: '1' })
+  })
+
+  it('derives path from url', () => {
+    const ctx = createRequestContext(() => ({ url: 'https://example.com/a/b?x=1' }))
+    expect(ctx.path()).toBe('/a/b')
+  })
+
+  it('derives path from a relative url too', () => {
+    // `new URL` throws on a relative url; falling back to the substring keeps
+    // this from taking down the render.
+    const ctx = createRequestContext(() => ({ url: '/a/b?x=1' }))
+    expect(ctx.path()).toBe('/a/b')
+  })
+})
+
+describe('no request in flight (#2232)', () => {
+  // Ask 3's spirit: shaped and empty rather than absent, so a page never needs
+  // `typeof requestContext !== 'undefined'`.
+  const ctx = createRequestContext(() => undefined)
+
+  it('answers with empty values instead of throwing', () => {
+    expect(ctx.url()).toBe('')
+    expect(ctx.path()).toBe('')
+    expect(ctx.search()).toBe('')
+    expect(ctx.query()).toEqual({})
+    expect(ctx.cookies()).toEqual({})
+    expect(ctx.cookie('session')).toBeNull()
+    expect(ctx.params()).toEqual({})
+    expect(ctx.ip()).toBe('')
+    expect(ctx.host()).toBe('')
+  })
+
+  it('falls back to en, not to the framework default locale', () => {
+    // What a page sees when the request carried no locale at all. Guessing a
+    // non-English one would be worse than saying so.
+    expect(ctx.locale()).toBe('en')
+  })
+})
+
+describe('the snapshot is read per access (#2232)', () => {
+  it('does not pin the first request onto later ones', () => {
+    // Capturing the snapshot once would serve request A's cookies to request B
+    // — the failure mode that matters most, since cookies carry who is signed in.
+    let current: any = { cookies: { session: 'first' } }
+    const ctx = createRequestContext(() => current)
+
+    expect(ctx.cookie('session')).toBe('first')
+    current = { cookies: { session: 'second' } }
+    expect(ctx.cookie('session')).toBe('second')
+  })
+})
+
+describe('cookie parsing (#2232)', () => {
+  it('parses a header', () => {
+    expect(parseCookieHeader('a=1; b=two')).toEqual({ a: '1', b: 'two' })
+  })
+
+  it('decodes percent-escapes', () => {
+    expect(parseCookieHeader('redirect=%2Fdashboard')).toEqual({ redirect: '/dashboard' })
+  })
+
+  it('keeps a malformed escape rather than dropping the cookie', () => {
+    // The sender's problem, not a reason to lose the value.
+    expect(parseCookieHeader('token=%E0%A4%A')).toEqual({ token: '%E0%A4%A' })
+  })
+
+  it('handles an absent or empty header', () => {
+    expect(parseCookieHeader(null)).toEqual({})
+    expect(parseCookieHeader('')).toEqual({})
+  })
+
+  it('skips malformed pairs', () => {
+    expect(parseCookieHeader('novalue; =orphan; a=1')).toEqual({ a: '1' })
+  })
+})
+
+describe('the single accessor (#2232 ask 4)', () => {
+  it('returns a shaped object with no request in flight', () => {
+    const previous = (globalThis as any).requestContext
+    delete (globalThis as any).requestContext
+    try {
+      const event = useRequestEvent()
+      expect(event.query).toEqual({})
+      expect(event.locale).toBe('en')
+      expect(event.url).toBe('')
+    }
+    finally {
+      if (previous !== undefined)
+        (globalThis as any).requestContext = previous
+    }
+  })
+
+  it('reads the installed context when there is one', () => {
+    const previous = (globalThis as any).requestContext
+    ;(globalThis as any).requestContext = createRequestContext(() => FULL)
+    try {
+      expect(useRequestEvent().query).toEqual({ range: '30d', site: '7' })
+      expect(useRequestEvent().locale).toBe('de')
+    }
+    finally {
+      if (previous === undefined)
+        delete (globalThis as any).requestContext
+      else
+        (globalThis as any).requestContext = previous
+    }
+  })
+})
+
+describe('both servers go through the factory (#2232 ask 1)', () => {
+  const dev = readFileSync(join(import.meta.dir, '../../actions/src/dev/views.ts'), 'utf8')
+  const prod = readFileSync(join(import.meta.dir, '../../buddy/src/production-server.ts'), 'utf8')
+
+  it('each installs via the shared factory', () => {
+    expect(dev).toContain('installRequestContext(')
+    expect(prod).toContain('installRequestContext(')
+  })
+
+  it('neither hand-assigns the global any more', () => {
+    // `(globalThis as any).requestContext = { ... }` in either file is how the
+    // two shapes drifted in the first place.
+    expect(dev).not.toContain('(globalThis as any).requestContext')
+    expect(prod).not.toContain('(globalThis as any).requestContext')
+  })
+
+  it('neither carries its own cookie parser', () => {
+    expect(dev).not.toContain('header.split(\';\')')
+    expect(prod).not.toContain('header.split(\';\')')
+  })
+})

--- a/storage/framework/types/request-context.d.ts
+++ b/storage/framework/types/request-context.d.ts
@@ -1,0 +1,65 @@
+// Hand-written, unlike its neighbours — `server-auto-imports.d.ts` is
+// regenerated whenever the API starts and would lose these.
+//
+// What a `<script server>` block can reach (stacksjs/stacks#2232). tsc cannot
+// see inside a `.stx` file, so these do not check the templates themselves;
+// they give an editor something to complete against, and they give the two
+// server implementations one written-down contract instead of two `as any`
+// installers that drifted twice into production.
+
+export {}
+
+declare global {
+  /**
+   * The request in flight, published by whichever server booted.
+   *
+   * Always present under `buddy dev` and `buddy serve`. A standalone or SSG
+   * render has no request, and every accessor answers with its empty value
+   * rather than throwing — so a page may call these unguarded.
+   */
+  const requestContext: {
+    /** One cookie by name, or null. */
+    cookie: (name: string) => string | null
+    /** Every cookie on the request. */
+    cookies: () => Record<string, string>
+    /** The full request URL. Safe to hand to `new URL()`. */
+    url: () => string
+    /** Path only, no query. */
+    path: () => string
+    /** Query string including the leading `?`, or ''. */
+    search: () => string
+    /** Query parameters, parsed. */
+    query: () => Record<string, string>
+    /** Route parameters for the matched page. */
+    params: () => Record<string, string>
+    /** Resolved locale, defaulting to 'en'. */
+    locale: () => string
+    /** Client IP, or '' when the server did not resolve one. */
+    ip: () => string
+    /** Host header, or ''. */
+    host: () => string
+  }
+
+  /**
+   * Query parameters injected onto the render context by the serve path.
+   *
+   * Declared optional-shaped for a reason: unlike `requestContext`, this is
+   * injected by bun-plugin-stx's serve path only. A standalone render (the SSG
+   * path, or `processDirectives` called without a request) supplies nothing, and
+   * a bare `query` is a ReferenceError there rather than an empty result. Until
+   * that path injects an empty-but-shaped object, reads still need a guard:
+   *
+   *     const params = typeof query !== 'undefined' ? query : {}
+   *
+   * `requestContext.query()` has no such caveat and is the safer spelling.
+   */
+  const query: Record<string, string>
+
+  /**
+   * Cookies injected onto the render context by the serve path.
+   *
+   * Same caveat as `query` — absent in a standalone render.
+   * `requestContext.cookie(name)` is the safer spelling.
+   */
+  const cookies: Record<string, string>
+}


### PR DESCRIPTION
Refs #2232 — asks 1, 2 and 4. Ask 3 is not fixable from this repository; details below.

### A shared type wasn't enough

Ask 1 proposes defining `StacksRequestContext` in one package and having both servers implement it. That makes a divergence *detectable*. Both divergences that reached production would still have been possible — you just would have had to run tsc on the right two files.

So both servers now call one **factory**. Each supplies only its snapshot reader, which is the one thing that genuinely differs (dev has `AsyncLocalStorage`; production established it doesn't survive into stx-serve's render). Neither can grow a different `url()` or lose `locale()`, because neither builds the object.

`parseCookies` was byte-identical in both files. Now one function.

### Wider, and never throwing

Added `path()`, `query()`, `params()`, `ip()`, `host()`, `cookies()` — all reading the snapshot stx already builds. Every accessor answers with an empty value when there's no request, so a page can call them unguarded.

The **dev** snapshot now carries `path`, `search` and `host` too. Without them `requestContext.path()` would have answered differently under `buddy dev` than on the box — the same class of bug, one method later.

`useRequestEvent()` (ask 4) returns the lot as one object.

### Ask 2 — the ambient declaration

`types/request-context.d.ts`, hand-written. It deliberately does **not** go in `server-auto-imports.d.ts`, which is regenerated whenever the API starts and would drop it.

It declares `query` and `cookies` too, with the caveat written down rather than implied: those are injected by bun-plugin-stx's serve path only, so a standalone or SSG render supplies neither and a bare `query` is still a `ReferenceError` there. The declaration points at `requestContext.query()`, which has no such caveat.

### Ask 3 — not done, and not doable here

"Inject an empty-but-shaped context on the standalone/SSG path" means changing what **bun-plugin-stx** does when rendering without a request. `build/views.ts` shells out to `stx build`, which never loads either of these servers, so nothing in this repo runs on that path to install anything.

What this PR *can* do — and does — is make `requestContext` itself total: every accessor has an answer with no request in flight. The remaining `typeof query !== 'undefined'` guards are for the two globals stx injects, and clearing those needs an stx-side change. Happy to file it there.

### Placement

`@stacksjs/config` is the only package both `@stacksjs/actions` (dev server) and `@stacksjs/buddy` (production server) already depend on. It is not conceptually config, and I'd rather say so than pretend — moving it to a better home later is a re-export away.

### Tests

21 tests. Eighteen drive the factory directly — full snapshot, partial snapshot (an older stx carrying only `url`), no snapshot at all, relative URLs, and per-access reads so one request's cookies can't be pinned onto the next. Three assert neither server hand-assigns the global or carries its own cookie parser any more; those three fail without the rewire.

Config + buddy + actions suites: 831 pass / 0 fail. `buddy lint` clean.
