### PR TITLE
feat(router/auth): route-model binding, so `can:` can reach a Policy

### DIFF
--- a/storage/framework/core/router/src/index.ts
+++ b/storage/framework/core/router/src/index.ts
@@ -54,6 +54,20 @@ export {
 // Export route introspection helpers
 export { listRegisteredRoutes, routeParams } from './stacks-router'
 
+// Route-model binding (stacksjs/stacks#2231): what lets `can:view,site`
+// reach `SitePolicy.view(user, site)` instead of handing the policy layer a
+// raw path string it can never match a policy against.
+export {
+  clearRouteModelBindings,
+  defineRouteModelBinding,
+  resolveRouteModel,
+  routeModelBindings,
+  setRouteModelFallback,
+  type RouteModelContext,
+  type RouteModelResolution,
+  type RouteModelResolver,
+} from './route-model-binding'
+
 // Export JSON-vs-HTML negotiation predicate so userland can short-circuit
 // the same decision the framework makes in formatResult / error-handler.
 export { isApiRequest, JSON_CONTENT_TYPE } from './api-shape'

--- a/storage/framework/core/router/src/route-model-binding.ts
+++ b/storage/framework/core/router/src/route-model-binding.ts
@@ -1,0 +1,120 @@
+/**
+ * Route-model binding (stacksjs/stacks#2231).
+ *
+ * The framework ships a full Policy system and a `can:` middleware, and they
+ * could not be connected. `Can` read the route parameter and handed the RAW
+ * STRING to `authorize()`, while `resolveAbility()` only reaches for a policy
+ * when the first argument is an object with a matching `constructor.name`. A
+ * string's is `String`, so `can:view,site` could never dispatch to
+ * `SitePolicy.view(user, site)` — every ownership check had to be written
+ * imperatively inside the handler instead.
+ *
+ * A gate that is opt-in per handler rather than declarative on the route means
+ * a new endpoint that forgets the three-line prologue is readable by anyone.
+ * One real app carries that prologue at 18 call sites and wrote a source-grep
+ * test purely to stop a copy being deleted.
+ *
+ * Resolution order: an explicit binding, then the fallback, then nothing. The
+ * "nothing" case matters most — it is what keeps this from changing behaviour
+ * for a parameter no one has bound.
+ */
+
+export interface RouteModelContext {
+  /** The route parameter's name, e.g. `site` in `/sites/:site`. */
+  param: string
+  /** The request being authorized, when the caller has one. */
+  request?: unknown
+}
+
+/**
+ * Resolves a parameter's raw path value to a model.
+ *
+ * `context.param` is supplied so ONE resolver can serve every parameter — which
+ * is what the convention fallback needs, since it derives the model name from
+ * the parameter name.
+ */
+export type RouteModelResolver = (value: string, context: RouteModelContext) => unknown | Promise<unknown>
+
+/**
+ * Outcome of a resolution attempt.
+ *
+ * `bound` distinguishes "nobody claims this parameter" from "someone claims it
+ * and there is no such row". They must not collapse: the first has to keep
+ * passing the raw string through, exactly as before, or every existing
+ * `can:ability,param` route changes meaning at once.
+ */
+export interface RouteModelResolution {
+  bound: boolean
+  model?: unknown
+}
+
+const bindings = new Map<string, RouteModelResolver>()
+let fallbackResolver: RouteModelResolver | null = null
+
+/**
+ * Bind a route parameter to a model.
+ *
+ * ```ts
+ * defineRouteModelBinding('site', id => Site.find(Number(id)))
+ * ```
+ *
+ * The last registration for a name wins, so an app can override a convention
+ * binding without having to unregister one.
+ */
+export function defineRouteModelBinding(param: string, resolver: RouteModelResolver): void {
+  bindings.set(param, resolver)
+}
+
+/**
+ * A resolver consulted for any parameter with no explicit binding.
+ *
+ * This is how a convention — parameter `site` resolves through the `Site`
+ * model — is supplied without the router having to import the ORM, which would
+ * be a dependency cycle. Pass `null` to remove it.
+ */
+export function setRouteModelFallback(resolver: RouteModelResolver | null): void {
+  fallbackResolver = resolver
+}
+
+/** Registered parameter names, for diagnostics and tests. */
+export function routeModelBindings(): string[] {
+  return [...bindings.keys()].sort()
+}
+
+export function clearRouteModelBindings(): void {
+  bindings.clear()
+  fallbackResolver = null
+}
+
+/**
+ * Resolve one route parameter to a model instance.
+ *
+ * A resolver that throws is treated as "no model" rather than allowed to
+ * propagate: a lookup failure must not turn an authorization check into a 500,
+ * and falling through to the unresolved path denies, which is the safe
+ * direction.
+ */
+export async function resolveRouteModel(
+  param: string,
+  value: string,
+  request?: unknown,
+): Promise<RouteModelResolution> {
+  const resolver = bindings.get(param) ?? fallbackResolver
+
+  if (!resolver)
+    return { bound: false }
+
+  try {
+    const model = await resolver(value, { param, request })
+    // A resolver may decline by returning undefined — used by the convention
+    // fallback to say "there is no model of this name", which is different
+    // from "there is one and the row is missing" (null).
+    if (model === undefined)
+      return { bound: false }
+
+    return { bound: true, model: model ?? undefined }
+  }
+  catch {
+    return { bound: true, model: undefined }
+  }
+}

--- a/storage/framework/core/router/tests/route-model-binding.test.ts
+++ b/storage/framework/core/router/tests/route-model-binding.test.ts
@@ -1,0 +1,161 @@
+// Route-model binding (stacksjs/stacks#2231).
+//
+// The framework ships a Policy system and a `can:` middleware that could not be
+// connected. `Can` handed the RAW STRING from the route parameter to
+// `authorize()`, while `resolveAbility()` only reaches for a policy when the
+// first argument is an object whose `constructor.name` matches a registration.
+// A string's is `String`, so `can:view,site` could never dispatch to
+// `SitePolicy.view(user, site)` — every ownership check had to be written
+// imperatively inside the handler, and an endpoint that forgot the prologue was
+// readable by anyone.
+//
+// The property under test is not just "a model comes back". It is that an
+// UNBOUND parameter still passes its raw string through, because otherwise
+// every existing `can:ability,param` route changes meaning at once.
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import {
+  clearRouteModelBindings,
+  defineRouteModelBinding,
+  resolveRouteModel,
+  routeModelBindings,
+  setRouteModelFallback,
+} from '../src/route-model-binding'
+
+class Site {
+  constructor(public id: number) {}
+}
+
+afterEach(() => {
+  clearRouteModelBindings()
+})
+
+describe('an unbound parameter is untouched (#2231)', () => {
+  it('reports not-bound when nothing claims it', () => {
+    // The compatibility guarantee. `bound: false` is what tells Can to push the
+    // raw string, exactly as it did before any of this existed.
+    expect(resolveRouteModel('site', '7')).resolves.toEqual({ bound: false })
+  })
+})
+
+describe('an explicit binding resolves a model (#2231)', () => {
+  it('returns the instance, so a policy can match on its constructor', () => {
+    defineRouteModelBinding('site', id => new Site(Number(id)))
+
+    return resolveRouteModel('site', '7').then((result) => {
+      expect(result.bound).toBeTrue()
+      expect(result.model).toBeInstanceOf(Site)
+      // The exact reason the raw string failed: this is what resolveAbility
+      // looks up in the policy registry.
+      expect((result.model as any).constructor.name).toBe('Site')
+    })
+  })
+
+  it('awaits an async resolver', async () => {
+    defineRouteModelBinding('site', async id => new Site(Number(id)))
+    const result = await resolveRouteModel('site', '9')
+    expect((result.model as Site).id).toBe(9)
+  })
+
+  it('passes the raw value through', async () => {
+    // Slugs, uuids and scoped keys are all legitimate — the binding decides
+    // what the value means, not the router.
+    defineRouteModelBinding('site', value => ({ key: value }))
+    const result = await resolveRouteModel('site', 'my-slug')
+    expect(result.model).toEqual({ key: 'my-slug' })
+  })
+
+  it('receives the parameter name and the request', async () => {
+    let seen: any
+    defineRouteModelBinding('site', (value, context) => {
+      seen = { value, ...context }
+      return new Site(1)
+    })
+
+    await resolveRouteModel('site', '7', { marker: true })
+    expect(seen.param).toBe('site')
+    expect(seen.value).toBe('7')
+    expect(seen.request).toEqual({ marker: true })
+  })
+
+  it('the last registration wins', () => {
+    defineRouteModelBinding('site', () => 'first')
+    defineRouteModelBinding('site', () => 'second')
+    return resolveRouteModel('site', '1').then(r => expect(r.model).toBe('second'))
+  })
+})
+
+describe('bound but missing is not the same as unbound (#2231)', () => {
+  it('a null row stays bound with no model', async () => {
+    // Collapsing these two would make a missing row indistinguishable from an
+    // unclaimed parameter, and the raw id string would be handed to the policy
+    // layer — silently reintroducing the bug.
+    defineRouteModelBinding('site', () => null)
+    expect(await resolveRouteModel('site', '404')).toEqual({ bound: true, model: undefined })
+  })
+
+  it('a resolver returning undefined declines instead', async () => {
+    // How the convention fallback says "there is no model of this name".
+    defineRouteModelBinding('site', () => undefined)
+    expect(await resolveRouteModel('site', '7')).toEqual({ bound: false })
+  })
+
+  it('a throwing resolver denies rather than 500ing', async () => {
+    // A lookup failure must not turn an authorization check into a server
+    // error, and no model means deny, which is the safe direction.
+    defineRouteModelBinding('site', () => { throw new Error('db down') })
+    expect(await resolveRouteModel('site', '7')).toEqual({ bound: true, model: undefined })
+  })
+})
+
+describe('the fallback (#2231)', () => {
+  it('serves a parameter with no explicit binding', async () => {
+    setRouteModelFallback((id, { param }) => ({ param, id }))
+    expect(await resolveRouteModel('site', '7')).toEqual({ bound: true, model: { param: 'site', id: '7' } })
+  })
+
+  it('an explicit binding still wins over it', async () => {
+    // Scoped lookups, soft deletes and slug-instead-of-id all need to be
+    // expressible over the convention.
+    setRouteModelFallback(() => 'from-fallback')
+    defineRouteModelBinding('site', () => 'from-binding')
+    expect((await resolveRouteModel('site', '7')).model).toBe('from-binding')
+  })
+
+  it('can be removed', async () => {
+    setRouteModelFallback(() => 'x')
+    setRouteModelFallback(null)
+    expect(await resolveRouteModel('site', '7')).toEqual({ bound: false })
+  })
+})
+
+describe('the registry is inspectable (#2231)', () => {
+  it('lists what is bound', () => {
+    defineRouteModelBinding('site', () => null)
+    defineRouteModelBinding('post', () => null)
+    expect(routeModelBindings()).toEqual(['post', 'site'])
+  })
+})
+
+describe('Can goes through it (#2231)', () => {
+  const source = require('node:fs').readFileSync(
+    require('node:path').join(import.meta.dir, '../../../defaults/app/Middleware/Can.ts'),
+    'utf8',
+  ) as string
+
+  it('resolves the parameter instead of pushing the raw string', () => {
+    expect(source).toContain('resolveRouteModel(')
+  })
+
+  it('still pushes the raw value when nothing is bound', () => {
+    // The regression this must not cause.
+    expect(source).toContain('if (!resolution.bound)')
+    expect(source).toContain('args.push(raw)')
+  })
+
+  it('registers the ORM convention as a fallback, not a per-name binding', () => {
+    // A per-name registration could not be overridden by an app without an
+    // unregister call.
+    expect(source).toContain('setRouteModelFallback(')
+  })
+})

--- a/storage/framework/defaults/app/Middleware/Can.ts
+++ b/storage/framework/defaults/app/Middleware/Can.ts
@@ -1,6 +1,43 @@
 import { AuthorizationException, authorize } from '@stacksjs/auth'
 import { HttpError } from '@stacksjs/error-handling'
-import { Middleware } from '@stacksjs/router'
+import { Middleware, resolveRouteModel, setRouteModelFallback } from '@stacksjs/router'
+
+/**
+ * Convention binding: parameter `site` resolves through the `Site` model
+ * (stacksjs/stacks#2231).
+ *
+ * Registered as the FALLBACK, not as a binding per name, so an app's own
+ * `defineRouteModelBinding('site', …)` still wins — scoped lookups, soft
+ * deletes and slug-instead-of-id all need to be expressible.
+ *
+ * Lives here rather than in `@stacksjs/router` because the router importing
+ * `@stacksjs/orm` would close a dependency cycle. This file is app-land, where
+ * importing the ORM is ordinary.
+ *
+ * Returning `undefined` means "no model of that name exists" and leaves the raw
+ * string to pass through exactly as before. That is what keeps this from
+ * changing the meaning of every existing `can:ability,param` route at once.
+ */
+setRouteModelFallback(async (value, { param }) => {
+  // `site` -> `Site`, `blogPost` -> `BlogPost`. Only the first character is
+  // touched: lowercasing the rest would turn `blogPost` into `Blogpost`.
+  const modelName = param.charAt(0).toUpperCase() + param.slice(1)
+
+  const orm = await import('@stacksjs/orm') as Record<string, any>
+  const model = orm[modelName]
+
+  // No model of that name — decline, so the raw string passes through exactly
+  // as it did before this existed.
+  if (!model || typeof model.find !== 'function')
+    return undefined
+
+  // `null` when the row is missing, which is deliberately NOT the same as
+  // declining: the parameter IS bound, there is simply nothing there. `Can`
+  // then authorizes with no model, which denies — the same 403 this route
+  // produced before, rather than a 404 that would tell an anonymous caller
+  // which ids exist.
+  return await model.find(Number.isNaN(Number(value)) ? value : Number(value)) ?? null
+})
 
 /**
  * Authorization Gate Middleware
@@ -44,13 +81,29 @@ export default new Middleware({
     // Prepare arguments for the gate check
     const args: any[] = []
 
-    // If a model parameter is specified, get it from route params
+    // If a model parameter is specified, resolve it to a MODEL before handing
+    // it to the gate. Passing the raw path string — which is what happened
+    // before — meant `resolveAbility()` saw a `String`, found no policy
+    // registered under that name, and fell through to the default deny. A
+    // declarative `can:view,site` could therefore never reach
+    // `SitePolicy.view(user, site)` (#2231).
     if (modelParam) {
       const routeParams = request.params || {}
-      const model = routeParams[modelParam]
+      const raw = routeParams[modelParam]
 
-      if (model) {
-        args.push(model)
+      if (raw !== undefined && raw !== null && raw !== '') {
+        const resolution = await resolveRouteModel(modelParam, String(raw), request)
+
+        if (!resolution.bound) {
+          // Nobody claims this parameter. Push the raw value, exactly as
+          // before — an app that authorizes on an id string keeps working.
+          args.push(raw)
+        }
+        else if (resolution.model !== undefined) {
+          args.push(resolution.model)
+        }
+        // Bound but absent: authorize with no model, which denies. Same 403
+        // this produced before, and it does not disclose which ids exist.
       }
     }
 


### PR DESCRIPTION
Refs #2231.

`Can` handed the raw path string to `authorize()`; `resolveAbility()` only reaches for a policy when the first argument is an object whose `constructor.name` matches a registration. A string's is `String`. So `can:view,site` could never dispatch to `SitePolicy.view(user, site)`, and every ownership check had to be written imperatively inside the handler — which is what makes the gate opt-in per endpoint, and why a forgotten prologue leaves an endpoint readable by anyone.

### The design constraint

Making the binding work is easy. Not breaking the routes that already use `can:ability,param` is the part that shaped this.

An unbound parameter **must** still pass its raw string through, or every existing such route changes meaning at once. So resolution reports `bound` separately from the model, giving three deliberately distinct outcomes:

| Outcome | `Can` does | Result |
|---|---|---|
| not bound | pushes the raw string | exactly as before |
| bound, model found | pushes the instance | the policy is now reachable |
| bound, row missing | pushes nothing | denies — **403, not 404** |

The last row is a choice worth confirming: Laravel 404s here. A 404 tells an anonymous caller which ids exist, and 403 is what this route already returned, so I kept it. Easy to flip if you'd rather match Laravel.

### The convention

Parameter `site` resolves through the `Site` model, registered as the **fallback** rather than a binding per name — so an app's own `defineRouteModelBinding('site', …)` wins without needing an unregister call. Slugs, uuids, scoped lookups and soft deletes all stay expressible.

It lives in the `Can` middleware, not in `@stacksjs/router`: the router importing `@stacksjs/orm` would close a dependency cycle, and the middleware is app-land where importing the ORM is ordinary. When no model of that name exists it **declines**, which is what routes the raw string back down the unchanged path.

A resolver that throws resolves to no-model rather than propagating — a lookup failure shouldn't turn an authorization check into a 500, and denying is the safe direction.

### Not done

`route.model('site', Site)` as a builder method. The issue asks for it alongside `resolveRouteBinding` and scoped bindings; `defineRouteModelBinding` covers the same ground declaratively, and threading a binding through the route-builder chain is a larger change to `stacks-router.ts` that I'd rather not bundle with the behaviour fix. Scoped bindings (`/sites/:site/pages/:page` where page is scoped to site) are expressible today via a resolver reading `context.request`, but there's no sugar for them.

Also: `app/Gates.ts` still ships the empty commented-out `policies` map. This PR makes that map usable; populating the scaffold with a worked example is a separate call.

### Tests

16 tests. Thirteen drive the registry directly — explicit bindings, async resolvers, last-wins, fallback precedence, and the three-way bound/missing/declined distinction that the compatibility guarantee rests on. Three assert `Can` goes through it *and* still pushes the raw value when nothing is bound; those fail without the middleware change.

Router suite: 320 pass / 0 fail. `buddy lint` clean.
