### PR TITLE
docs(forms): point at the other useForm, so nobody writes a third

### DIFF
--- a/storage/framework/core/composables/src/useForm.ts
+++ b/storage/framework/core/composables/src/useForm.ts
@@ -13,6 +13,35 @@ import { ref } from '@stacksjs/stx'
  * `<SubmitButton>` / `<ErrorMessage>` companion components, field
  * arrays, server-error auto-surfacing on 422, and progressive HTML
  * fallback are scoped to Phases 2-5 of the issue.
+ *
+ * ---
+ *
+ * THERE IS A SECOND `useForm`, in stx
+ * (packages/stx/src/composables/use-form.ts, called `defineForm` before
+ * stacksjs/stx#1843). It is not this one, and the two are not interchangeable —
+ * they were written independently because neither side could find the other's,
+ * which is stx#1843's adoption problem happening to the framework itself.
+ *
+ *   this one                        stx
+ *   useForm({ initialValues,        useForm(schema, initialValues)
+ *             onSubmit })
+ *   form.values.value.email         form.values.email
+ *   form.field('email')             form.getFieldState('email')
+ *   schema.string().email()         v.required().email()  (stx's own builder)
+ *   validate() -> { valid, errors } validate() -> Promise<string[]>
+ *   has: isSubmitting, isValid,     has: validating, validateField
+ *        isDirty, setErrors (422),
+ *        clearErrors,
+ *        submitButtonProps,
+ *        firstErrorField,
+ *        aria inputProps
+ *
+ * stx's is the one that reaches a `<script client>` block via the demand
+ * bundler; this one is delivered through the browser vendors re-export.
+ *
+ * Before adding a feature here, check whether it exists there — and say so in
+ * the PR either way. Unifying them is a breaking change to one side's public
+ * API, not a re-export, so it needs a deliberate decision rather than drift.
  */
 
 /** Minimal Validator surface this composable depends on. */


### PR DESCRIPTION
Refs stacksjs/stx#1843. Comment-only; no behaviour change.

I set out to make this `useForm` a re-export of stx's, to kill the duplication. **It isn't a re-export job.** The two are not variants of one primitive — they're unrelated APIs:

| | this one (stacks) | stx |
|---|---|---|
| call | `useForm({ initialValues, onSubmit })` | `useForm(schema, initialValues)` |
| values | `form.values.value.email` | `form.values.email` |
| field | `form.field('email')` | `form.getFieldState('email')` |
| validators | `schema.string().email()` (ts-validation) | `v.required().email()` (stx's own builder) |
| `validate()` | sync → `{ valid, errors }` | async → `string[]` |
| cross-field | — | validator gets `formValues` |
| only here | `isSubmitting`, `isValid`, `isDirty`, `setErrors` (422), `clearErrors`, `submitButtonProps`, `firstErrorField`, aria `inputProps` | |
| only there | | `validating`, `validateField` |

Making either one a re-export of the other rewrites a public API and breaks its callers — **29 tests pin this one's shape** — so it needs a deliberate decision, not a refactor smuggled into a dedup PR.

So this does the cheap thing that stops the problem *recurring*: each file now names the other, states the differences, says which one reaches a `<script client>` block by which path, and asks that a feature added to one be checked against the other.

That matters because the duplication itself is stx#1843's thesis turned on the framework: two teams built the same primitive because neither could find the other's — which is exactly what that issue reports apps doing.

The stx side is `48ae669f72`.

29 useForm tests pass, `buddy lint` clean.
