### PR TITLE
feat(browser): make useForm reachable from a client script

### DIFF
--- a/storage/framework/core/browser/src/utils/vendors.ts
+++ b/storage/framework/core/browser/src/utils/vendors.ts
@@ -3,9 +3,18 @@ export {
   useDark,
   useDateFormat,
   useFetch,
+  // Reachable from a client script at last (stacksjs/stacks#1940, stx#1843).
+  // It shipped with per-field validation, `inputProps()` carrying
+  // aria-invalid / aria-describedby, isSubmitting, touched/dirty and
+  // setErrors for 422 mapping — and appeared in neither auto-import surface,
+  // so there was no way to find it without already knowing the package path.
+  // Two production apps hand-rolled N signals plus manual error flags and
+  // manual focus per form rather than use it.
+  useForm,
   useNow,
   useOnline,
   usePreferredDark,
+  useScrollLock,
   useStorage,
   useToggle,
 } from '@stacksjs/composables'

--- a/storage/framework/core/browser/tests/use-form-reachable.test.ts
+++ b/storage/framework/core/browser/tests/use-form-reachable.test.ts
@@ -1,0 +1,63 @@
+// `useForm` is reachable from a client script (stacksjs/stx#1843).
+//
+// It shipped with per-field validation, `inputProps()` carrying aria-invalid /
+// aria-describedby, isSubmitting, touched/dirty and setErrors for 422 mapping —
+// and appeared in NEITHER auto-import surface, so there was no way to find it
+// without already knowing the package path. Two production apps hand-rolled N
+// signals plus manual error flags and manual focus per form instead. The audit
+// in stx#1843 measured 0 hits for `useForm` against a control that hit, which
+// is how the gap was found.
+//
+// Reachability has two halves and both are checked, because they fail
+// independently: the module has to actually re-export it (runtime), and the
+// generated declaration has to name it (editor autocomplete, which is how
+// anyone discovers it in the first place).
+
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const AUTO_IMPORTS = join(import.meta.dir, '../../../types/browser-auto-imports.d.ts')
+
+describe('useForm is reachable (stx#1843)', () => {
+  it('is re-exported by the browser surface at runtime', async () => {
+    const vendors = await import('../src/utils/vendors')
+    expect(typeof (vendors as Record<string, unknown>).useForm).toBe('function')
+  })
+
+  it('is declared in the browser auto-import surface', () => {
+    // Without this an editor never offers it, which is the entire failure
+    // mode — the primitive existed and worked the whole time.
+    expect(readFileSync(AUTO_IMPORTS, 'utf8')).toContain("const useForm:")
+  })
+
+  it('the composable behind it is the reactive one, not a schema builder', () => {
+    // stx also ships `defineForm`, which is a validation SCHEMA library whose
+    // state is plain objects — `form.errors.email` in a template never
+    // re-renders. The two names are confusingly close and only this one can
+    // drive a template, so pin which one landed here.
+    const source = readFileSync(join(import.meta.dir, '../../composables/src/useForm.ts'), 'utf8')
+    expect(source).toContain('import { ref }')
+    expect(source).toContain('export function useForm')
+  })
+})
+
+describe('a declared browser global is actually exported (stx#1843)', () => {
+  // Narrow on purpose. The generated declaration currently names 243 symbols
+  // from this module and the module exports 12, so asserting the whole set
+  // would just be red — that gap is real but it is its own issue, not this
+  // change. These are the ones this commit is responsible for.
+  const OWNED = ['useForm', 'useScrollLock']
+
+  it('every name this change touched resolves', async () => {
+    const vendors = await import('../src/utils/vendors') as Record<string, unknown>
+    const missing = OWNED.filter(name => typeof vendors[name] !== 'function')
+    expect(missing).toEqual([])
+  })
+
+  it('and is declared', () => {
+    const declared = readFileSync(AUTO_IMPORTS, 'utf8')
+    const undeclared = OWNED.filter(name => !declared.includes(`const ${name}:`))
+    expect(undeclared).toEqual([])
+  })
+})

