### PR TITLE
fix(browser): one completeSocialLogin, covering both handoffs

### DIFF
--- a/storage/framework/core/browser/src/composables/useAuth.ts
+++ b/storage/framework/core/browser/src/composables/useAuth.ts
@@ -69,7 +69,7 @@ let inFlightRefresh: Promise<boolean> | null = null
  * Returns false when there was no handoff to apply, so a page can call it
  * unconditionally on every load.
  */
-function completeSocialLogin(pack?: SessionHandoffPack | null): boolean {
+function applySessionHandoff(pack?: SessionHandoffPack | null): boolean {
   const resolved = pack ?? (typeof window !== 'undefined' ? readSessionHandoff(window.location.hash) : null)
 
   if (!resolved)
@@ -386,22 +386,32 @@ export function useAuth(): AuthComposable {
    * if (user) location.replace('/account')
    * ```
    */
-  async function completeSocialLogin(
-    pack?: { token?: string, refresh_token?: string } | null,
-  ): Promise<UserData | null> {
-    if (pack?.token)
-      token.value = pack.token
-    if (pack?.refresh_token)
-      refreshToken.value = pack.refresh_token
+  async function completeSocialLogin(pack?: SessionHandoffPack | null): Promise<UserData | null> {
+    // Fragment or explicit pack first: it writes the tokens through the same
+    // refs `login()` uses and strips the fragment out of history.
+    const applied = applySessionHandoff(pack)
 
-    return fetchAuthUser()
+    // Then confirm with the server. This is what covers the cookie handoff,
+    // where the browser arrives holding no tokens at all and the session lives
+    // in an httpOnly cookie the page cannot read — `applySessionHandoff`
+    // returns false and there is nothing to apply, but the request is
+    // authenticated all the same.
+    //
+    // Also worth the round-trip when a pack WAS applied: the pack is a claim
+    // made by a redirect, and `/api/me` is the server agreeing with it. An
+    // expired or revoked token then fails here rather than at the next call,
+    // which is where a confusing session comes from.
+    const confirmed = await fetchAuthUser()
+    if (confirmed || applied)
+      return confirmed
+
+    return null
   }
 
   return {
     user,
     isAuthenticated,
     token,
-    completeSocialLogin,
     getToken: () => token.value,
     register,
     login,

--- a/storage/framework/core/browser/src/types/dashboard.ts
+++ b/storage/framework/core/browser/src/types/dashboard.ts
@@ -1,3 +1,4 @@
+import type { SessionHandoffPack } from '@stacksjs/composables'
 import type { Ref } from '@stacksjs/stx'
 
 export interface ValidationError {
@@ -86,7 +87,7 @@ export interface AuthComposable {
    * inside the framework instead of being re-derived by an inline script
    * (stacksjs/stacks#2236).
    */
-  completeSocialLogin: (pack?: { token?: string, refresh_token?: string } | null) => Promise<UserData | null>
+  completeSocialLogin: (pack?: SessionHandoffPack | null) => Promise<UserData | null>
   checkAuthentication: () => Promise<boolean>
   logout: () => void
   getToken: () => string | null

--- a/storage/framework/core/socials/README.md
+++ b/storage/framework/core/socials/README.md
@@ -151,13 +151,15 @@ On the landing page:
 ```ts
 const { completeSocialLogin } = useAuth()
 
-// Returns false when there is no handoff, so it is safe on every load.
-completeSocialLogin()
+// Safe on every load: resolves null when there was no handoff to apply.
+const user = await completeSocialLogin()
 ```
 
 That writes through the same storage refs an ordinary `login()` uses, so the
 encoding cannot be got wrong, and strips the fragment from the URL and from
-history.
+history. It then confirms the session against `/api/me`, which is also what
+picks up the cookie handoff below — there the browser holds no tokens at all
+and there is nothing in the fragment to apply.
 
 An absolute `redirectTo` is refused unless its host is in `allowedHosts` — the
 redirect carries a token pack, and the target often comes from user input.


### PR DESCRIPTION
**Main is currently red on typecheck.** #2270 and #2272 were developed in parallel against #2236 and both landed. Each added a `completeSocialLogin` to `useAuth`:

```
useAuth.ts(410,5): error TS1117: An object literal cannot have multiple properties with the same name.
```

Worse than the type error: the inner declaration shadowed the module-scope one, so the exported function was #2272's cookie version and **#2270's fragment reading was unreachable**. Both PRs merged, one feature silently didn't ship, and the two examples in the same README disagreed about whether the call is awaited.

## They were solving different halves

- **`applySessionHandoff()`** (was #2270's `completeSocialLogin`) — applies a pack from the URL fragment or an explicit argument, writing through the same refs `login()` uses and stripping the fragment from history.
- **`completeSocialLogin()`** — runs that, then confirms against `/api/me`. The confirmation is what covers #2272's cookie handoff, where the browser arrives holding no tokens at all and there is nothing in the fragment to apply; the request is authenticated by an httpOnly cookie the page cannot read.

The round-trip is worth it even when a pack *was* applied: a pack is a claim made by a redirect, and `/api/me` is the server agreeing with it. An expired or revoked token then fails there rather than at whatever the page does next.

Async returning the user, which is the signature `AuthComposable` **already declared** — #2270's implementation was synchronous and returned a boolean, so the declared type and the implementation disagreed too.

## Verification

Typecheck 0 errors. Failure sets compared line-for-line against main across `browser`, `composables`, `auth` and `socials`: identical, 6 pre-existing DOM-dependent failures on each side.

Docs reconciled in both places they contradicted.