### PR TITLE
feat(router): mount framework default route bundles individually

### DIFF
--- a/docs/guide/apis.md
+++ b/docs/guide/apis.md
@@ -74,6 +74,48 @@ export default defineModel({
 } as const)
 ```
 
+### Framework Default Routes
+
+Stacks ships default routes of its own - auth, the admin dashboard's REST
+surface, and email webhooks - registered *after* your routes, so anything you
+declare yourself always wins.
+
+Pick which of them you mount with `STACKS_DEFAULT_ROUTES`:
+
+```bash
+# Auth only: login, register, logout, refresh/revoke, passkeys, 2FA, password reset
+STACKS_DEFAULT_ROUTES=auth
+
+# Several bundles
+STACKS_DEFAULT_ROUTES=auth,email
+
+# Everything (the default when the variable is unset)
+STACKS_DEFAULT_ROUTES=all
+
+# Nothing
+STACKS_DEFAULT_ROUTES=none
+```
+
+Available bundles are `auth`, `dashboard` and `email`. Unset means all of them,
+so an app that says nothing keeps the behaviour it already had.
+`STACKS_SKIP_DEFAULT_ROUTES=1` still means "none" and is still supported.
+
+This exists so an app can mount `/login` and 2FA without also mounting the
+storefront, reviews, AI and voice routes that share `dashboard.ts`. Before it,
+the only way to avoid those was to turn everything off and re-declare the auth
+routes by hand, rate limits included.
+
+One asymmetry worth knowing, because it is confusing when you hit it: turning
+bundles off stops framework **routes** from registering, but framework
+**actions** still resolve. A route you declare yourself can point straight at
+one:
+
+```typescript
+// routes/api.ts — works with STACKS_DEFAULT_ROUTES=none,
+// with no file in app/Actions/
+route.post('/login', 'Actions/Auth/LoginAction').rateLimit(5, 'minute')
+```
+
 ### Manual API Routes
 
 ```typescript

--- a/storage/framework/core/auth/tests/passkey-registration-auth-gate.test.ts
+++ b/storage/framework/core/auth/tests/passkey-registration-auth-gate.test.ts
@@ -39,8 +39,8 @@ describe('passkey registration auth gate', () => {
     expect(source).not.toMatch(/const email = request\.get\('email'\)/)
   })
 