--- a/storage/framework/types/browser-auto-imports.d.ts
+++ b/storage/framework/types/browser-auto-imports.d.ts
@@ -273,6 +273,7 @@ declare global {
   const useFocus: typeof import('../core/browser/src/utils/vendors')['useFocus']
   const useFocusWithin: typeof import('../core/browser/src/utils/vendors')['useFocusWithin']
   const useFps: typeof import('../core/browser/src/utils/vendors')['useFps']
+  const useForm: typeof import('../core/browser/src/utils/vendors')['useForm']
   const useFullscreen: typeof import('../core/browser/src/utils/vendors')['useFullscreen']
   const useGamepad: typeof import('../core/browser/src/utils/vendors')['useGamepad']
   const useGeolocation: typeof import('../core/browser/src/utils/vendors')['useGeolocation']
@@ -706,6 +707,7 @@ declare module '@stacksjs/stx' {
     readonly useFocus: UnwrapRef<typeof import('../core/browser/src/utils/vendors')['useFocus']>
     readonly useFocusWithin: UnwrapRef<typeof import('../core/browser/src/utils/vendors')['useFocusWithin']>
     readonly useFps: UnwrapRef<typeof import('../core/browser/src/utils/vendors')['useFps']>
+    readonly useForm: UnwrapRef<typeof import('../core/browser/src/utils/vendors')['useForm']>
     readonly useFullscreen: UnwrapRef<typeof import('../core/browser/src/utils/vendors')['useFullscreen']>
     readonly useGamepad: UnwrapRef<typeof import('../core/browser/src/utils/vendors')['useGamepad']>
     readonly useGeolocation: UnwrapRef<typeof import('../core/browser/src/utils/vendors')['useGeolocation']>


### PR DESCRIPTION
Item 1 of stacksjs/stx#1843's adoption problem: make `useForm` findable.

### The gap

`useForm` ships with per-field validation, `inputProps()` carrying `aria-invalid`/`aria-describedby`, `isSubmitting`, `touched`/`dirty`, and `setErrors` for 422 mapping. It appeared in **neither** auto-import surface, so there was no way to discover it without already knowing the package path — and two production apps hand-rolled N signals plus manual error flags and manual focus per form instead.

Reachability has two halves that fail independently, so both are fixed and both are tested:

- **runtime** — without the re-export, a bare `useForm(...)` is a `ReferenceError`
- **declaration** — without it, no editor ever offers the name, which is the failure that actually happened

### `useScrollLock` came along, and it's the uncomfortable part

It was in the same state, and worse: **declared in the generated surface while the module exported nothing of that name.** It was the control I used to measure the `useForm` gap in the first place — so the control was itself broken.

That is not one stale line:

```
declared from core/browser/src/utils/vendors : 243
actually exported by that module             :  12
```

The remaining ~231 are a VueUse-shaped surface — `breakpointsTailwind`, `computedAsync`, `createEventHook`, `controlledRef` — that an editor autocompletes and that resolves to nothing at runtime. The file carries `@ts-nocheck`, which is why nothing ever caught it. **That is #1804's trap at scale.**

I deliberately did **not** widen this PR to cover it. Deleting 231 declarations or re-exporting 231 symbols are both real decisions with blast radius, and neither belongs stapled to a two-name fix. It wants its own issue — happy to file it with the measurement script if you want.

For the same reason the guard here is **scoped to the two names this commit owns** rather than asserting the whole surface, which would just ship red.

### Tests

5 tests; 4 fail without the change. Browser suite 91 pass / 0 fail. `buddy lint` clean.

### Note on the sibling ask

stx#1843 also wants two codemods (`confirm(` → `stxConfirm(`, `title=` → `x-tooltip=`). Those target **stx** primitives, so they belong in that repo, not this one — doing them separately.
