### PR TITLE
fix(dashboard): read model data the same on every database dialect

### DIFF
--- a/storage/framework/defaults/app/Actions/Dashboard/Analytics/request-analytics.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Analytics/request-analytics.ts
@@ -105,7 +105,12 @@ export function requestAnalyticsRow(record: AnalyticsModelRecord): RequestAnalyt
   if (durationMs < 0)
     throw new TypeError('Request.duration_ms cannot be negative.')
 
-  const createdAt = requiredRecordString(record, 'created_at')
+  // Postgres and MySQL drivers return Date instances for timestamp columns;
+  // SQLite stores TEXT and returns strings.
+  const createdAtValue = record.get('created_at')
+  const createdAt = createdAtValue instanceof Date
+    ? createdAtValue.toISOString()
+    : requiredRecordString(record, 'created_at')
   if (!Number.isFinite(timestamp(createdAt)))
     throw new TypeError('Request.created_at must be a valid timestamp.')
 

--- a/storage/framework/defaults/app/Actions/Dashboard/Commerce/CommercePosCheckoutAction.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Commerce/CommercePosCheckoutAction.ts
@@ -79,6 +79,13 @@ function receiptOptionalText(input: unknown, source: string, fieldName: string):
 }
 
 function receiptTimestamp(input: unknown, source: string, fieldName: string): string {
+  // Postgres and MySQL drivers return Date instances for timestamp columns;
+  // SQLite stores TEXT and returns strings. Accept both.
+  if (input instanceof Date) {
+    if (!Number.isFinite(input.getTime()))
+      throw receiptError(source, fieldName, 'a valid timestamp')
+    return input.toISOString()
+  }
   const raw = receiptText(input, source, fieldName)
   const date = new Date(/^\d{4}-\d{2}-\d{2} \d/.test(raw) ? `${raw.replace(' ', 'T')}Z` : raw)
   if (!Number.isFinite(date.getTime()))

--- a/storage/framework/defaults/app/Actions/Dashboard/Commerce/commerce-product-records.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Commerce/commerce-product-records.ts
@@ -1,3 +1,5 @@
+import { commerceTimestamp } from './commerce-record'
+
 export interface CommerceProductRecord {
   id: string
   name: string
@@ -230,7 +232,7 @@ export function normalizeCommerceProductRecord(
     variantCount: variantCounts.get(id) || 0,
     unitCount: unitCounts.get(id) || 0,
     reviewCount: reviewCounts.get(id) || 0,
-    createdAt: requiredText(value(product, 'created_at', 'createdAt'), source, 'created_at'),
+    createdAt: commerceTimestamp(value(product, 'created_at', 'createdAt'), source, 'created_at'),
   }
 }
 

--- a/storage/framework/defaults/app/Actions/Dashboard/Commerce/commerce-record.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Commerce/commerce-record.ts
@@ -174,6 +174,13 @@ export function commerceUrl(input: unknown, source: string, field: string): stri
 }
 
 export function commerceTimestamp(input: unknown, source: string, field = 'created_at'): string {
+  // Postgres and MySQL drivers return Date instances for timestamp columns;
+  // SQLite stores TEXT and returns strings. Accept both.
+  if (input instanceof Date) {
+    if (!Number.isFinite(input.getTime()))
+      throw commerceRecordError(source, field, 'a valid timestamp')
+    return input.toISOString()
+  }
   const raw = typeof input === 'number'
     ? String(input)
     : commerceRequiredString(input, source, field)
@@ -197,6 +204,12 @@ export function commerceOptionalTimestamp(input: unknown, source: string, field:
 }
 
 export function commerceDate(input: unknown, source: string, field: string): string {
+  // Postgres and MySQL drivers return Date instances for date columns.
+  if (input instanceof Date) {
+    if (!Number.isFinite(input.getTime()))
+      throw commerceRecordError(source, field, 'a valid YYYY-MM-DD date')
+    return input.toISOString().slice(0, 10)
+  }
   const raw = commerceRequiredString(input, source, field)
   if (!/^\d{4}-\d{2}-\d{2}$/.test(raw))
     throw commerceRecordError(source, field, 'a valid YYYY-MM-DD date')

--- a/storage/framework/defaults/app/Actions/Dashboard/Infrastructure/InsightsAction.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Infrastructure/InsightsAction.ts
@@ -56,20 +56,20 @@ export default new Action({
         db.fn.max('duration_ms').as('maximum'),
         db.fn.max('created_at').as('latest'),
       ])
-      .where('deleted_at', 'is', null)
+      .whereNull('deleted_at')
       .executeTakeFirst() as Promise<NumericSummaryRow | undefined>
 
     const requestSuccessQuery = db
       .selectFrom('requests')
       .select(db.fn.count('id').as('count'))
-      .where('deleted_at', 'is', null)
+      .whereNull('deleted_at')
       .where('status_code', '<', 400)
       .executeTakeFirst() as Promise<{ count: number | string } | undefined>
 
     const slowRequestsQuery = db
       .selectFrom('requests')
       .select(['id', 'method', 'path', 'status_code', 'duration_ms', 'created_at'])
-      .where('deleted_at', 'is', null)
+      .whereNull('deleted_at')
       .orderBy('duration_ms', 'desc')
       .orderBy('id', 'desc')
       .limit(5)

--- a/storage/framework/defaults/app/Actions/Dashboard/Jobs/job-records.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Jobs/job-records.ts
@@ -98,7 +98,11 @@ function timestampValue(
     return undefined
 
   let time = Number.NaN
-  if (typeof value === 'number' && Number.isInteger(value) && value >= 0)
+  // Postgres and MySQL drivers return Date instances for timestamp columns;
+  // SQLite stores TEXT and returns strings.
+  if (value instanceof Date)
+    time = value.getTime()
+  else if (typeof value === 'number' && Number.isInteger(value) && value >= 0)
     time = value * 1000
   else if (typeof value === 'string' && value.trim())
     time = new Date(/^\d{4}-\d{2}-\d{2} \d/.test(value) ? `${value.replace(' ', 'T')}Z` : value).getTime()

--- a/storage/framework/defaults/app/Actions/Dashboard/Kanban/BoardShowAction.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Kanban/BoardShowAction.ts
@@ -1,5 +1,6 @@
 import { Action } from '@stacksjs/actions'
 import { db } from '@stacksjs/database'
+import { modelBoolean } from './kanban-model'
 import { kanbanError } from './kanban-response'
 
 interface BoardRow {
@@ -10,7 +11,8 @@ interface BoardRow {
   icon: string
   color: string
   position: number
-  archived: number
+  // SQLite stores booleans as 0/1 INTEGER columns; Postgres returns real booleans.
+  archived: number | boolean
   created_at: string | null
   updated_at: string | null
 }
@@ -37,7 +39,7 @@ interface CardRow {
   position: number
   created_by_user_id: number | null
   due_date: string | null
-  archived: number
+  archived: number | boolean
   created_at: string | null
   updated_at: string | null
 }
@@ -103,7 +105,7 @@ export default new Action({
           [id],
         ).execute() as Promise<ColumnRow[]>,
         db.unsafe(
-          'SELECT * FROM cards WHERE board_id = ? AND archived = 0 ORDER BY column_id ASC, position ASC, id ASC',
+          'SELECT * FROM cards WHERE board_id = ? AND archived = false ORDER BY column_id ASC, position ASC, id ASC',
           [id],
         ).execute() as Promise<CardRow[]>,
         db.unsafe(
@@ -121,7 +123,7 @@ export default new Action({
           `SELECT cl.card_id, l.id, l.name, l.color
           FROM card_labels cl
           JOIN labels l ON l.id = cl.label_id
-          WHERE cl.card_id IN (SELECT id FROM cards WHERE board_id = ? AND archived = 0)
+          WHERE cl.card_id IN (SELECT id FROM cards WHERE board_id = ? AND archived = false)
           ORDER BY l.name ASC`,
           [id],
         ).execute() as Promise<Array<{ card_id: number, id: number, name: string, color: string }>>,
@@ -129,7 +131,7 @@ export default new Action({
           `SELECT ca.card_id, ca.user_id, u.name, u.email
           FROM card_assignees ca
           LEFT JOIN users u ON u.id = ca.user_id
-          WHERE ca.card_id IN (SELECT id FROM cards WHERE board_id = ? AND archived = 0)`,
+          WHERE ca.card_id IN (SELECT id FROM cards WHERE board_id = ? AND archived = false)`,
           [id],
         ).execute() as Promise<Array<{ card_id: number, user_id: number, name: string | null, email: string | null }>>,
       ])
@@ -175,7 +177,7 @@ export default new Action({
           position: c.position,
           createdByUserId: c.created_by_user_id,
           dueDate: c.due_date,
-          archived: c.archived === 1,
+          archived: modelBoolean(c, 'archived'),
           createdAt: c.created_at,
           updatedAt: c.updated_at,
           labels: labelsByCard.get(c.id) ?? [],
@@ -192,7 +194,7 @@ export default new Action({
           icon: board.icon,
           color: board.color,
           position: board.position,
-          archived: board.archived === 1,
+          archived: modelBoolean(board, 'archived'),
           createdAt: board.created_at,
           updatedAt: board.updated_at,
         },

--- a/storage/framework/defaults/app/Actions/Dashboard/Kanban/BoardStoreAction.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Kanban/BoardStoreAction.ts
@@ -46,7 +46,7 @@ export default new Action({
       // is a sort hint, not a unique key. Reorder via /boards/reorder
       // restores tight ordering when the user cares.
       const maxRow = await db.unsafe(
-        'SELECT COALESCE(MAX(position), -1) AS m FROM boards WHERE archived = 0',
+        'SELECT COALESCE(MAX(position), -1) AS m FROM boards WHERE archived = false',
       ).execute() as Array<{ m: number }>
       const nextPosition = (Number(maxRow?.[0]?.m ?? -1) + 1) || 0
 

--- a/storage/framework/defaults/app/Actions/Dashboard/Kanban/BoardsIndexAction.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Kanban/BoardsIndexAction.ts
@@ -1,5 +1,6 @@
 import { Action } from '@stacksjs/actions'
 import { db } from '@stacksjs/database'
+import { modelBoolean } from './kanban-model'
 import { kanbanError } from './kanban-response'
 
 interface BoardRow {
@@ -10,7 +11,8 @@ interface BoardRow {
   icon: string
   color: string
   position: number
-  archived: number
+  // SQLite stores booleans as 0/1 INTEGER columns; Postgres returns real booleans.
+  archived: number | boolean
   created_at: string | null
   updated_at: string | null
   card_count?: number
@@ -46,9 +48,9 @@ export default new Action({
         SELECT
           b.id, b.uuid, b.name, b.description, b.icon, b.color,
           b.position, b.archived, b.created_at, b.updated_at,
-          (SELECT COUNT(*) FROM cards c WHERE c.board_id = b.id AND c.archived = 0) AS card_count
+          (SELECT COUNT(*) FROM cards c WHERE c.board_id = b.id AND c.archived = false) AS card_count
         FROM boards b
-        WHERE b.archived = 0
+        WHERE b.archived = false
         ORDER BY b.position ASC, b.id ASC
       `).execute() as BoardRow[]
 
@@ -60,7 +62,7 @@ export default new Action({
         icon: r.icon,
         color: r.color,
         position: r.position,
-        archived: r.archived === 1,
+        archived: modelBoolean(r, 'archived'),
         cardCount: Number(r.card_count ?? 0),
         createdAt: r.created_at,
         updatedAt: r.updated_at,

--- a/storage/framework/defaults/app/Actions/Dashboard/Kanban/CardShowAction.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Kanban/CardShowAction.ts
@@ -1,5 +1,6 @@
 import { Action } from '@stacksjs/actions'
 import { db } from '@stacksjs/database'
+import { modelBoolean } from './kanban-model'
 import { kanbanError } from './kanban-response'
 
 interface CardRow {
@@ -12,7 +13,8 @@ interface CardRow {
   position: number
   created_by_user_id: number | null
   due_date: string | null
-  archived: number
+  // SQLite stores booleans as 0/1 INTEGER columns; Postgres returns real booleans.
+  archived: number | boolean
   created_at: string | null
   updated_at: string | null
 }
@@ -91,7 +93,7 @@ export default new Action({
           position: card.position,
           createdByUserId: card.created_by_user_id,
           dueDate: card.due_date,
-          archived: card.archived === 1,
+          archived: modelBoolean(card, 'archived'),
           createdAt: card.created_at,
           updatedAt: card.updated_at,
         },

--- a/storage/framework/defaults/app/Actions/Dashboard/Library/GetAverageReleaseTime.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Library/GetAverageReleaseTime.ts
@@ -10,7 +10,7 @@ export default new Action({
     const rows = await db
       .selectFrom('releases')
       .select(['created_at'])
-      .where('created_at', 'is not', null)
+      .whereNotNull('created_at')
       .orderBy('created_at')
       .execute() as unknown as Array<{ created_at: string }>
 

--- a/storage/framework/defaults/app/Actions/Dashboard/Marketing/CampaignIndexAction.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Marketing/CampaignIndexAction.ts
@@ -35,13 +35,13 @@ export default new Action({
       db
         .selectFrom('campaign_sends')
         .select(['campaign_id', db.fn.count('id').as('count')])
-        .where('opened_at', 'is not', null)
+        .whereNotNull('opened_at')
         .groupBy('campaign_id')
         .execute(),
       db
         .selectFrom('campaign_sends')
         .select(['campaign_id', db.fn.count('id').as('count')])
-        .where('clicked_at', 'is not', null)
+        .whereNotNull('clicked_at')
         .groupBy('campaign_id')
         .execute(),
     ])

--- a/storage/framework/defaults/app/Actions/Dashboard/Marketing/ListIndexAction.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Marketing/ListIndexAction.ts
@@ -36,7 +36,7 @@ export default new Action({
           db.fn.count('id').as('count'),
           db.fn.max('sent_at').as('last_sent_at'),
         ])
-        .where('email_list_id', 'is not', null)
+        .whereNotNull('email_list_id')
         .groupBy('email_list_id')
         .execute(),
     ])

--- a/storage/framework/defaults/app/Actions/Dashboard/Queries/query-dashboard.ts
+++ b/storage/framework/defaults/app/Actions/Dashboard/Queries/query-dashboard.ts
@@ -6,7 +6,8 @@ export interface QueryLogSourceRow {
   connection?: string | null
   status?: string | null
   error?: string | null
-  executed_at: string
+  // SQLite returns timestamp columns as TEXT; Postgres and MySQL drivers return Date instances.
+  executed_at: string | Date
   model?: string | null
   method?: string | null
   rows_affected?: number | null
@@ -89,7 +90,8 @@ export function mapDashboardQueryLog(row: QueryLogSourceRow): DashboardQueryLog 
   const status = queryStatus(row.status, label)
   if (typeof row.query !== 'string' || !row.query.trim())
     throw new TypeError(`${label} query must be a non-empty string`)
-  if (typeof row.executed_at !== 'string' || !row.executed_at.trim())
+  const executedAt = row.executed_at instanceof Date ? row.executed_at.toISOString() : row.executed_at
+  if (typeof executedAt !== 'string' || !executedAt.trim())
     throw new TypeError(`${label} executed_at must be a non-empty string`)
 
   return {
@@ -101,7 +103,7 @@ export function mapDashboardQueryLog(row: QueryLogSourceRow): DashboardQueryLog 
     connection: row.connection || 'unknown',
     status,
     error: row.error || '',
-    executedAt: row.executed_at,
+    executedAt,
     model: row.model || '',
     method: row.method || '',
     rowsAffected: nullableFiniteNumber(row.rows_affected, `${label} rows_affected`),


### PR DESCRIPTION
The dashboard's data endpoints were written against SQLite's loose typing and broke on Postgres in three ways, each surfacing as a 500/503 on a live dashboard page:

1. **Timestamps**: the Postgres/MySQL drivers return `Date` instances for timestamp columns, while SQLite stores TEXT and returns strings. The commerce, jobs, queries, and analytics record normalizers hard-required strings and rejected every row (`Product 10.created_at must be a string or null`), taking down the entire commerce namespace (~23 endpoints). The normalizers now accept `Date` and emit the same ISO string they already produced for text input.

2. **Parameterized null predicates**: `.where('col', 'is not', null)` parameterizes the null, which SQLite tolerates (`IS NOT ?`) and Postgres rejects (`syntax error at or near "$1"`). The marketing, library, and insights queries now use `whereNotNull`/`whereNull`, which render the literal `IS [NOT] NULL` on every dialect.

3. **Boolean comparisons**: the kanban actions' raw SQL compared the `archived` boolean column to integer `0`, which Postgres refuses (`operator does not exist: boolean = integer`), and their row mappers tested `archived === 1`, never true for a real boolean. The SQL now compares against `false` (integer 0 on SQLite, boolean on Postgres/MySQL) and the mappers reuse the existing dialect-agnostic `modelBoolean()`.

Verified by sweeping all 83 dashboard GET endpoints against a migrated and seeded database on **both** sqlite and postgres: every endpoint returns 200 on both dialects, except the pre-existing `email/captured` 503 that needs mail infrastructure. The 122 colocated action tests pass unchanged; typecheck is clean for all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)