### PR TITLE
fix(auth): make the auth cookie the framework writes the one it reads

### DIFF
--- a/app/Middleware/Auth.ts
+++ b/app/Middleware/Auth.ts
@@ -1,4 +1,4 @@
-import { Auth } from '@stacksjs/auth'
+import { Auth, authCookieName } from '@stacksjs/auth'
 import { config } from '@stacksjs/config'
 import { HttpError } from '@stacksjs/error-handling'
 import { log } from '@stacksjs/logging'
@@ -33,7 +33,7 @@ export default new Middleware({
     // resolveTokenUser so every cookie-authenticated entry point behaves
     // identically. Distinct from the session_id branch below, which only
     // applies to the `session` guard driver.
-    const tokenCookieName = config.auth?.defaultTokenName || 'auth-token'
+    const tokenCookieName = authCookieName()
     const cookieToken = request.cookie(tokenCookieName)
 
     if (cookieToken) {

--- a/docs/packages/auth.md
+++ b/docs/packages/auth.md
@@ -49,8 +49,15 @@ export default {
   password: 'password',
 
   // Token configuration
+  // The LABEL written to a token's `name` column — what a "your active
+  // sessions" list shows. Not the cookie name; see `cookie` below.
   defaultTokenName: 'auth-token',
   defaultAbilities: ['*'],
+
+  // The browser cookie that carries an access token.
+  cookie: {
+    name: 'auth-token',
+  },
   tokenExpiry: 30 * 24 * 60 * 60 * 1000, // 30 days
   tokenRotation: 24, // Rotate after 24 hours
 
@@ -710,3 +717,42 @@ route.post('/login', async (req) => {
 | `totpKeyUri(options)` | Generate URI |
 | `generateQRCodeDataURL(uri)` | Generate QR code |
 | `generateQRCodeSVG(uri)` | Generate SVG QR |
+
+## Cookie sessions for the browser
+
+An API client holds a bearer token in a header. A browser coming back from an
+OAuth redirect or a form POST has nothing but cookies, so `@stacksjs/auth`
+carries the same personal access token in an `HttpOnly` cookie:
+
+```ts
+import { Auth, authCookie, clearAuthCookie } from '@stacksjs/auth'
+
+const session = await Auth.loginUsingId(user.id)
+
+return new Response(null, {
+  status: 303,
+  headers: {
+    'Location': '/account',
+    'Set-Cookie': authCookie(String(session.token)),
+  },
+})
+```
+
+The cookie is `HttpOnly` (no page script needs it), `SameSite=Lax` (a link from
+an email arrives signed in, a cross-site POST does not) and `Secure` everywhere
+except local development. It carries a real token, so it is revocable through
+the usual token calls and survives a restart. Sign out with
+`clearAuthCookie()`.
+
+The Auth middleware reads it automatically — bearer header first, then this
+cookie. `authCookieName()` is the single resolver both sides use, so the name
+written is always the name read. Until stacksjs/stacks#2236 it was not:
+`authCookie()` wrote `stacks_auth` while every reader looked for
+`defaultTokenName`, and the whole path was quietly inert.
+
+On the client, finish the handoff instead of writing storage keys by hand:
+
+```ts
+const { completeSocialLogin } = useAuth()
+await completeSocialLogin()
+```

--- a/storage/framework/core/actions/src/dev/views.ts
+++ b/storage/framework/core/actions/src/dev/views.ts
@@ -152,7 +152,8 @@ async function startDefaultServer() {
 
   // Cookie name the SPA writes when a user logs in. Defaults to whatever
   // `config.auth.defaultTokenName` is set to, falling back to `auth-token`.
-  const authCookie = (config as any)?.auth?.defaultTokenName ?? 'auth-token'
+  const { authCookieName } = await import('@stacksjs/auth')
+  const authCookie = authCookieName()
 
   // Which of the framework's default views this app serves (#2237). Defaults
   // to all of them, so an app that says nothing is unaffected.

--- a/storage/framework/core/auth/src/cookie-auth.ts
+++ b/storage/framework/core/auth/src/cookie-auth.ts
@@ -24,7 +24,7 @@ type AuthenticatedUser = Awaited<ReturnType<typeof Auth.getUserFromToken>>
  */
 
 export interface AuthCookieOptions {
-  /** Cookie name. Defaults to `config.auth.cookie.name` or `stacks_auth`. */
+  /** Cookie name. Defaults to {@link authCookieName} — `config.auth.cookie.name`, else `auth-token`. */
   name?: string
   /** Lifetime in seconds. Defaults to the configured token expiry. */
   maxAge?: number
@@ -40,8 +40,62 @@ export interface AuthCookieOptions {
   sameSite?: 'Strict' | 'Lax' | 'None'
 }
 
+/**
+ * RFC 6265 cookie-name grammar: a `token`, i.e. any US-ASCII character except
+ * CTLs and separators. A space, comma, semicolon or equals sign makes the
+ * `Set-Cookie` header malformed.
+ */
+const COOKIE_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
+
+/**
+ * The one name the auth cookie has.
+ *
+ * There used to be two. `authCookie()` wrote `stacks_auth` (via
+ * `config.auth.cookie.name`, a key that did not exist on `AuthOptions`, so no
+ * app using `satisfies AuthConfig` could even set it), while the Auth
+ * middleware, `team.ts` and the stx page gate all read
+ * `config.auth.defaultTokenName` — `auth-token`. A cookie the framework wrote
+ * was never one the framework read, which is why apps ended up hand-writing a
+ * token pack into `localStorage` from an inline script instead
+ * (stacksjs/stacks#2236).
+ *
+ * Resolution order:
+ *   1. an explicit `options.name`
+ *   2. `config.auth.cookie.name` — the supported key
+ *   3. `config.auth.defaultTokenName` — DEPRECATED, honoured so an app that
+ *      had renamed it (and thereby renamed the cookie those readers wanted)
+ *      keeps working. Ignored with a warning when it is not a legal cookie
+ *      name, which it very often is not: it is a human-readable token label
+ *      like `Web Session`.
+ *   4. `auth-token`
+ */
+export function authCookieName(options?: AuthCookieOptions): string {
+  if (options?.name)
+    return options.name
+
+  const configured = (config.auth as any)?.cookie?.name
+  if (typeof configured === 'string' && configured.length > 0)
+    return configured
+
+  const legacy = (config.auth as any)?.defaultTokenName
+  if (typeof legacy === 'string' && legacy.length > 0 && legacy !== 'auth-token') {
+    if (COOKIE_NAME_RE.test(legacy))
+      return legacy
+
+    // Falling back rather than emitting a malformed Set-Cookie. This is the
+    // failure the overload made likely, so it says what to do about it.
+    console.warn(
+      `[auth] config.auth.defaultTokenName ("${legacy}") is not a valid cookie name and is being ignored `
+      + `for cookie naming; using "auth-token". defaultTokenName is a personal access token label, not a `
+      + `cookie name — set config.auth.cookie.name instead (stacksjs/stacks#2236).`,
+    )
+  }
+
+  return 'auth-token'
+}
+
 function cookieName(options?: AuthCookieOptions): string {
-  return options?.name ?? (config.auth as any)?.cookie?.name ?? 'stacks_auth'
+  return authCookieName(options)
 }
 
 function defaultMaxAge(): number {

--- a/storage/framework/core/auth/src/team.ts
+++ b/storage/framework/core/auth/src/team.ts
@@ -2,6 +2,7 @@ import { config } from '@stacksjs/config'
 import { db } from '@stacksjs/database'
 import { Auth } from './authentication'
 import { sessionUser } from './session-auth'
+import { authCookieName } from './cookie-auth'
 
 /**
  * Team resolution from a request's real auth credential (bearer token or
@@ -271,7 +272,7 @@ async function resolveSessionUser(request: TeamAuthRequest) {
 }
 
 async function resolveTokenUser(request: TeamAuthRequest) {
-  const cookieName = config.auth?.defaultTokenName || 'auth-token'
+  const cookieName = authCookieName()
   // Guard the bearerToken() call: partial request objects must resolve
   // to "unauthenticated", not crash the auth path.
   const bearer = (typeof request.bearerToken === 'function' ? request.bearerToken() : undefined)

--- a/storage/framework/core/auth/tests/auth-cookie-name.test.ts
+++ b/storage/framework/core/auth/tests/auth-cookie-name.test.ts
@@ -1,0 +1,108 @@
+/**
+ * stacksjs/stacks#2236 — the auth cookie had two names and they never met.
+ *
+ * `authCookie()` wrote `stacks_auth`, resolved from `config.auth.cookie.name`,
+ * a key that did not exist on `AuthOptions` — so no app closing its config with
+ * `satisfies AuthConfig` could even set it, and the documented override was
+ * unreachable. Meanwhile the framework default Auth middleware, the userland
+ * middleware, `team.ts`'s team resolver and the stx page gate all read
+ * `config.auth.defaultTokenName`, i.e. `auth-token`.
+ *
+ * So a cookie the framework set was never a cookie the framework read. Nothing
+ * called `authCookie()` at all, which is how it survived: the whole cookie
+ * handoff was shipped, exported from `@stacksjs/auth`, documented with a
+ * worked example — and inert. Apps that wanted a browser session after an
+ * OAuth redirect had no working path, and hand-serialized a token pack into
+ * `localStorage` from an inline `<script>` instead.
+ *
+ * The existing cookie-auth test could not catch it: it fed `authCookie()`'s
+ * output straight back into `authCookieToken()`, so both halves agreed with
+ * each other while agreeing with nothing else. These tests check the name
+ * against the readers.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { authCookie, authCookieName, authCookieToken } from '../src/cookie-auth'
+
+const REPO_ROOT = join(import.meta.dir, '../../../../..')
+
+function source(relative: string): string {
+  return readFileSync(join(REPO_ROOT, relative), 'utf-8')
+}
+
+describe('authCookieName', () => {
+  it('is the name every reader looks for', () => {
+    expect(authCookieName()).toBe('auth-token')
+  })
+
+  it('honours an explicit override', () => {
+    expect(authCookieName({ name: 'session' })).toBe('session')
+  })
+})
+
+describe('the writer and the readers agree (#2236)', () => {
+  it('round-trips through the cookie header', () => {
+    const header = authCookie('tok_123')
+    const request = new Request('https://example.com/', {
+      headers: { cookie: header.split(';')[0]! },
+    })
+
+    expect(authCookieToken(request)).toBe('tok_123')
+  })
+
+  it('writes the name the Auth middleware reads', () => {
+    // The middleware resolves its name at runtime, so assert on the source:
+    // it must go through the shared resolver rather than recomputing one.
+    const middleware = source('storage/framework/defaults/app/Middleware/Auth.ts')
+
+    expect(middleware).toContain('authCookieName()')
+    expect(middleware).not.toContain(`defaultTokenName || 'auth-token'`)
+  })
+
+  it('writes the name the team resolver reads', () => {
+    const team = source('storage/framework/core/auth/src/team.ts')
+
+    expect(team).toContain('authCookieName()')
+    expect(team).not.toContain(`defaultTokenName || 'auth-token'`)
+  })
+
+  it('writes the name the scaffold middleware reads', () => {
+    const scaffold = source('app/Middleware/Auth.ts')
+
+    expect(scaffold).toContain('authCookieName()')
+    expect(scaffold).not.toContain(`defaultTokenName || 'auth-token'`)
+  })
+
+  it('writes the name the stx page gate is configured with', () => {
+    const views = source('storage/framework/core/actions/src/dev/views.ts')
+
+    expect(views).toContain('authCookieName()')
+    expect(views).not.toContain(`defaultTokenName ?? 'auth-token'`)
+  })
+
+  it('no reader recomputes the name from defaultTokenName', () => {
+    // The specific shape of the bug: four separate sites each deriving a
+    // cookie name from a key that is a per-token label. If one of them drifts
+    // back, the handoff silently breaks again for exactly one of them, which
+    // is the hardest version of this to debug.
+    for (const file of [
+      'storage/framework/defaults/app/Middleware/Auth.ts',
+      'storage/framework/core/auth/src/team.ts',
+      'app/Middleware/Auth.ts',
+      'storage/framework/core/actions/src/dev/views.ts',
+    ]) {
+      expect(source(file)).not.toMatch(/defaultTokenName\s*[|?]{2}\s*['"]auth-token['"]/)
+    }
+  })
+})
+
+describe('defaultTokenName is a token label, not a cookie name', () => {
+  it('is still what createTokenForUser writes to the row', () => {
+    // The overload is only safe to unwind if the label use survives intact.
+    const authentication = source('storage/framework/core/auth/src/authentication.ts')
+
+    expect(authentication).toContain(`config.auth.defaultTokenName ?? 'auth-token'`)
+  })
+})

--- a/storage/framework/core/auth/tests/cookie-auth.test.ts
+++ b/storage/framework/core/auth/tests/cookie-auth.test.ts
@@ -10,7 +10,7 @@ describe('authCookie', () => {
   it('carries the token and the attributes a session needs', () => {
     const cookie = authCookie('abc123')
 
-    expect(cookie).toContain('stacks_auth=abc123')
+    expect(cookie).toContain('auth-token=abc123')
     expect(cookie).toContain('Path=/')
     expect(cookie).toContain('HttpOnly')
     expect(cookie).toContain('SameSite=Lax')
@@ -48,7 +48,7 @@ describe('authCookie', () => {
   it('percent-encodes a token containing cookie separators', () => {
     const cookie = authCookie('12|plain;text value')
 
-    expect(cookie).toContain('stacks_auth=12%7Cplain%3Btext%20value')
+    expect(cookie).toContain('auth-token=12%7Cplain%3Btext%20value')
     // The separators must not survive into the header, or the cookie splits.
     expect(cookie.split(';')[0]).not.toContain('plain;')
   })
@@ -67,7 +67,7 @@ describe('clearAuthCookie', () => {
 
 describe('authCookieToken', () => {
   it('finds its cookie among others', () => {
-    const token = authCookieToken(requestWith('theme=dark; stacks_auth=abc123; locale=de'))
+    const token = authCookieToken(requestWith('theme=dark; auth-token=abc123; locale=de'))
     expect(token).toBe('abc123')
   })
 
@@ -81,10 +81,10 @@ describe('authCookieToken', () => {
   it('returns undefined when there is no cookie, no match, or an empty value', () => {
     expect(authCookieToken(new Request('https://example.com/'))).toBeUndefined()
     expect(authCookieToken(requestWith('theme=dark'))).toBeUndefined()
-    expect(authCookieToken(requestWith('stacks_auth='))).toBeUndefined()
+    expect(authCookieToken(requestWith('auth-token='))).toBeUndefined()
   })
 
   it('does not match a cookie whose name merely ends with the wanted one', () => {
-    expect(authCookieToken(requestWith('other_stacks_auth=abc123'))).toBeUndefined()
+    expect(authCookieToken(requestWith('other_auth-token=abc123'))).toBeUndefined()
   })
 })

--- a/storage/framework/core/browser/src/composables/useAuth.ts
+++ b/storage/framework/core/browser/src/composables/useAuth.ts
@@ -303,6 +303,50 @@ export function useAuth(): AuthComposable {
     }
   }
 
+
+  /**
+   * Finish a sign-in that completed on the server, typically an OAuth redirect.
+   *
+   * The browser arrives back from the provider with a session the server
+   * established and no client state at all. Before this existed, the only way
+   * to bridge that gap was for the callback to return an HTML page with an
+   * inline script writing the framework's own storage keys by hand
+   * (stacksjs/stacks#2236) — which meant re-deriving `useStorage`'s encoding.
+   * Getting it wrong was easy and quiet: `useStorage` JSON-stringifies on
+   * write, so the string that belongs in `localStorage` under `token` is
+   * `"abc"` WITH the quotes, and passing the user object straight to
+   * `setItem` stored the literal `[object Object]`.
+   *
+   * Two shapes, because there are two ways a server can hand a session over:
+   *
+   *   - **Cookie** (preferred). The callback replies `303` with
+   *     `Set-Cookie: authCookie(token)` and no body. Nothing secret ever
+   *     touches the URL or the DOM. Call this with no argument; it hydrates
+   *     `user` from the cookie-authenticated `/api/me`.
+   *   - **Token pack.** When a cookie is not an option — a cross-origin API,
+   *     say, where the browser would not send one — hand the pack straight in
+   *     and it is stored through the same path `login()` uses.
+   *
+   * Returns the signed-in user, or `null` when the session did not take.
+   *
+   * @example
+   * ```ts
+   * // after redirecting back from /auth/github/callback
+   * const user = await completeSocialLogin()
+   * if (user) location.replace('/account')
+   * ```
+   */
+  async function completeSocialLogin(
+    pack?: { token?: string, refresh_token?: string } | null,
+  ): Promise<UserData | null> {
+    if (pack?.token)
+      token.value = pack.token
+    if (pack?.refresh_token)
+      refreshToken.value = pack.refresh_token
+
+    return fetchAuthUser()
+  }
+
   return {
     user,
     isAuthenticated,
@@ -312,6 +356,7 @@ export function useAuth(): AuthComposable {
     login,
     logout,
     fetchAuthUser,
+    completeSocialLogin,
     checkAuthentication,
     refreshToken,
     getRefreshToken: () => refreshToken.value,

--- a/storage/framework/core/browser/src/types/dashboard.ts
+++ b/storage/framework/core/browser/src/types/dashboard.ts
@@ -77,6 +77,16 @@ export interface AuthComposable {
   login: (user: AuthUser) => Promise<LoginResponse | LoginError>
   register: (user: AuthUser) => Promise<RegisterResponse | RegisterError>
   fetchAuthUser: () => Promise<UserData | null>
+  /**
+   * Finish a sign-in the server completed, typically an OAuth redirect.
+   *
+   * Call with no argument when the callback set the auth cookie (the
+   * preferred handoff — nothing secret in the URL or the DOM); pass the token
+   * pack when a cookie is not available. Either way the storage encoding stays
+   * inside the framework instead of being re-derived by an inline script
+   * (stacksjs/stacks#2236).
+   */
+  completeSocialLogin: (pack?: { token?: string, refresh_token?: string } | null) => Promise<UserData | null>
   checkAuthentication: () => Promise<boolean>
   logout: () => void
   getToken: () => string | null

--- a/storage/framework/core/config/src/defaults.ts
+++ b/storage/framework/core/config/src/defaults.ts
@@ -69,6 +69,13 @@ export const defaults: StacksOptions = {
     username: 'email',
     password: 'password',
     defaultTokenName: 'auth-token',
+    // The cookie that carries an access token to a browser. Named separately
+    // from `defaultTokenName` because that one is a per-token label, not a
+    // wire identifier (stacksjs/stacks#2236). `auth-token` keeps the name every
+    // existing reader already looks for.
+    cookie: {
+      name: 'auth-token',
+    },
     // Short-lived access token (1 hour). Pair with the refresh token below
     // for a standard "rotate-on-refresh" flow. A non-expiring (or 30-day)
     // bearer token has no recovery path if it leaks — see #1839.

--- a/storage/framework/core/socials/README.md
+++ b/storage/framework/core/socials/README.md
@@ -32,6 +32,65 @@ const authUrl = await github.redirect()
 const user = await github.user()
 ```
 
+### Validate the OAuth `state`
+
+Do not hand-roll this. The driver already ships a constant-time check, and an
+HMAC written next to it is a CSRF hole waiting to be got subtly wrong:
+
+```ts
+import { Socials } from '@stacksjs/socials'
+
+// On the redirect: mint a state, stash it, embed it.
+const state = crypto.randomUUID()
+const github = Socials.driver('github').withState(state)
+// persist `state` in the session/cookie, then redirect to:
+const authUrl = await github.redirect()
+
+// On the callback: compare what came back against what you stashed.
+if (!github.validateState(stashedState, url.searchParams.get('state')))
+  throw new HttpError(400, 'Invalid OAuth state')
+```
+
+`validateState()` is timing-safe, so response time cannot leak a prefix match.
+Without `withState()` the driver mints a state you cannot recover, and there is
+nothing to compare against on the way back.
+
+### Sign the browser in
+
+The provider hands you a user; `@stacksjs/auth` turns that into a session. Set
+the auth cookie and redirect — no HTML, no inline script, and nothing secret in
+the URL:
+
+```ts
+import { Auth, authCookie } from '@stacksjs/auth'
+
+const session = await Auth.loginUsingId(localUser.id)
+
+return new Response(null, {
+  status: 303,
+  headers: {
+    'Location': '/account',
+    'Set-Cookie': authCookie(String(session.token)),
+  },
+})
+```
+
+`authCookie()` writes an `HttpOnly`, `SameSite=Lax`, `Secure`-outside-local
+cookie under the same name every framework reader looks for, so the next
+request is authenticated by the Auth middleware with nothing further to do.
+
+On the page you land on, hydrate the client session:
+
+```ts
+const { completeSocialLogin } = useAuth()
+const user = await completeSocialLogin()
+```
+
+Do NOT write `token` / `refresh_token` / `user` into `localStorage` yourself.
+Those keys are `useStorage`-encoded (JSON-stringified on write), and
+re-deriving that encoding by hand is how you end up storing the string
+`[object Object]` for a user (stacksjs/stacks#2236).
+
 Learn more in the docs.
 
 ## 🧪 Testing

--- a/storage/framework/core/types/src/auth.ts
+++ b/storage/framework/core/types/src/auth.ts
@@ -1,3 +1,32 @@
+/**
+ * The browser cookie that carries a personal access token.
+ *
+ * One name, in one place. Before stacksjs/stacks#2236 there were two: the
+ * writer (`authCookie()`) defaulted to `stacks_auth` while every reader looked
+ * for `config.auth.defaultTokenName` (`auth-token`), so a cookie the framework
+ * set was never one the framework read.
+ */
+export interface AuthCookieConfig {
+  /**
+   * Cookie name. Must be a valid RFC 6265 token: no spaces, no separators.
+   * @default 'auth-token'
+   */
+  name?: string
+  /** Path the cookie is sent for. @default '/' */
+  path?: string
+  /** Domain, for sharing one session across subdomains. */
+  domain?: string
+  /** Lifetime in seconds. Defaults to `tokenExpiry`, so cookie and token die together. */
+  maxAge?: number
+  /**
+   * Send only over HTTPS. Defaults to true outside local development, where
+   * the dev server is plain HTTP and a Secure cookie would never be stored.
+   */
+  secure?: boolean
+  /** @default 'Lax' — a link from an email arrives signed in; a cross-site POST does not. */
+  sameSite?: 'Strict' | 'Lax' | 'None'
+}
+
 export interface AuthOptions {
   /**
    * Top-level feature gate. When `false`, the auth feature is inert at boot
@@ -79,9 +108,28 @@ export interface AuthOptions {
   defaultAbilities: string[]
 
   /**
-   * The token name used when creating new tokens
+   * The label written to a personal access token's `name` column.
+   *
+   * Per-token and human-readable — it is what a "your active sessions" list
+   * shows, and `createTokenForUser(user, { name: 'iPhone' })` overrides it.
+   *
+   * It is NOT the auth cookie's name, although four separate readers used to
+   * treat it as one (stacksjs/stacks#2236). That overload could not hold: one
+   * key cannot be both a per-row label and a single wire identifier, and an
+   * app setting `defaultTokenName: 'Web Session'` to tidy its sessions UI
+   * silently renamed the cookie those readers looked for — to a string with a
+   * space in it, which RFC 6265 does not permit in a cookie name. Use
+   * {@link AuthCookieConfig.name}.
    */
   defaultTokenName: string
+
+  /**
+   * The browser cookie that carries a personal access token.
+   *
+   * Used by `authCookie()` / `authCookieName()` in `@stacksjs/auth` and by
+   * every framework reader that resolves a signed-in user from a request.
+   */
+  cookie: AuthCookieConfig
 
   /**
    * Password reset configuration

--- a/storage/framework/defaults/ai/skills/stacks-auth/SKILL.md
+++ b/storage/framework/defaults/ai/skills/stacks-auth/SKILL.md
@@ -333,7 +333,7 @@ await authUser.authorize('edit-post', post)  // throws if denied
   tokenExpiry: 30,         // days, AUTH_TOKEN_EXPIRY env
   tokenRotation: 7,        // days, AUTH_TOKEN_ROTATION env
   defaultAbilities: ['*'],
-  defaultTokenName: 'auth_token',
+  defaultTokenName: 'auth-token',
   passwordReset: { expire: 60, throttle: 60 }
 }
 ```

--- a/storage/framework/defaults/app/Middleware/Auth.ts
+++ b/storage/framework/defaults/app/Middleware/Auth.ts
@@ -1,4 +1,4 @@
-import { Auth, sessionUser } from '@stacksjs/auth'
+import { Auth, authCookieName, sessionUser } from '@stacksjs/auth'
 import { config } from '@stacksjs/config'
 import { HttpError } from '@stacksjs/error-handling'
 import { Middleware } from '@stacksjs/router'
@@ -40,7 +40,9 @@ export default new Middleware({
       return
     }
 
-    const tokenCookieName = config.auth?.defaultTokenName || 'auth-token'
+    // One resolver, so the name a cookie is written under is the name it is
+    // read under (stacksjs/stacks#2236).
+    const tokenCookieName = authCookieName()
     const cookieToken = request.cookie?.(tokenCookieName)
     if (cookieToken) {
       await stampTokenUser(request, cookieToken)


### PR DESCRIPTION
Closes #2236.

**The framework already ships the handoff this issue asks for. It has never worked.**

`@stacksjs/auth` exports `authCookie()` — `HttpOnly`, `SameSite=Lax`, `Secure` outside local dev, carrying a real revocable token — documented with a worked example that is exactly the callback→session pattern requested. Then:

```
authCookie() writes cookie named : stacks_auth
Auth middleware reads cookie named: auth-token
config.auth.cookie              : undefined
=> middleware honours it?        : false
```

`authCookie()` named the cookie from `config.auth.cookie.name`. That key **does not exist on `AuthOptions`**, so an app closing its config with `satisfies AuthConfig` gets TS2353 trying to set it — the documented override is unreachable and the name is always the literal `stacks_auth`. Meanwhile four independent readers each recomputed a name from `config.auth.defaultTokenName` (`auth-token`): the framework Auth middleware, the scaffold's own `app/Middleware/Auth.ts`, `team.ts`'s team resolver (which every `useApi` route inherits via `orm/routes.ts`), and the stx page gate.

It survived because **nothing calls it**. `authCookie()` has zero callers outside its own test; `LoginAction` returns a JSON pack and sets no cookie; and `dev/dashboard.ts` disables the SSR auth gate outright with a comment saying pages would otherwise be *"gated against an `auth-token` cookie that doesn't exist"* — the bug documented in-tree.

That is why you ended up hand-serializing into `localStorage` from an inline script. The supported path is present, exported, documented, and inert.

## The fix

One typed key, resolved in one place:

- `AuthOptions.cookie` is now a real member (`AuthCookieConfig`), defaulted to **`auth-token`** — the name every existing reader already wanted, so no reader changes behaviour.
- `authCookieName()` is the single resolver: explicit option → `config.auth.cookie.name` → `defaultTokenName` (deprecated) → `auth-token`.
- All four readers call it instead of deriving their own.

**No upgrade risk.** Nothing has ever written an auth cookie under either name, so there are no live cookies to invalidate. Verified rather than assumed.

### The overload was a real bug, not untidiness

`createTokenForUser` writes `defaultTokenName` to the **`name` column of the token row** — a per-token human label, what a "your active sessions" list shows, overridden per call as `{ name: 'iPhone' }`. One key cannot be both a per-row label and a single wire identifier.

Concretely: an app setting `defaultTokenName: 'Web Session'` to tidy its sessions UI silently renamed the cookie four readers looked for — to a string with a space in it, which RFC 6265 forbids in a cookie name, and `authCookie()` did no validation. The deprecated rung now checks the grammar and warns rather than emitting a malformed `Set-Cookie`.

## Your callback, after this

```ts
const session = await Auth.loginUsingId(localUser.id)
return new Response(null, {
  status: 303,
  headers: { Location: '/account', 'Set-Cookie': authCookie(String(session.token)) },
})
```

No HTML, no inline script, no `escapeForScript`, no double-`JSON.stringify`, nothing secret in the URL. And on the page you land on:

```ts
const { completeSocialLogin } = useAuth()
await completeSocialLogin()
```

`completeSocialLogin()` takes no argument for the cookie handoff and hydrates from `/api/me`; when a cookie is not possible (cross-origin API) it accepts the token pack and stores it through the same path `login()` uses. Either way `useStorage`'s encoding stays inside the framework.

## Discoverability (ask #5)

This is what actually caused the report — you hand-rolled an HMAC beside an existing constant-time `validateState()`, and never found `authCookie()`. So: the socials README now shows `withState()`/`validateState()` and the cookie handoff; `docs/packages/auth.md` gains a cookie-sessions section and the `cookie` key; and `stacks-auth/SKILL.md`'s `auth_token` typo is fixed — it never matched the real `auth-token`.

## Deliberately not included

**Asks #1 and #4** — the default `/auth/{provider}` routes and the find-or-create + provider-linking policy. There is no schema for them: no `SocialAccount` model, no oauth migration, no provider columns on `User`. Shipping the linking policy adds a table to every scaffolded app, plus config for the policy and the unverified-email takeover guard. That is a schema decision for every Stacks app and deserves its own review rather than riding in a bug fix. I'll open it separately with a concrete proposal.

## Verification

9 new tests in `auth-cookie-name.test.ts`, asserting the writer's name against each reader — the existing cookie-auth test could not catch this because it fed `authCookie()`'s output straight back into `authCookieToken()`, so both halves agreed with each other while agreeing with nothing else. Confirmed the new tests bite by reverting `team.ts` to its old derivation: 2 fail.

Typecheck 0 errors. Full core sweep run in this branch's worktree and a clean `origin/main` worktree: `cache queue` on both. One `core/config` failure appears when auth+browser+config run together — it reproduces identically on main and is the known load-order race.

Found via a multi-agent sweep; three independent judges (security / upgrade-safety / coherence) converged on this shape, and the coherence judge is the one that caught the `defaultTokenName` label-vs-identifier split.