-  test('routes/dashboard.ts gates both registration routes behind middleware(\'auth\')', () => {
-    const source = readFileSync(resolve(DEFAULTS_ROOT, 'routes/dashboard.ts'), 'utf-8')
+  test('routes/auth.ts gates both registration routes behind middleware(\'auth\')', () => {
+    const source = readFileSync(resolve(DEFAULTS_ROOT, 'routes/auth.ts'), 'utf-8')
 
     const genLine = source.split('\n').find(l => l.includes('generate-registration-options'))
     const verifyLine = source.split('\n').find(l => l.includes('/verify-registration'))
@@ -52,7 +52,7 @@ describe('passkey registration auth gate', () => {
   })
 
   test('passkey AUTHENTICATION (login) routes remain unauthenticated', () => {
-    const source = readFileSync(resolve(DEFAULTS_ROOT, 'routes/dashboard.ts'), 'utf-8')
+    const source = readFileSync(resolve(DEFAULTS_ROOT, 'routes/auth.ts'), 'utf-8')
 
     const genAuthLine = source.split('\n').find(l => l.includes('generate-authentication-options'))
     const verifyAuthLine = source.split('\n').find(l => l.includes('/verify-authentication'))

--- a/storage/framework/core/auth/tests/two-factor-login-wiring.test.ts
+++ b/storage/framework/core/auth/tests/two-factor-login-wiring.test.ts
@@ -41,8 +41,8 @@ describe('TOTP login-challenge wiring', () => {
     expect(enableSource).not.toMatch(/request\.get\('secret'\)/)
   })
 
-  test('routes/dashboard.ts gates setup/enable/disable behind auth, leaves verify-two-factor-login open', () => {
-    const source = readFileSync(resolve(DEFAULTS_ROOT, 'routes/dashboard.ts'), 'utf-8')
+  test('routes/auth.ts gates setup/enable/disable behind auth, leaves verify-two-factor-login open', () => {
+    const source = readFileSync(resolve(DEFAULTS_ROOT, 'routes/auth.ts'), 'utf-8')
     const lines = source.split('\n')
 
     const setupLine = lines.find(l => l.includes('generate-two-factor-secret'))

--- a/storage/framework/core/router/src/route-loader.ts
+++ b/storage/framework/core/router/src/route-loader.ts
@@ -89,23 +89,148 @@ export async function loadRoutes(registry: RouteRegistry): Promise<void> {
  * Resolved through @stacksjs/path so the same import works whether this
  * package runs from the workspace or from `node_modules/@stacksjs/router/`.
  */
+/**
+ * The framework's default route files, as selectable bundles.
+ *
+ * `core` is not listed because it is not optional: it carries the locale
+ * cookie and the `/locale/{code}` redirect, and bootstrap registers it
+ * unconditionally.
+ */
+export const DEFAULT_ROUTE_BUNDLES = ['auth', 'dashboard', 'email'] as const
+
+export type DefaultRouteBundle = typeof DEFAULT_ROUTE_BUNDLES[number]
+
+/** Where {@link loadFrameworkRoutes} leaves the selection for bootstrap.ts. */
+export const DEFAULT_ROUTE_BUNDLES_KEY = '__stacksDefaultRouteBundles'
+
+/**
+ * Which framework default route bundles this app mounts.
+ *
+ * `STACKS_SKIP_DEFAULT_ROUTES=1` was a single boolean over a 724-line
+ * `dashboard.ts` that bundled auth, password reset, 2FA, storefront
+ * cart/checkout, reviews, sitemap, AI and voice together. An app wanting
+ * `/login` and 2FA without shipping `Product` or `Coupon` had exactly two
+ * options: mount the commerce demo surface, or turn everything off and
+ * re-declare the auth routes by hand with the rate limits copied out of
+ * framework source. One reporting app took the second and permanently gave up
+ * 2FA, sign-out-everywhere and API token management (stacksjs/stacks#2229).
+ *
+ * `STACKS_DEFAULT_ROUTES=auth` now names the bundles directly.
+ *
+ * ## Why bundles are not gated on `feature()`
+ *
+ * The issue asks for `feature('auth')` to mount the auth bundle. It cannot:
+ * `feature()` treats a present config object as enabled, and `config/auth.ts`
+ * ships in every scaffolded app with `enabled: true`. Gating on it would mount
+ * `/login`, `/register`, `/generate-two-factor-secret`, `/logout-all` and
+ * `/auth/tokens` in every app that currently runs with `dashboard` off -
+ * silently widening the public surface of existing apps on upgrade. An opt-in
+ * that is on by default is not an opt-in. So selection is explicit, and the
+ * default is exactly what the app got before.
+ *
+ * Precedence: `STACKS_DEFAULT_ROUTES` wins; then the legacy
+ * `STACKS_SKIP_DEFAULT_ROUTES`; then everything.
+ *
+ * Accepted spellings, so the two variables cannot contradict each other in a
+ * surprising way:
+ *   - `STACKS_DEFAULT_ROUTES=auth,email` - exactly those bundles
+ *   - `STACKS_DEFAULT_ROUTES=none` (or empty) - none, same as the old `=1`
+ *   - `STACKS_DEFAULT_ROUTES=all` - everything, same as the old unset
+ *   - `STACKS_SKIP_DEFAULT_ROUTES=1` - none. Still supported, still documented.
+ *
+ * An unknown name is ignored rather than fatal: a typo should cost you the
+ * bundle you misspelled, not the whole boot. `unknown` reports them so the
+ * caller can warn.
+ *
+ * ## Actions still resolve when routes do not
+ *
+ * Worth knowing because it is what made the original failure confusing to
+ * diagnose. Turning bundles off stops the framework's ROUTES from being
+ * registered; it does not stop its ACTIONS from resolving. A handler
+ * referenced by string - `route.post('/login', 'Actions/Auth/LoginAction')` -
+ * is still found in `@stacksjs/defaults`, so an app can re-declare a route in
+ * `routes/api.ts` and point it at a framework action it never copied into
+ * `app/Actions/`. The reporting app's nine hand-written auth routes work
+ * exactly this way, which is why they have no files behind them.
+ */
+export function resolveDefaultRouteBundles(env: NodeJS.ProcessEnv = process.env): Set<DefaultRouteBundle> {
+  return resolveDefaultRouteBundlesWithDiagnostics(env).bundles
+}
+
+/**
+ * {@link resolveDefaultRouteBundles} plus the names it did not recognise, and
+ * whether the app named bundles at all.
+ *
+ * `explicit` matters because it decides who wins against the feature flags. An
+ * app that wrote `STACKS_DEFAULT_ROUTES=auth` has said what it wants; the
+ * `feature('dashboard')` gate must not then withhold it, or the whole point -
+ * mounting auth WITHOUT the dashboard surface - is lost. When nothing is
+ * named, the flags gate exactly as they did before.
+ */
+export function resolveDefaultRouteBundlesWithDiagnostics(
+  env: NodeJS.ProcessEnv = process.env,
+): { bundles: Set<DefaultRouteBundle>, unknown: string[], explicit: boolean } {
+  const all = (): Set<DefaultRouteBundle> => new Set(DEFAULT_ROUTE_BUNDLES)
+  const raw = env.STACKS_DEFAULT_ROUTES
+
+  if (raw !== undefined) {
+    const names = raw.split(',').map(name => name.trim().toLowerCase()).filter(Boolean)
+
+    if (names.length === 0 || names.includes('none'))
+      return { bundles: new Set(), unknown: [], explicit: true }
+    if (names.includes('all'))
+      return { bundles: all(), unknown: [], explicit: true }
+
+    const bundles = new Set<DefaultRouteBundle>()
+    const unknown: string[] = []
+    for (const name of names) {
+      if ((DEFAULT_ROUTE_BUNDLES as readonly string[]).includes(name))
+        bundles.add(name as DefaultRouteBundle)
+      else
+        unknown.push(name)
+    }
+    return { bundles, unknown, explicit: true }
+  }
+
+  // Legacy wholesale switch. Only `1` ever meant anything, and it still does.
+  if (env.STACKS_SKIP_DEFAULT_ROUTES === '1')
+    return { bundles: new Set(), unknown: [], explicit: true }
+
+  return { bundles: all(), unknown: [], explicit: false }
+}
+
 async function loadFrameworkRoutes(): Promise<void> {
-  // Projects that don't use the bundled dashboard / commerce / monitoring
-  // surface area can opt out of framework default route registration
-  // entirely by setting `STACKS_SKIP_DEFAULT_ROUTES=1`. Without it, the
-  // bootstrap imports `defaults/routes/dashboard.ts` (and friends), each
-  // of which references actions that pull in models like `Product`,
-  // `Coupon`, `WaitlistRestaurant`, `Error` — and projects that don't
-  // ship those models flood their API boot with
-  // `[Router] Failed to import action ...` lines for every missing one.
-  //
-  // The per-route override pattern (declare the same path first in
-  // `routes/api.ts`) only scales when you want a handful of overrides;
-  // for projects that want none of the bundled domain at all this gate
-  // is the wholesale escape hatch. Pattern matches the existing
-  // `STACKS_DEV_DASHBOARD=1` opt-in on the dev-server side.
-  if (process.env.STACKS_SKIP_DEFAULT_ROUTES === '1') return
+  const { bundles, unknown, explicit } = resolveDefaultRouteBundlesWithDiagnostics()
+
+  for (const name of unknown)
+    log.warn(`[Routes] STACKS_DEFAULT_ROUTES lists unknown bundle "${name}" — known bundles are ${DEFAULT_ROUTE_BUNDLES.join(', ')}.`)
+
+  if (bundles.size === 0)
+    return
+
+  // Publish the selection for `defaults/bootstrap.ts`, which does the actual
+  // per-bundle registration. A module-scoped export would be cleaner, but
+  // bootstrap.ts is reached by dynamic import from a path this package
+  // resolves at runtime, so there is no import edge to hang it on.
+  ;(globalThis as Record<string, unknown>)[DEFAULT_ROUTE_BUNDLES_KEY] = { bundles, explicit }
+
   try {
+    // The gates in bootstrap.ts call `feature()`, which reads the live config
+    // proxy. Before `overridesReady` resolves that proxy holds
+    // `defaultsForOverrides()`, where every feature key is a present object
+    // with no `enabled` field - and `feature()` treats presence as on. So a
+    // gate evaluated too early answers "enabled" for a feature the app
+    // switched off. `serve/api.ts` and `dev/api.ts` already await it before
+    // calling in; `buddy route:list` and the lazy first-request load in
+    // `handleServerRequest` did not. Awaiting here puts the wait next to the
+    // read instead of relying on every caller to remember
+    // (stacksjs/stacks#2229).
+    try {
+      const { overridesReady } = await import('@stacksjs/config')
+      await overridesReady
+    }
+    catch { /* config unavailable; gates fall back to framework defaults */ }
+
     const { frameworkPath } = await import('@stacksjs/path')
     const bootstrapPath = frameworkPath('defaults/bootstrap.ts')
     if (await Bun.file(bootstrapPath).exists()) {

--- a/storage/framework/core/router/tests/default-route-bundles.test.ts
+++ b/storage/framework/core/router/tests/default-route-bundles.test.ts
@@ -1,0 +1,188 @@
+/**
+ * stacksjs/stacks#2229 — framework default routes were gated by one boolean
+ * over one 724-line file.
+ *
+ * `defaults/routes/dashboard.ts` bundled auth, password reset, 2FA, email
+ * subscribe, storefront cart/checkout, reviews, sitemap, AI, voice and the
+ * admin dashboard's REST surface together, behind a single
+ * `feature('dashboard')`. An app that wanted `/login`, `/register` and 2FA but
+ * ships no `Product` or `Coupon` had two options: mount the commerce demo
+ * surface, or set `STACKS_SKIP_DEFAULT_ROUTES=1` and re-declare the auth
+ * routes by hand with the rate limits copied out of framework source.
+ *
+ * The reporting app took the second and re-declared nine routes. It also
+ * permanently gave up 2FA, sign-out-everywhere and API token management,
+ * because re-registering those was not worth the maintenance — shipped
+ * framework features it simply could not reach.
+ *
+ * Two properties are load-bearing here and both are tested below:
+ *
+ *   1. `STACKS_DEFAULT_ROUTES=auth` mounts the auth surface and nothing else.
+ *   2. An app that says nothing gets EXACTLY what it got before. This is the
+ *      one that would be expensive to get wrong, because the failure mode is
+ *      silently changing which endpoints an existing deployment exposes.
+ *
+ * Selection is read once per process and bootstrap registers into the router
+ * singleton as an import side effect, so each scenario runs the
+ * fixtures/print-bundled-routes.ts fixture in a fresh subprocess. The pure
+ * resolver is unit-tested directly.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+import process from 'node:process'
+import {
+  DEFAULT_ROUTE_BUNDLES,
+  resolveDefaultRouteBundles,
+  resolveDefaultRouteBundlesWithDiagnostics,
+} from '../src/route-loader'
+
+const projectRoot = join(import.meta.dir, '../../../../..')
+const fixture = join(import.meta.dir, 'fixtures/print-bundled-routes.ts')
+
+async function routesFor(vars: Record<string, string | undefined>): Promise<Set<string>> {
+  const env: Record<string, string | undefined> = { ...process.env }
+  // Scrub inherited values so each scenario controls the gate's input.
+  delete env.STACKS_DEFAULT_ROUTES
+  delete env.STACKS_SKIP_DEFAULT_ROUTES
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined)
+      delete env[key]
+    else
+      env[key] = value
+  }
+
+  const proc = Bun.spawn(['bun', fixture], { cwd: projectRoot, env, stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    proc.exited,
+  ])
+  expect(exitCode).toBe(0)
+
+  // The fixture prints one JSON line last; env-loader chatter precedes it.
+  const line = stdout.trim().split('\n').at(-1)!
+  return new Set(JSON.parse(line) as string[])
+}
+
+// The endpoints the reporting app named as permanently lost.
+const AUTH_ROUTES = [
+  'POST /login',
+  'POST /register',
+  'POST /logout-all',
+  'POST /generate-two-factor-secret',
+  'POST /password/forgot',
+  'GET /auth/tokens',
+]
+
+describe('resolveDefaultRouteBundles (#2229)', () => {
+  test('an app that says nothing gets every bundle', () => {
+    expect(resolveDefaultRouteBundles({})).toEqual(new Set(DEFAULT_ROUTE_BUNDLES))
+  })
+
+  test('the legacy STACKS_SKIP_DEFAULT_ROUTES=1 still means none', () => {
+    expect(resolveDefaultRouteBundles({ STACKS_SKIP_DEFAULT_ROUTES: '1' })).toEqual(new Set())
+  })
+
+  test('only "1" ever meant anything for the legacy switch', () => {
+    // `=0`, `=true`, `=false` were never honoured; keeping that exact
+    // behaviour matters more than making them consistent, because an app
+    // relying on `=0` meaning "off" would lose its routes on upgrade.
+    for (const value of ['0', 'true', 'false', ''])
+      expect(resolveDefaultRouteBundles({ STACKS_SKIP_DEFAULT_ROUTES: value }).size).toBe(DEFAULT_ROUTE_BUNDLES.length)
+  })
+
+  test('names the bundles it is given', () => {
+    expect(resolveDefaultRouteBundles({ STACKS_DEFAULT_ROUTES: 'auth' })).toEqual(new Set(['auth']))
+    expect(resolveDefaultRouteBundles({ STACKS_DEFAULT_ROUTES: 'auth,email' })).toEqual(new Set(['auth', 'email']))
+  })
+
+  test('tolerates whitespace, case and empty entries', () => {
+    expect(resolveDefaultRouteBundles({ STACKS_DEFAULT_ROUTES: ' Auth , ,EMAIL ' })).toEqual(new Set(['auth', 'email']))
+  })
+
+  test('"none" and "all" are spellings of the two extremes', () => {
+    expect(resolveDefaultRouteBundles({ STACKS_DEFAULT_ROUTES: 'none' })).toEqual(new Set())
+    expect(resolveDefaultRouteBundles({ STACKS_DEFAULT_ROUTES: '' })).toEqual(new Set())
+    expect(resolveDefaultRouteBundles({ STACKS_DEFAULT_ROUTES: 'all' })).toEqual(new Set(DEFAULT_ROUTE_BUNDLES))
+  })
+
+  test('the new variable wins over the legacy one', () => {
+    expect(resolveDefaultRouteBundles({
+      STACKS_DEFAULT_ROUTES: 'auth',
+      STACKS_SKIP_DEFAULT_ROUTES: '1',
+    })).toEqual(new Set(['auth']))
+  })
+
+  test('an unknown name costs you that bundle, not the boot', () => {
+    const { bundles, unknown } = resolveDefaultRouteBundlesWithDiagnostics({ STACKS_DEFAULT_ROUTES: 'auth,commerce' })
+    expect(bundles).toEqual(new Set(['auth']))
+    expect(unknown).toEqual(['commerce'])
+  })
+
+  test('reports whether the app named bundles at all', () => {
+    // `explicit` decides whether the feature flags get a second veto. Naming
+    // `auth` has to mount auth even with `dashboard` off, or the whole point
+    // is lost.
+    expect(resolveDefaultRouteBundlesWithDiagnostics({}).explicit).toBe(false)
+    expect(resolveDefaultRouteBundlesWithDiagnostics({ STACKS_DEFAULT_ROUTES: 'auth' }).explicit).toBe(true)
+    expect(resolveDefaultRouteBundlesWithDiagnostics({ STACKS_SKIP_DEFAULT_ROUTES: '1' }).explicit).toBe(true)
+  })
+})
+
+describe('mounted routes per bundle (#2229)', () => {
+  test('an app that says nothing mounts exactly what it did before', async () => {
+    // The back-compat property. `all` is the pre-change behaviour, so an
+    // unset environment resolving to anything else would change which
+    // endpoints an existing deployment exposes.
+    const [unset, all] = await Promise.all([routesFor({}), routesFor({ STACKS_DEFAULT_ROUTES: 'all' })])
+
+    expect(unset).toEqual(all)
+    for (const route of AUTH_ROUTES)
+      expect(unset).toContain(route)
+  }, 120_000)
+
+  test('the legacy switch still mounts nothing', async () => {
+    const [legacy, none] = await Promise.all([
+      routesFor({ STACKS_SKIP_DEFAULT_ROUTES: '1' }),
+      routesFor({ STACKS_DEFAULT_ROUTES: 'none' }),
+    ])
+
+    expect(legacy).toEqual(none)
+    for (const route of AUTH_ROUTES)
+      expect(legacy).not.toContain(route)
+  }, 120_000)
+
+  test('auth mounts the auth surface without the rest', async () => {
+    const [auth, none, all] = await Promise.all([
+      routesFor({ STACKS_DEFAULT_ROUTES: 'auth' }),
+      routesFor({ STACKS_DEFAULT_ROUTES: 'none' }),
+      routesFor({ STACKS_DEFAULT_ROUTES: 'all' }),
+    ])
+
+    // Everything the reporter lost is reachable again.
+    for (const route of AUTH_ROUTES)
+      expect(auth).toContain(route)
+
+    // And none of the demo surface came with it.
+    for (const route of ['POST /ai/ask', 'GET /api/analytics/commerce'])
+      expect(auth).not.toContain(route)
+
+    // `auth` sits strictly between the two extremes.
+    expect(auth.size).toBeGreaterThan(none.size)
+    expect(auth.size).toBeLessThan(all.size)
+    for (const route of none)
+      expect(auth).toContain(route)
+  }, 180_000)
+
+  test('bundles compose', async () => {
+    const [auth, authEmail] = await Promise.all([
+      routesFor({ STACKS_DEFAULT_ROUTES: 'auth' }),
+      routesFor({ STACKS_DEFAULT_ROUTES: 'auth,email' }),
+    ])
+
+    for (const route of auth)
+      expect(authEmail).toContain(route)
+    expect(authEmail).toContain('POST /webhooks/email/ses')
+    expect(auth).not.toContain('POST /webhooks/email/ses')
+  }, 120_000)
+})

--- a/storage/framework/core/router/tests/dev-only-default-routes.test.ts
+++ b/storage/framework/core/router/tests/dev-only-default-routes.test.ts
@@ -61,14 +61,18 @@ describe('dev-only default routes — registration gate (#1955)', () => {
     expect(routes).not.toContain('GET /install')
     expect(routes).not.toContain('GET /test-error')
     // Sanity: the file still registered — the gate fired, not a broken import.
-    expect(routes).toContain('POST /login')
+    // Anchored on a route dashboard.ts still owns. This used to be
+    // `POST /login`, which moved to defaults/routes/auth.ts when the auth
+    // bundle was split out (stacksjs/stacks#2229) and the fixture only imports
+    // dashboard.ts.
+    expect(routes).toContain('POST /ai/ask')
   }, 30000)
 
   test('APP_ENV=staging omits both (allowlist, not a production blocklist)', async () => {
     const routes = await routesFor('staging')
     expect(routes).not.toContain('GET /install')
     expect(routes).not.toContain('GET /test-error')
-    expect(routes).toContain('POST /login')
+    expect(routes).toContain('POST /ai/ask')
   }, 30000)
 
   test('unset APP_ENV/NODE_ENV keeps both (buddy dev out of the box)', async () => {

--- a/storage/framework/core/router/tests/fixtures/print-bundled-routes.ts
+++ b/storage/framework/core/router/tests/fixtures/print-bundled-routes.ts
@@ -1,0 +1,22 @@
+/**
+ * Subprocess fixture for default-route-bundles.test.ts (#2229).
+ *
+ * Bundle selection is read once per process and bootstrap.ts registers into
+ * the router singleton as an import side effect, so each STACKS_DEFAULT_ROUTES
+ * scenario needs a fresh process. Goes through `route.importRoutes()` rather
+ * than importing a routes file directly, because the gate under test lives in
+ * the loader and the mounting lives in bootstrap.
+ *
+ * Behind `import.meta.main` and using dynamic imports for the same reason the
+ * sibling print-dashboard-routes.ts fixture is: `bun test <dir>` loads every
+ * `.ts` file under the directory, and registering the framework route table
+ * into the shared singleton poisons every other file in the run.
+ */
+
+if (import.meta.main) {
+  const { listRegisteredRoutes, route } = await import('@stacksjs/router')
+  await route.importRoutes()
+
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(listRegisteredRoutes().map(r => `${r.method} ${r.path}`)))
+}

--- a/storage/framework/defaults/bootstrap.ts
+++ b/storage/framework/defaults/bootstrap.ts
@@ -76,26 +76,58 @@ route.use(MaintenanceMiddleware.toRouterHandler() as any)
 // Overridable by registering the same path in app routes first.
 await route.register(frameworkPath('defaults/routes/core.ts'))
 
-// Feature-gated route registration. The dashboard.ts file currently bundles
-// ~687 lines covering auth, password reset, email subscribe, storefront
-// cart/checkout, reviews, sitemap, AI, voice, and the admin dashboard's
-// REST surface. Until that file is split per-feature (auth.ts, marketing.ts,
-// commerce.ts, monitoring.ts), the whole thing loads when `dashboard` is
-// activated and stays inert otherwise.
+// Which default route bundles this app mounts. The route loader resolves the
+// selection (STACKS_DEFAULT_ROUTES, or the legacy STACKS_SKIP_DEFAULT_ROUTES)
+// and leaves it here; see `resolveDefaultRouteBundles` in
+// `core/router/src/route-loader.ts`. Absent when bootstrap is imported by
+// something other than the loader, in which case every bundle is eligible and
+// the feature gates below decide, exactly as before.
+const selection = (globalThis as Record<string, unknown>).__stacksDefaultRouteBundles as
+  { bundles: Set<string>, explicit: boolean } | undefined
+
+/**
+ * Whether a bundle mounts.
+ *
+ * An app that NAMED its bundles has already answered the question, so the
+ * feature flag does not get a second veto - otherwise `STACKS_DEFAULT_ROUTES=auth`
+ * would still be withheld from an app running with `dashboard` off, which is
+ * the exact case this exists for. When nothing was named, the flags gate
+ * precisely as they did before.
+ */
+function mounts(bundle: string, featureEnabled: boolean): boolean {
+  if (selection && !selection.bundles.has(bundle))
+    return false
+  return selection?.explicit ? true : featureEnabled
+}
+
+// Auth: login, registration, logout, refresh/revoke, passkeys, TOTP 2FA and
+// password reset. Split out of dashboard.ts so it can be mounted on its own
+// (stacksjs/stacks#2229) — previously the only way to get `/login` was to
+// activate `dashboard` and take the storefront, reviews, AI and voice surface
+// with it.
 //
-// Apps that need only a slice — e.g. a marketing site that wants
-// `/api/email/subscribe` and `/api/contact` but not the rest — can either
-//   1. Activate `dashboard` and live with the over-broad register; the
-//      action handlers for routes you don't hit never fire, and their
-//      models stay un-loaded as long as the corresponding feature flag
-//      (`commerce`, `cms`, `monitoring`) is off, so there's no hidden
-//      cost beyond the bun-router route-table entries.
-//   2. Define the routes they want directly in `routes/api.ts` —
-//      first-registration-wins means the user version takes priority.
+// Registered BEFORE dashboard.ts, which is where these lived, so the
+// first-registration-wins order among framework routes is unchanged.
 //
-// Once the per-feature route split lands, each `if (feature('X'))` block
-// below registers just the X-specific routes file.
-if (feature('dashboard')) {
+// Deliberately NOT gated on `feature('auth')`, despite the issue asking for
+// it: `config/auth.ts` ships in every app with `enabled: true`, so that gate
+// is true everywhere and would mount the auth surface — including
+// `/generate-two-factor-secret`, `/logout-all` and `/auth/tokens` — in apps
+// currently running with `dashboard` off. Widening an app's public surface on
+// upgrade is not something a refactor gets to do silently.
+if (mounts('auth', feature('dashboard')))
+  await route.register(frameworkPath('defaults/routes/auth.ts'))
+
+// The rest of dashboard.ts: email subscribe, storefront cart/checkout,
+// reviews, sitemap, AI, voice, and the admin dashboard's REST surface. Still
+// one file and still one gate — splitting auth out was the case with a
+// reporter behind it; marketing.ts / commerce.ts / monitoring.ts remain the
+// obvious next cuts.
+//
+// Apps that need only a slice can also define the routes they want directly
+// in `routes/api.ts` — first-registration-wins means the user version takes
+// priority.
+if (mounts('dashboard', feature('dashboard'))) {
   await route.register(frameworkPath('defaults/routes/dashboard.ts'))
   // JSON endpoints for the dev dashboard UI. Kept separate from the view
   // routes above so the data layer is one obvious file to grep.
@@ -112,6 +144,6 @@ if (feature('dashboard')) {
 // non-default mount path register their own routes in `routes/api.ts`
 // and the framework's mount silently no-ops since user routes
 // register first.
-if (feature('email')) {
+if (mounts('email', feature('email'))) {
   await route.register(frameworkPath('defaults/routes/email.ts'))
 }

--- a/storage/framework/defaults/routes/auth.ts
+++ b/storage/framework/defaults/routes/auth.ts
@@ -1,0 +1,83 @@
+/**
+ * Framework Default Routes - Auth
+ *
+ * Login, registration, logout, token refresh and revocation, passkeys, TOTP
+ * 2FA, and password reset.
+ *
+ * Split out of `dashboard.ts` for stacksjs/stacks#2229. That file bundles the
+ * auth surface together with storefront cart/checkout, reviews, sitemap, AI
+ * and voice, and the only gate over the whole thing is `feature('dashboard')`
+ * - so an app that wanted `/login` and 2FA but ships no `Product` or `Coupon`
+ * had to either mount the commerce demo surface or set
+ * `STACKS_SKIP_DEFAULT_ROUTES=1` and re-declare every auth route by hand, rate
+ * limits included. One reporting app did the latter and permanently gave up
+ * 2FA, sign-out-everywhere and API token management, because re-registering
+ * those was not worth the maintenance.
+ *
+ * Mounted by `defaults/bootstrap.ts` as the `auth` bundle; see
+ * `resolveDefaultRouteBundles` in `core/router/src/route-loader.ts` for how an
+ * app selects bundles.
+ *
+ * Users should NOT edit this file. To override any route here, define the same
+ * method + path in your `routes/api.ts`: bun-router is first-registration-wins
+ * and user routes load first, so your handler always takes priority.
+ */
+
+import { route } from '@stacksjs/router'
+
+// Rate limits on token-issuance + password-reset endpoints
+// (stacksjs/stacks#1921). `Auth.attempt()` already has a per-email
+// lockout but it doesn't stop credential-stuffing across many emails
+// from one IP, and the token endpoints have no upstream brake at all
+// — a leaked refresh token could be hammered for unlimited access
+// tokens until the row TTL. Userland that overrides any of these in
+// `routes/api.ts` (user routes win) gets to pick its own limits.
+route.post('/login', 'Actions/Auth/LoginAction').rateLimit(5, 'minute')
+route.post('/register', 'Actions/Auth/RegisterAction').rateLimit(3, 'minute')
+// Passkey ENROLLMENT (attaching a new credential to an account) must be
+// auth-gated — it's not a login flow, it's a logged-in user adding a
+// second factor to their own account. Previously unauthenticated and
+// keyed off a client-supplied `email` field: anyone who knew a victim's
+// email could register a passkey against that account and log in as
+// them, no password required. GenerateRegistrationAction/
+// VerifyRegistrationAction now derive identity from request.user().
+route.get('/generate-registration-options', 'Actions/Auth/GenerateRegistrationAction').middleware('auth').rateLimit(10, 'minute')
+route.post('/verify-registration', 'Actions/Auth/VerifyRegistrationAction').middleware('auth').rateLimit(5, 'minute')
+// Passkey AUTHENTICATION (logging in) is correctly unauthenticated —
+// the caller doesn't have a session yet, that's the point.
+route.get('/generate-authentication-options', 'Actions/Auth/GenerateAuthenticationAction').rateLimit(10, 'minute')
+route.get('/verify-authentication', 'Actions/Auth/VerifyAuthenticationAction').rateLimit(10, 'minute')
+
+// TOTP 2FA. Setup/enable/disable act on the caller's own authenticated
+// account (auth-gated, same identity rule as passkey enrollment above).
+// verify-two-factor-login is the second step of LoginAction's flow and
+// is correctly unauthenticated — the caller only has a short-lived
+// challenge token at that point, not a session yet.
+route.post('/generate-two-factor-secret', 'Actions/Auth/GenerateTwoFactorSecretAction').middleware('auth').rateLimit(10, 'minute')
+route.post('/enable-two-factor', 'Actions/Auth/EnableTwoFactorAction').middleware('auth').rateLimit(10, 'minute')
+route.post('/disable-two-factor', 'Actions/Auth/DisableTwoFactorAction').middleware('auth').rateLimit(10, 'minute')
+route.post('/verify-two-factor-login', 'Actions/Auth/VerifyTwoFactorLoginAction').rateLimit(10, 'minute')
+
+route.group({ prefix: '/auth' }, () => {
+  route.post('/refresh', 'Actions/Auth/RefreshTokenAction').rateLimit(10, 'minute')
+  route.get('/tokens', 'Actions/Auth/ListTokensAction').middleware('auth')
+  route.post('/token', 'Actions/Auth/CreateTokenAction').middleware('auth').rateLimit(10, 'minute')
+  route.delete('/tokens/{id}', 'Actions/Auth/RevokeTokenAction').middleware('auth')
+  route.get('/abilities', 'Actions/Auth/TestAbilitiesAction').middleware('auth')
+})
+
+route.group({ middleware: 'auth' }, () => {
+  route.get('/me', 'Actions/Auth/AuthUserAction')
+  route.post('/logout', 'Actions/Auth/LogoutAction')
+  // Sign out everywhere: revoke every access/refresh token AND destroy
+  // every session for the authenticated user (stacksjs/stacks#1957).
+  route.post('/logout-all', 'Actions/Auth/LogoutAllAction')
+})
+
+// Password Reset. `/forgot` triggers a mailer hop so it's the most
+// abuse-prone — keep that tighter than the verification endpoints.
+route.group({ prefix: '/password' }, () => {
+  route.post('/forgot', 'Actions/Password/SendPasswordResetEmailAction').rateLimit(3, 'minute')
+  route.post('/reset', 'Actions/Password/PasswordResetAction').rateLimit(5, 'minute')
+  route.post('/verify-token', 'Actions/Password/VerifyResetTokenAction').rateLimit(10, 'minute')
+})

--- a/storage/framework/defaults/routes/dashboard.ts
+++ b/storage/framework/defaults/routes/dashboard.ts
@@ -19,67 +19,6 @@ import process from 'node:process'
 import { response, route } from '@stacksjs/router'
 
 // ============================================================================
-// Auth Routes
-// ============================================================================
-
-// Rate limits on token-issuance + password-reset endpoints
-// (stacksjs/stacks#1921). `Auth.attempt()` already has a per-email
-// lockout but it doesn't stop credential-stuffing across many emails
-// from one IP, and the token endpoints have no upstream brake at all
-// — a leaked refresh token could be hammered for unlimited access
-// tokens until the row TTL. Userland that overrides any of these in
-// `routes/api.ts` (user routes win) gets to pick its own limits.
-route.post('/login', 'Actions/Auth/LoginAction').rateLimit(5, 'minute')
-route.post('/register', 'Actions/Auth/RegisterAction').rateLimit(3, 'minute')
-// Passkey ENROLLMENT (attaching a new credential to an account) must be
-// auth-gated — it's not a login flow, it's a logged-in user adding a
-// second factor to their own account. Previously unauthenticated and
-// keyed off a client-supplied `email` field: anyone who knew a victim's
-// email could register a passkey against that account and log in as
-// them, no password required. GenerateRegistrationAction/
-// VerifyRegistrationAction now derive identity from request.user().
-route.get('/generate-registration-options', 'Actions/Auth/GenerateRegistrationAction').middleware('auth').rateLimit(10, 'minute')
-route.post('/verify-registration', 'Actions/Auth/VerifyRegistrationAction').middleware('auth').rateLimit(5, 'minute')
-// Passkey AUTHENTICATION (logging in) is correctly unauthenticated —
-// the caller doesn't have a session yet, that's the point.
-route.get('/generate-authentication-options', 'Actions/Auth/GenerateAuthenticationAction').rateLimit(10, 'minute')
-route.get('/verify-authentication', 'Actions/Auth/VerifyAuthenticationAction').rateLimit(10, 'minute')
-
-// TOTP 2FA. Setup/enable/disable act on the caller's own authenticated
-// account (auth-gated, same identity rule as passkey enrollment above).
-// verify-two-factor-login is the second step of LoginAction's flow and
-// is correctly unauthenticated — the caller only has a short-lived
-// challenge token at that point, not a session yet.
-route.post('/generate-two-factor-secret', 'Actions/Auth/GenerateTwoFactorSecretAction').middleware('auth').rateLimit(10, 'minute')
-route.post('/enable-two-factor', 'Actions/Auth/EnableTwoFactorAction').middleware('auth').rateLimit(10, 'minute')
-route.post('/disable-two-factor', 'Actions/Auth/DisableTwoFactorAction').middleware('auth').rateLimit(10, 'minute')
-route.post('/verify-two-factor-login', 'Actions/Auth/VerifyTwoFactorLoginAction').rateLimit(10, 'minute')
-
-route.group({ prefix: '/auth' }, () => {
-  route.post('/refresh', 'Actions/Auth/RefreshTokenAction').rateLimit(10, 'minute')
-  route.get('/tokens', 'Actions/Auth/ListTokensAction').middleware('auth')
-  route.post('/token', 'Actions/Auth/CreateTokenAction').middleware('auth').rateLimit(10, 'minute')
-  route.delete('/tokens/{id}', 'Actions/Auth/RevokeTokenAction').middleware('auth')
-  route.get('/abilities', 'Actions/Auth/TestAbilitiesAction').middleware('auth')
-})
-
-route.group({ middleware: 'auth' }, () => {
-  route.get('/me', 'Actions/Auth/AuthUserAction')
-  route.post('/logout', 'Actions/Auth/LogoutAction')
-  // Sign out everywhere: revoke every access/refresh token AND destroy
-  // every session for the authenticated user (stacksjs/stacks#1957).
-  route.post('/logout-all', 'Actions/Auth/LogoutAllAction')
-})
-
-// Password Reset. `/forgot` triggers a mailer hop so it's the most
-// abuse-prone — keep that tighter than the verification endpoints.
-route.group({ prefix: '/password' }, () => {
-  route.post('/forgot', 'Actions/Password/SendPasswordResetEmailAction').rateLimit(3, 'minute')
-  route.post('/reset', 'Actions/Password/PasswordResetAction').rateLimit(5, 'minute')
-  route.post('/verify-token', 'Actions/Password/VerifyResetTokenAction').rateLimit(10, 'minute')
-})
-
-// ============================================================================
 // Email
 // ============================================================================
 


### PR DESCRIPTION
Closes #2229.

Framework default routes were gated by one boolean over one 724-line file. `defaults/routes/dashboard.ts` bundled auth, password reset, 2FA, email subscribe, storefront cart/checkout, reviews, sitemap, AI, voice and the admin dashboard's REST surface behind a single `feature('dashboard')`, and `STACKS_SKIP_DEFAULT_ROUTES=1` was the only other lever.

Your app took the only remaining option and paid for it: nine routes re-declared by hand with rate limits copied out of framework source, and 2FA, sign-out-everywhere and API token management given up permanently — shipped features you could not reach.

## What this adds

```bash
STACKS_DEFAULT_ROUTES=auth          # just the auth surface
STACKS_DEFAULT_ROUTES=auth,email    # compose
STACKS_DEFAULT_ROUTES=all           # everything (the default when unset)
STACKS_DEFAULT_ROUTES=none          # nothing
```

Measured against this repo, by subprocess rather than by inspection:

| selection | routes | note |
|---|---|---|
| unset | 992 | **unchanged** — the pre-change behaviour |
| `all` | 992 | |
| `auth,email` | 394 | |
| `auth` | 389 | +26 over the base: `/login` … `/auth/tokens` |
| `none` | 363 | user routes only |
| `STACKS_SKIP_DEFAULT_ROUTES=1` | 363 | legacy alias, unchanged |

Every endpoint you named as lost — `/logout-all`, `/generate-two-factor-secret`, `/auth/tokens` — is reachable under `STACKS_DEFAULT_ROUTES=auth`, and none of `/ai/ask` or `/api/analytics/*` comes with it.

The auth surface moved to `defaults/routes/auth.ts`. **The split is lossless**: 339 route registrations before, the same 339 after, identical sets. It registers before `dashboard.ts`, so first-registration-wins order among framework routes is unchanged.

## On ask #2, which I did not do

**`feature('auth')` cannot gate this, and doing it would be a security regression.**

`feature()` treats a present config object as enabled, and `config/auth.ts` ships in every scaffolded app with `enabled: true`. So `feature('auth')` is true everywhere. Gating on it would mount `/login`, `/register`, `/generate-two-factor-secret`, `/logout-all` and `/auth/tokens` in every app currently running with `dashboard` off — silently widening the public surface of existing deployments on upgrade. An opt-in that is on by default is not an opt-in.

Selection is explicit instead. And an app that *names* bundles beats the feature flags, because otherwise `STACKS_DEFAULT_ROUTES=auth` would still be withheld from an app with `dashboard` off — the exact case this exists for. I caught that one mid-implementation after first writing the gate as `wants('auth') && feature('dashboard')`, which would have shipped the feature broken for its own reporter.

## An ordering gap found on the way

The gates call `feature()`, which reads the live config proxy. Before `overridesReady` resolves, that proxy holds `defaultsForOverrides()`, where every feature key is a present object with **no `enabled` field** — so `feature()` hits its "presence implies on" branch and answers *enabled* for a feature the app switched off:

```
BEFORE overridesReady:  config.dashboard = {"sections":{...}}          <- no `enabled`
AFTER  overridesReady:  config.dashboard = {"enabled":true,"sections":{...}}
```

`serve/api.ts` and `dev/api.ts` already await it. `buddy route:list` and the lazy first-request load in `handleServerRequest` did not. The await now sits next to the read instead of relying on every caller to remember.

## Ask #5

Documented in both places it bites: the resolver's docblock and `docs/guide/apis.md`. Turning bundles off stops framework **routes** registering but not framework **actions** resolving — which is why your nine hand-written routes work with no files behind them, and why the failure was confusing.

## Ask #4

Not done. `buddy publish:routes auth` is a separate deliverable and the drift it targets is largely gone once you can mount the framework's own auth file instead of copying it. Happy to take it as its own issue if you still want ownership of the file.

## Tests

13 new — the pure resolver unit-tested directly, and five mounting scenarios through a fresh subprocess each, since selection is read once per process and bootstrap registers into the router singleton as an import side effect.

The back-compat case is tested as its own assertion (`unset` deep-equals `all`), because that is the one that would be expensive to get wrong.

Three existing tests were anchored on `POST /login` living in `dashboard.ts`. The #1955 dev-only-routes sanity check moved to `POST /ai/ask`; the passkey and TOTP gate tests in `core/auth` read the routes file as source, and **they follow the routes to `auth.ts` rather than being weakened** — they are security assertions and still assert the same gates.

`core/router` 352 pass, `core/auth` 258 pass (matching baseline), app suite 222 pass. Full core sweep run in both this branch's worktree and a clean `origin/main` worktree of the same shape: `cache queue` on both.

## Not a breaking change

Despite the issue expecting one. Unset resolves to every bundle, byte-for-byte what an app got before, and the legacy variable still works.