### PR TITLE
feat(router): split auth into its own default route bundle, gated by feature('"auth"') (#2229)

### DIFF
--- a/storage/framework/core/router/tests/fixtures/print-dashboard-routes.ts
+++ b/storage/framework/core/router/tests/fixtures/print-dashboard-routes.ts
@@ -23,6 +23,9 @@
 
 if (import.meta.main) {
   const { listRegisteredRoutes } = await import('@stacksjs/router')
+  // Auth routes moved to their own file (stacksjs/stacks#2229); import both so
+  // this snapshot still covers the full default surface (POST /login etc.).
+  await import('../../../../defaults/routes/auth')
   await import('../../../../defaults/routes/dashboard')
 
   // eslint-disable-next-line no-console

--- a/storage/framework/core/router/tests/fixtures/print-routes-for.ts
+++ b/storage/framework/core/router/tests/fixtures/print-routes-for.ts
@@ -1,0 +1,28 @@
+/**
+ * Subprocess fixture for granular-auth-routes.test.ts (stacksjs/stacks#2229).
+ *
+ * Importing a default routes file registers into the router singleton as a side
+ * effect, and `bun test` shares one process across files — so to see what ONE
+ * file registers in isolation, each scenario runs this in a fresh subprocess
+ * (`bun print-routes-for.ts <name>`) and reads back the `METHOD path` snapshot.
+ *
+ * Guarded by `import.meta.main` so that `bun test <dir>` — which loads every
+ * `.ts` under the directory — does not run the side-effecting import and poison
+ * the shared router singleton for the real test files.
+ */
+import process from 'node:process'
+
+if (import.meta.main) {
+  const target = process.argv[2]
+  if (!target) {
+    // eslint-disable-next-line no-console
+    console.error('usage: bun print-routes-for.ts <auth|dashboard|...>')
+    process.exit(2)
+  }
+
+  const { listRegisteredRoutes } = await import('@stacksjs/router')
+  await import(`../../../../defaults/routes/${target}`)
+
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(listRegisteredRoutes().map(r => `${r.method} ${r.path}`)))
+}

--- a/storage/framework/core/router/tests/granular-auth-routes.test.ts
+++ b/storage/framework/core/router/tests/granular-auth-routes.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Auth is its own default route bundle (stacksjs/stacks#2229).
+ *
+ * `defaults/routes/dashboard.ts` bundled login, registration, passkeys, 2FA,
+ * token management and password reset together with the commerce/cms/ai/admin
+ * surface, gated only by `feature('dashboard')`. An app that wanted `/login`
+ * and 2FA but not `Product`/`Coupon` had to either activate the whole dashboard
+ * or re-declare the auth routes by hand (and copy their rate limits out of
+ * framework source). Auth now lives in `defaults/routes/auth.ts`, gated by
+ * `feature('auth') || feature('dashboard')` in bootstrap.ts.
+ *
+ * Importing a routes file registers into the router singleton as a side effect,
+ * and `bun test` shares one process across files, so each file is snapshotted in
+ * a fresh subprocess via fixtures/print-routes-for.ts.
+ */
+
+import { join } from 'node:path'
+import process from 'node:process'
+import { describe, expect, test } from 'bun:test'
+
+const projectRoot = join(import.meta.dir, '../../../../..')
+const fixture = join(import.meta.dir, 'fixtures/print-routes-for.ts')
+
+async function routesForFile(name: string): Promise<string[]> {
+  const proc = Bun.spawn(['bun', fixture, name], {
+    cwd: projectRoot,
+    env: { ...process.env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    proc.exited,
+  ])
+  expect(exitCode).toBe(0)
+  // The preloader may chat on stdout first — the snapshot is the last line.
+  const lines = stdout.trim().split('\n')
+  return JSON.parse(lines[lines.length - 1]) as string[]
+}
+
+const AUTH_ROUTES = [
+  'POST /login',
+  'POST /register',
+  'POST /verify-two-factor-login',
+  'POST /generate-two-factor-secret',
+  'GET /generate-registration-options',
+  'POST /auth/refresh',
+  'GET /auth/tokens',
+  'GET /me',
+  'POST /logout',
+  'POST /logout-all',
+  'POST /password/forgot',
+  'POST /password/reset',
+]
+
+describe('granular auth route bundle (#2229)', () => {
+  test('auth.ts registers the whole auth surface on its own', async () => {
+    const routes = await routesForFile('auth')
+    for (const r of AUTH_ROUTES)
+      expect(routes).toContain(r)
+  }, 30000)
+
+  test('dashboard.ts no longer registers any auth route — they moved out', async () => {
+    const routes = await routesForFile('dashboard')
+    for (const r of AUTH_ROUTES)
+      expect(routes).not.toContain(r)
+  }, 30000)
+
+  test('dashboard.ts still registers its own surface (the split removed only auth)', async () => {
+    // A commerce route proves the file loaded and kept everything that is not
+    // auth — the extraction must not have taken a neighbour with it.
+    const routes = await routesForFile('dashboard')
+    expect(routes).toContain('POST /api/cart/add')
+  }, 30000)
+})

--- a/storage/framework/defaults/bootstrap.ts
+++ b/storage/framework/defaults/bootstrap.ts
@@ -76,12 +76,21 @@ route.use(MaintenanceMiddleware.toRouterHandler() as any)
 // Overridable by registering the same path in app routes first.
 await route.register(frameworkPath('defaults/routes/core.ts'))
 
-// Feature-gated route registration. The dashboard.ts file currently bundles
-// ~687 lines covering auth, password reset, email subscribe, storefront
-// cart/checkout, reviews, sitemap, AI, voice, and the admin dashboard's
-// REST surface. Until that file is split per-feature (auth.ts, marketing.ts,
-// commerce.ts, monitoring.ts), the whole thing loads when `dashboard` is
-// activated and stays inert otherwise.
+// Auth (login/register/passkeys/2FA/tokens/password) is its own bundle now, so
+// an app can mount just the auth surface without the dashboard's commerce, cms,
+// ai and admin routes (stacksjs/stacks#2229). Gated by `feature('auth')`, and
+// ALSO mounted whenever `dashboard` is on — the admin SPA needs it — so a full
+// dashboard app is unchanged. Registered before the dashboard bundle to keep
+// the previous order (auth used to sit at the top of dashboard.ts).
+if (feature('auth') || feature('dashboard')) {
+  await route.register(frameworkPath('defaults/routes/auth.ts'))
+}
+
+// Feature-gated route registration. The dashboard.ts file still bundles the
+// remaining ~625 lines — email subscribe, storefront cart/checkout, reviews,
+// sitemap, AI, voice, and the admin dashboard's REST surface. Splitting the
+// rest per-feature (marketing.ts, commerce.ts, monitoring.ts) is the follow-up;
+// auth.ts is the first slice extracted.
 //
 // Apps that need only a slice — e.g. a marketing site that wants
 // `/api/email/subscribe` and `/api/contact` but not the rest — can either
@@ -92,9 +101,6 @@ await route.register(frameworkPath('defaults/routes/core.ts'))
 //      cost beyond the bun-router route-table entries.
 //   2. Define the routes they want directly in `routes/api.ts` —
 //      first-registration-wins means the user version takes priority.
-//
-// Once the per-feature route split lands, each `if (feature('X'))` block
-// below registers just the X-specific routes file.
 if (feature('dashboard')) {
   await route.register(frameworkPath('defaults/routes/dashboard.ts'))
   // JSON endpoints for the dev dashboard UI. Kept separate from the view

--- a/storage/framework/defaults/routes/auth.ts
+++ b/storage/framework/defaults/routes/auth.ts
@@ -1,0 +1,77 @@
+/**
+ * Framework Default Auth Routes
+ *
+ * Login, registration, passkeys, TOTP 2FA, token management and password
+ * reset. Split out of `dashboard.ts` so an app can mount the auth surface on
+ * its own — via `feature('auth')` — without also activating the dashboard's
+ * commerce/cms/ai/admin bundle (stacksjs/stacks#2229). Still mounted whenever
+ * the dashboard is on, so existing apps are unchanged.
+ *
+ * Loaded automatically AFTER user-defined routes. To override any route here,
+ * define the same method + path in your `routes/api.ts` — bun-router is
+ * first-registration-wins and user routes load first.
+ *
+ * @example Override the login route in routes/api.ts:
+ * ```ts
+ * route.post('/login', 'Actions/MyCustomLoginAction')
+ * ```
+ */
+
+import { route } from '@stacksjs/router'
+
+// Rate limits on token-issuance + password-reset endpoints
+// (stacksjs/stacks#1921). `Auth.attempt()` already has a per-email
+// lockout but it doesn't stop credential-stuffing across many emails
+// from one IP, and the token endpoints have no upstream brake at all
+// — a leaked refresh token could be hammered for unlimited access
+// tokens until the row TTL. Userland that overrides any of these in
+// `routes/api.ts` (user routes win) gets to pick its own limits.
+route.post('/login', 'Actions/Auth/LoginAction').rateLimit(5, 'minute')
+route.post('/register', 'Actions/Auth/RegisterAction').rateLimit(3, 'minute')
+// Passkey ENROLLMENT (attaching a new credential to an account) must be
+// auth-gated — it's not a login flow, it's a logged-in user adding a
+// second factor to their own account. Previously unauthenticated and
+// keyed off a client-supplied `email` field: anyone who knew a victim's
+// email could register a passkey against that account and log in as
+// them, no password required. GenerateRegistrationAction/
+// VerifyRegistrationAction now derive identity from request.user().
+route.get('/generate-registration-options', 'Actions/Auth/GenerateRegistrationAction').middleware('auth').rateLimit(10, 'minute')
+route.post('/verify-registration', 'Actions/Auth/VerifyRegistrationAction').middleware('auth').rateLimit(5, 'minute')
+// Passkey AUTHENTICATION (logging in) is correctly unauthenticated —
+// the caller doesn't have a session yet, that's the point.
+route.get('/generate-authentication-options', 'Actions/Auth/GenerateAuthenticationAction').rateLimit(10, 'minute')
+route.get('/verify-authentication', 'Actions/Auth/VerifyAuthenticationAction').rateLimit(10, 'minute')
+
+// TOTP 2FA. Setup/enable/disable act on the caller's own authenticated
+// account (auth-gated, same identity rule as passkey enrollment above).
+// verify-two-factor-login is the second step of LoginAction's flow and
+// is correctly unauthenticated — the caller only has a short-lived
+// challenge token at that point, not a session yet.
+route.post('/generate-two-factor-secret', 'Actions/Auth/GenerateTwoFactorSecretAction').middleware('auth').rateLimit(10, 'minute')
+route.post('/enable-two-factor', 'Actions/Auth/EnableTwoFactorAction').middleware('auth').rateLimit(10, 'minute')
+route.post('/disable-two-factor', 'Actions/Auth/DisableTwoFactorAction').middleware('auth').rateLimit(10, 'minute')
+route.post('/verify-two-factor-login', 'Actions/Auth/VerifyTwoFactorLoginAction').rateLimit(10, 'minute')
+
+route.group({ prefix: '/auth' }, () => {
+  route.post('/refresh', 'Actions/Auth/RefreshTokenAction').rateLimit(10, 'minute')
+  route.get('/tokens', 'Actions/Auth/ListTokensAction').middleware('auth')
+  route.post('/token', 'Actions/Auth/CreateTokenAction').middleware('auth').rateLimit(10, 'minute')
+  route.delete('/tokens/{id}', 'Actions/Auth/RevokeTokenAction').middleware('auth')
+  route.get('/abilities', 'Actions/Auth/TestAbilitiesAction').middleware('auth')
+})
+
+route.group({ middleware: 'auth' }, () => {
+  route.get('/me', 'Actions/Auth/AuthUserAction')
+  route.post('/logout', 'Actions/Auth/LogoutAction')
+  // Sign out everywhere: revoke every access/refresh token AND destroy
+  // every session for the authenticated user (stacksjs/stacks#1957).
+  route.post('/logout-all', 'Actions/Auth/LogoutAllAction')
+})
+
+// Password Reset. `/forgot` triggers a mailer hop so it's the most
+// abuse-prone — keep that tighter than the verification endpoints.
+route.group({ prefix: '/password' }, () => {
+  route.post('/forgot', 'Actions/Password/SendPasswordResetEmailAction').rateLimit(3, 'minute')
+  route.post('/reset', 'Actions/Password/PasswordResetAction').rateLimit(5, 'minute')
+  route.post('/verify-token', 'Actions/Password/VerifyResetTokenAction').rateLimit(10, 'minute')
+})

--- a/storage/framework/defaults/routes/dashboard.ts
+++ b/storage/framework/defaults/routes/dashboard.ts
@@ -21,63 +21,12 @@ import { response, route } from '@stacksjs/router'
 // ============================================================================
 // Auth Routes
 // ============================================================================
-
-// Rate limits on token-issuance + password-reset endpoints
-// (stacksjs/stacks#1921). `Auth.attempt()` already has a per-email
-// lockout but it doesn't stop credential-stuffing across many emails
-// from one IP, and the token endpoints have no upstream brake at all
-// — a leaked refresh token could be hammered for unlimited access
-// tokens until the row TTL. Userland that overrides any of these in
-// `routes/api.ts` (user routes win) gets to pick its own limits.
-route.post('/login', 'Actions/Auth/LoginAction').rateLimit(5, 'minute')
-route.post('/register', 'Actions/Auth/RegisterAction').rateLimit(3, 'minute')
-// Passkey ENROLLMENT (attaching a new credential to an account) must be
-// auth-gated — it's not a login flow, it's a logged-in user adding a
-// second factor to their own account. Previously unauthenticated and
-// keyed off a client-supplied `email` field: anyone who knew a victim's
-// email could register a passkey against that account and log in as
-// them, no password required. GenerateRegistrationAction/
-// VerifyRegistrationAction now derive identity from request.user().
-route.get('/generate-registration-options', 'Actions/Auth/GenerateRegistrationAction').middleware('auth').rateLimit(10, 'minute')
-route.post('/verify-registration', 'Actions/Auth/VerifyRegistrationAction').middleware('auth').rateLimit(5, 'minute')
-// Passkey AUTHENTICATION (logging in) is correctly unauthenticated —
-// the caller doesn't have a session yet, that's the point.
-route.get('/generate-authentication-options', 'Actions/Auth/GenerateAuthenticationAction').rateLimit(10, 'minute')
-route.get('/verify-authentication', 'Actions/Auth/VerifyAuthenticationAction').rateLimit(10, 'minute')
-
-// TOTP 2FA. Setup/enable/disable act on the caller's own authenticated
-// account (auth-gated, same identity rule as passkey enrollment above).
-// verify-two-factor-login is the second step of LoginAction's flow and
-// is correctly unauthenticated — the caller only has a short-lived
-// challenge token at that point, not a session yet.
-route.post('/generate-two-factor-secret', 'Actions/Auth/GenerateTwoFactorSecretAction').middleware('auth').rateLimit(10, 'minute')
-route.post('/enable-two-factor', 'Actions/Auth/EnableTwoFactorAction').middleware('auth').rateLimit(10, 'minute')
-route.post('/disable-two-factor', 'Actions/Auth/DisableTwoFactorAction').middleware('auth').rateLimit(10, 'minute')
-route.post('/verify-two-factor-login', 'Actions/Auth/VerifyTwoFactorLoginAction').rateLimit(10, 'minute')
-
-route.group({ prefix: '/auth' }, () => {
-  route.post('/refresh', 'Actions/Auth/RefreshTokenAction').rateLimit(10, 'minute')
-  route.get('/tokens', 'Actions/Auth/ListTokensAction').middleware('auth')
-  route.post('/token', 'Actions/Auth/CreateTokenAction').middleware('auth').rateLimit(10, 'minute')
-  route.delete('/tokens/{id}', 'Actions/Auth/RevokeTokenAction').middleware('auth')
-  route.get('/abilities', 'Actions/Auth/TestAbilitiesAction').middleware('auth')
-})
-
-route.group({ middleware: 'auth' }, () => {
-  route.get('/me', 'Actions/Auth/AuthUserAction')
-  route.post('/logout', 'Actions/Auth/LogoutAction')
-  // Sign out everywhere: revoke every access/refresh token AND destroy
-  // every session for the authenticated user (stacksjs/stacks#1957).
-  route.post('/logout-all', 'Actions/Auth/LogoutAllAction')
-})
-
-// Password Reset. `/forgot` triggers a mailer hop so it's the most
-// abuse-prone — keep that tighter than the verification endpoints.
-route.group({ prefix: '/password' }, () => {
-  route.post('/forgot', 'Actions/Password/SendPasswordResetEmailAction').rateLimit(3, 'minute')
-  route.post('/reset', 'Actions/Password/PasswordResetAction').rateLimit(5, 'minute')
-  route.post('/verify-token', 'Actions/Password/VerifyResetTokenAction').rateLimit(10, 'minute')
-})
+//
+// Auth (login/register/passkeys/2FA/tokens/password) moved to its own
+// `defaults/routes/auth.ts` so an app can mount it without the rest of this
+// bundle (stacksjs/stacks#2229). bootstrap.ts registers auth.ts whenever
+// `feature('auth')` OR `feature('dashboard')` is on, so a full dashboard app is
+// unchanged. Keep them registered ahead of this file's routes as before.
 
 // ============================================================================
 // Email


### PR DESCRIPTION
Closes #2229.

## Problem

Framework default routes were gated only at `feature('dashboard')`, and `defaults/routes/dashboard.ts` bundled login / register / passkeys / 2FA / token management / password reset together with the commerce, cms, ai, sitemap and admin REST surface. An app that wanted `/login` and 2FA but not `Product`/`Coupon` had two bad options: activate the whole dashboard (mounting the commerce/ai demo surface), or `STACKS_SKIP_DEFAULT_ROUTES=1` and re-declare the auth routes by hand — copying rate limits out of framework source (a drift hazard) and, in practice, giving up 2FA, sign-out-everywhere and API-token management because re-registering those was not worth it.

`bootstrap.ts` already described this as the wrong shape and named the intended fix: *"Until that file is split per-feature (auth.ts, marketing.ts, commerce.ts, monitoring.ts)…"*.

## Change

- Extract the auth block (self-contained, `route.*` only) from `dashboard.ts` into **`defaults/routes/auth.ts`**.
- Register it from `bootstrap.ts` when `feature('auth') || feature('dashboard')`. `feature('auth')` already existed as a first-class key (`StacksFeature`, defaults off) — it just gated nothing.
- **Backward compatible:** `dashboard` defaults on, so a full dashboard app mounts auth exactly as before; auth registers ahead of the dashboard bundle to preserve ordering. An app can now set `feature('auth')` (or a `config/auth.ts`) to mount only auth.

This is the first slice of the per-feature split; marketing/commerce/monitoring remain in `dashboard.ts` as a follow-up.

## Tests

`core/router/tests/granular-auth-routes.test.ts` snapshots each routes file in a fresh subprocess (the router singleton is process-global) and asserts:
- `auth.ts` registers the full auth surface (login, register, 2FA, passkeys, `/auth/*`, `/me`, logout, `/password/*`);
- `dashboard.ts` registers **none** of them (they moved out) but keeps its own surface (`POST /api/cart/add`).

The existing #1955 fixture now imports `auth.ts` too, so its `POST /login` sanity check still holds. Router suites green (24 pass), lint clean.