### PR TITLE
fix(views): resolve dev default resources from @stacksjs/defaults, not a gitignored path (#2240)

### DIFF
--- a/storage/framework/core/actions/src/dev/defaults-resources.ts
+++ b/storage/framework/core/actions/src/dev/defaults-resources.ts
@@ -1,0 +1,35 @@
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+/**
+ * Resolve the framework's default resources root — the fallback views, layouts
+ * and components a server renders under an app's own.
+ *
+ * A vendored checkout keeps them at `storage/framework/defaults/resources` and
+ * wins, so a full framework checkout behaves exactly as before. An app that
+ * consumes the framework from node_modules has no vendored copy — that directory
+ * is generated and gitignored, so `git ls-files storage/framework` is empty on a
+ * fresh clone — and must resolve the published `@stacksjs/defaults` package
+ * instead. Without this fallback the dev server pointed every default at a path
+ * that does not exist until `buddy setup` has run (stacksjs/stacks#2240).
+ *
+ * The production server (core/buddy's production-server.ts) already resolved it
+ * this way; the dev server still had the bare path. This is the shared shape —
+ * import it from both rather than keep two copies that can drift.
+ *
+ * Returns the vendored path if neither resolves, letting the caller (stx serve)
+ * surface a clear missing-directory error rather than a silent empty glob.
+ */
+export function resolveDefaultsResources(): string {
+  const vendored = 'storage/framework/defaults/resources'
+  if (existsSync(vendored))
+    return vendored
+
+  try {
+    const pkgJson = Bun.resolveSync('@stacksjs/defaults/package.json', process.cwd())
+    return join(dirname(pkgJson), 'resources')
+  }
+  catch {
+    return vendored
+  }
+}

--- a/storage/framework/core/actions/src/dev/views.ts
+++ b/storage/framework/core/actions/src/dev/views.ts
@@ -1,10 +1,12 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { existsSync } from 'node:fs'
 import type { RequestContextSnapshot } from '@stacksjs/config'
+import { join } from 'node:path'
 import { config, installRequestContext, overridesReady, parseCookieHeader, resolveViewPatterns } from '@stacksjs/config'
 import { log } from '@stacksjs/logging'
 import { projectPath } from '@stacksjs/path'
 import { seedCsrfPageResponse } from './csrf'
+import { resolveDefaultsResources } from './defaults-resources'
 import { exitWithParent } from './exit-with-parent'
 
 /**
@@ -89,8 +91,11 @@ async function startDefaultServer() {
 
   const { site: siteConfig, i18n: i18nConfig } = await loadStxSiteConfig()
 
+  // Vendored in a full checkout, the published @stacksjs/defaults package in a
+  // framework-as-dependencies app (stacksjs/stacks#2240).
+  const defaultsResources = resolveDefaultsResources()
   const userViewsPath = 'resources/views'
-  const defaultViewsPath = 'storage/framework/defaults/resources/views'
+  const defaultViewsPath = join(defaultsResources, 'views')
   // Layouts and partials are distinct resources. Prefer the
   // framework-standard resources/* paths while retaining the older
   // resources/views/* and root partials locations for existing apps.
@@ -98,7 +103,7 @@ async function startDefaultServer() {
     'resources/views/layouts',
     'resources/layouts',
   ]) ?? 'resources/views/layouts'
-  const defaultLayoutsPath = 'storage/framework/defaults/resources/layouts'
+  const defaultLayoutsPath = join(defaultsResources, 'layouts')
   const userPartialsPath = await firstExistingPath([
     'resources/partials',
     'resources/views/partials',
@@ -174,7 +179,7 @@ async function startDefaultServer() {
     // Storefront/* (and any future <Namespace>/Component.stx) get
     // resolved. stx-serve walks one subdirectory deep, so this
     // gives us discovery without enumerating every namespace.
-    componentsDir: 'storage/framework/defaults/resources/components',
+    componentsDir: join(defaultsResources, 'components'),
     layoutsDir: userLayoutsPath,
     // Modern Stacks apps keep include fragments in resources/components;
     // omit only when no conventional include directory exists.

--- a/storage/framework/core/actions/tests/dev-defaults-resources.test.ts
+++ b/storage/framework/core/actions/tests/dev-defaults-resources.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The dev server resolves its default resources instead of hardcoding a
+ * gitignored path (stacksjs/stacks#2240).
+ *
+ * `dev/views.ts` pointed `defaultViewsPath` / `componentsDir` / `defaultLayouts`
+ * at the string `storage/framework/defaults/resources/...`. That directory is
+ * generated and gitignored (`git ls-files storage/framework` is empty), so a
+ * framework-as-dependencies app has nothing there on a fresh clone — the same
+ * content ships as the published `@stacksjs/defaults` package. The production
+ * server already resolved it (vendored copy wins, else the package); the dev
+ * server did not, so this extracts that resolver and points the dev server at
+ * it too.
+ *
+ * HONEST LIMIT. Only the vendored branch executes here: the monorepo checkout
+ * HAS `storage/framework/defaults/resources`, so `existsSync` is true and the
+ * package fallback is never taken. The fallback runs only in a node_modules app,
+ * which this test environment is not — the same reason the twin in
+ * production-server.ts is untested. What is guarded below is that the resolver
+ * is behaviour-preserving in the environment every contributor develops in: the
+ * resolved sub-paths still equal the strings the dev server used to hardcode.
+ */
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+import { resolveDefaultsResources } from '../src/dev/defaults-resources'
+
+describe('resolveDefaultsResources — vendored branch (#2240)', () => {
+  it('returns the vendored resources root when it exists', () => {
+    expect(resolveDefaultsResources()).toBe('storage/framework/defaults/resources')
+  })
+
+  it('is behaviour-preserving: the sub-paths equal the old hardcoded strings', () => {
+    // dev/views.ts previously hardcoded exactly these three. If the resolver
+    // ever drifts from them, a default view/component/layout stops resolving in
+    // dev with no other signal, so pin them.
+    const root = resolveDefaultsResources()
+    expect(join(root, 'views')).toBe('storage/framework/defaults/resources/views')
+    expect(join(root, 'components')).toBe('storage/framework/defaults/resources/components')
+    expect(join(root, 'layouts')).toBe('storage/framework/defaults/resources/layouts')
+  })
+
+  it('resolves to a real directory that actually holds the defaults', () => {
+    // Non-vacuity: a resolver that returned a plausible-but-empty path would
+    // pass the string checks above and still serve nothing.
+    const root = resolveDefaultsResources()
+    expect(existsSync(join(root, 'views'))).toBe(true)
+    expect(existsSync(join(root, 'components'))).toBe(true)
+    expect(existsSync(join(root, 'layouts'))).toBe(true)
+  })
+
+  it('the fallback target is a resolvable package, so the other branch has somewhere to go', () => {
+    // The fallback itself does not run here, but its precondition — that
+    // `@stacksjs/defaults` resolves at all — must hold, or an app that DOES take
+    // that branch would land in the catch and get the vendored path that is not
+    // there. This asserts the branch is reachable, not that it executes.
+    expect(() => Bun.resolveSync('@stacksjs/defaults/package.json', process.cwd())).not.toThrow()
+  })
+})


### PR DESCRIPTION
Closes #2240.

## Problem

The dev views server (`storage/framework/core/actions/src/dev/views.ts`) pointed `defaultViewsPath` / `componentsDir` / `defaultLayoutsPath` at the string `storage/framework/defaults/resources/...`. That directory is **generated and gitignored** — `git ls-files storage/framework` returns 0 — so a framework-as-dependencies app has nothing there on a fresh clone. The identical content ships as the published `@stacksjs/defaults` package.

The production server (`core/buddy/production-server.ts`) already resolved this correctly (vendored copy wins, else the package, via `resolveDefaultsResources()`); the dev server still carried the bare path. Result: an app booted in dev could not render a default view, and any tool that has to *scan* those templates (crosswind content globs in particular) silently covered nothing until `buddy setup` had run.

## Change

- Extract the resolver production-server already uses into `dev/defaults-resources.ts` (`resolveDefaultsResources()`): vendored `storage/framework/defaults/resources` wins when it exists, else `Bun.resolveSync('@stacksjs/defaults/package.json')` → `<pkg>/resources`, else the vendored path so stx surfaces a clear missing-dir error.
- Point the dev server at it. A full framework checkout is unchanged (the vendored branch always wins); only the node_modules shape gains the fallback.
- The two servers now share one resolver shape instead of two copies that can drift.

## Tests

`tests/dev-defaults-resources.test.ts` (4 pass):
- vendored branch returns the resources root, and the resolved `views`/`components`/`layouts` sub-paths **equal the strings the dev server used to hardcode** (behaviour-preserving regression guard);
- the resolved dirs actually exist (non-vacuity);
- the fallback package is resolvable (the other branch has somewhere to go).

Honest limit, noted in the test: only the vendored branch executes in a monorepo checkout — the package fallback runs only in a node_modules app, the same reason the twin in production-server.ts is untested.