### PR TITLE
fix(database): preflight missing notification tables

### DIFF
--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -49,7 +49,7 @@ import { findShadowedColumnDrops, shadowDropsAllowed, shadowedDropMessage } from
 import { frameworkManagedColumns, withoutManagedColumnDrops, withoutManagedColumnDropSql } from './managed-columns'
 import { acquireMigrationLock } from './migration-lock'
 import { relativeMigrationDirectory, resolveMigrationDirectory } from './migration-path'
-import { ensureNotificationForeignKeys, migrateNotificationTables } from './notification-tables'
+import { ensureNotificationForeignKeys, migrateNotificationTables, notificationTablesMissingCreateStatements } from './notification-tables'
 import { traitTableNames } from './trait-tables'
 
 // Use environment variables via @stacksjs/env for proper type coercion
@@ -1464,6 +1464,36 @@ export async function runDatabaseMigration(): Promise<Result<string, Error>> {
 
     const modelsDir = path.userModelsPath()
 
+    /*
+     * Some older generated migration corpora rebuild or normalize framework
+     * notification tables but never contain their original CREATE TABLE. On a
+     * fresh database those statements fail before the post-batch guarantee can
+     * run. Pre-create only the tables the corpus does not declare itself, so a
+     * model-owned CREATE remains authoritative over its full schema and keys.
+     */
+    const migrationsDir = migrationDirectory()
+    let migrationSql = ''
+    try {
+      migrationSql = readdirSync(migrationsDir)
+        .filter(file => file.endsWith('.sql'))
+        .sort()
+        .map(file => readFileSync(join(migrationsDir, file), 'utf8'))
+        .join('\n')
+    }
+    catch {
+      // A missing migration directory is a valid first-run state. The normal
+      // post-batch guarantee below still creates the framework tables.
+    }
+
+    if (migrationSql) {
+      const preflightTables = notificationTablesMissingCreateStatements(migrationSql)
+      if (preflightTables.length > 0) {
+        const preflight = await migrateNotificationTables({ tables: preflightTables })
+        if (!preflight.success)
+          throw new Error(preflight.error || 'Failed to prepare notification tables before migrations')
+      }
+    }
+
     // Count applied-before so we can compute the delta after the
     // migration run. Lets the buddy CLI distinguish "nothing to
     // migrate" from "applied N" in the outro (user-reported
@@ -1474,30 +1504,8 @@ export async function runDatabaseMigration(): Promise<Result<string, Error>> {
     log.debug(`[migration] Running migrations from: ${modelsDir}`)
     await qbExecuteMigration(modelsDir)
 
-    /*
-     * The notification tables, *after* the model migrations and not before.
-     *
-     * These guarantees create the framework's notification tables so an app
-     * that never declares the models still has somewhere to write. They used
-     * to run ahead of the batch, on the reasoning that a generated migration
-     * might ALTER one of them and would need it to exist - and that quietly
-     * broke the more common case. An app that *does* declare `Notification`
-     * generates a CREATE TABLE carrying the relations the model declares;
-     * pre-creating the table makes that `CREATE TABLE IF NOT EXISTS` a no-op,
-     * so the table survives without its foreign keys and nothing reports it.
-     * The migration is recorded as applied, the file plainly contains
-     * `REFERENCES "users"("id")`, and the constraint is simply absent.
-     *
-     * `buddy migrate` already ordered its own copy of these guarantees after
-     * the batch for exactly this reason (#1952, which fixed
-     * `notification_preferences`); this call ran before it and undid that for
-     * `notifications` and `notification_deliveries`. One ordering, in both
-     * places, so the model stays authoritative over the table it declares.
-     *
-     * Safe for the case that motivated the old placement: a generated ALTER
-     * only exists when the model does, and when the model exists so does its
-     * CREATE, which the batch above has already run.
-     */
+    // Complete the guarantee after the model batch. This creates tables absent
+    // from both the corpus and the preflight, and validates existing shapes.
     const notificationTables = await migrateNotificationTables()
     if (!notificationTables.success)
       throw new Error(notificationTables.error || 'Failed to prepare notification tables')
@@ -1505,12 +1513,11 @@ export async function runDatabaseMigration(): Promise<Result<string, Error>> {
     /*
      * The notification foreign keys, now that `users` is certain to exist.
      *
-     * The guarantee above runs before the batch on purpose, so a generated
-     * model migration can normalize these tables - and that is exactly why the
-     * keys never landed. The guarantee created the tables without them, and the
-     * model's own `CREATE TABLE IF NOT EXISTS … REFERENCES users(id)` was then a
-     * no-op against a table that already existed. The migration ran, the corpus
-     * declared the key, and the key was not there.
+     * The conditional preflight can create a table before the batch when an
+     * older corpus references it without declaring it. Those framework tables
+     * intentionally start without user foreign keys because `users` may not
+     * exist yet. Model-owned tables skip the preflight and retain the inline
+     * keys from their own CREATE statements.
      *
      * Same shape as `ensureUsersAuthColumns` being called a second time after
      * the numbered migrations, and for the same reason.

--- a/storage/framework/core/database/src/notification-tables.ts
+++ b/storage/framework/core/database/src/notification-tables.ts
@@ -110,6 +110,36 @@ const REQUIRED_COLUMNS: Record<string, string[]> = {
   notification_deliveries: ['id', 'user_id', 'channel', 'recipient', 'body', 'status'],
 }
 
+export const notificationTableNames = [
+  'notifications',
+  'notification_preferences',
+  'notification_deliveries',
+] as const
+
+export type NotificationTableName = typeof notificationTableNames[number]
+
+/**
+ * Return framework notification tables that a migration corpus does not
+ * create itself.
+ *
+ * Old generated corpora can contain UPDATE or SQLite rebuild statements for
+ * these tables without containing their original CREATE TABLE migrations. A
+ * fresh database therefore needs the framework guarantee before that corpus
+ * runs. When the corpus does declare a table, the model-owned CREATE remains
+ * authoritative and the framework must not pre-create a narrower shape.
+ */
+export function notificationTablesMissingCreateStatements(sql: string): NotificationTableName[] {
+  return notificationTableNames.filter((table) => {
+    const escaped = table.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const createPattern = new RegExp(
+      `\\bCREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?["\\x60\\[]?${escaped}["\\x60\\]]?\\s*\\(`,
+      'i',
+    )
+
+    return !createPattern.test(sql)
+  })
+}
+
 /**
  * Warn when a guaranteed table already exists in a shape we would not have
  * created.
@@ -176,29 +206,36 @@ async function warnOnShapeMismatch(table: string): Promise<void> {
  * Create the notification + notification_preferences tables. Idempotent
  * (`IF NOT EXISTS`), so it's safe to run on every `buddy migrate`.
  */
-export async function migrateNotificationTables(options: { verbose?: boolean } = {}): Promise<{ success: boolean, error?: string }> {
+export async function migrateNotificationTables(options: { verbose?: boolean, tables?: readonly NotificationTableName[] } = {}): Promise<{ success: boolean, error?: string }> {
   const dbDriver = getDbDriver()
   const sql = sqlHelpers(dbDriver)
+  const tables = new Set(options.tables ?? notificationTableNames)
 
   if (options.verbose)
     log.info(`Creating notification tables for ${dbDriver}...`)
 
   try {
-    if (options.verbose) log.info('Creating notifications table...')
-    await warnOnShapeMismatch('notifications')
-    await db.unsafe(notificationsTableSql(sql)).execute()
-    await createIndex(`CREATE INDEX IF NOT EXISTS idx_notifications_user ON notifications (user_id)`, dbDriver)
+    if (tables.has('notifications')) {
+      if (options.verbose) log.info('Creating notifications table...')
+      await warnOnShapeMismatch('notifications')
+      await db.unsafe(notificationsTableSql(sql)).execute()
+      await createIndex(`CREATE INDEX IF NOT EXISTS idx_notifications_user ON notifications (user_id)`, dbDriver)
+    }
 
-    if (options.verbose) log.info('Creating notification_preferences table...')
-    await warnOnShapeMismatch('notification_preferences')
-    await db.unsafe(notificationPreferencesTableSql(sql)).execute()
-    await createIndex(`CREATE INDEX IF NOT EXISTS idx_notification_preferences_user ON notification_preferences (user_id)`, dbDriver)
+    if (tables.has('notification_preferences')) {
+      if (options.verbose) log.info('Creating notification_preferences table...')
+      await warnOnShapeMismatch('notification_preferences')
+      await db.unsafe(notificationPreferencesTableSql(sql)).execute()
+      await createIndex(`CREATE INDEX IF NOT EXISTS idx_notification_preferences_user ON notification_preferences (user_id)`, dbDriver)
+    }
 
-    if (options.verbose) log.info('Creating notification deliveries table...')
-    await warnOnShapeMismatch('notification_deliveries')
-    await db.unsafe(notificationDeliveriesTableSql(sql)).execute()
-    await createIndex(`CREATE INDEX IF NOT EXISTS idx_notification_deliveries_channel ON notification_deliveries (channel)`, dbDriver)
-    await createIndex(`CREATE INDEX IF NOT EXISTS idx_notification_deliveries_status ON notification_deliveries (status)`, dbDriver)
+    if (tables.has('notification_deliveries')) {
+      if (options.verbose) log.info('Creating notification deliveries table...')
+      await warnOnShapeMismatch('notification_deliveries')
+      await db.unsafe(notificationDeliveriesTableSql(sql)).execute()
+      await createIndex(`CREATE INDEX IF NOT EXISTS idx_notification_deliveries_channel ON notification_deliveries (channel)`, dbDriver)
+      await createIndex(`CREATE INDEX IF NOT EXISTS idx_notification_deliveries_status ON notification_deliveries (status)`, dbDriver)
+    }
 
     if (options.verbose) log.success('Notification tables created')
     return { success: true }

--- a/storage/framework/core/database/tests/notification-tables.test.ts
+++ b/storage/framework/core/database/tests/notification-tables.test.ts
@@ -3,6 +3,7 @@ import {
   migrateNotificationTables,
   notificationDeliveriesTableSql,
   notificationPreferencesTableSql,
+  notificationTablesMissingCreateStatements,
   notificationsTableSql,
 } from '../src/notification-tables'
 import { sqlHelpers } from '../src/sql-helpers'
@@ -81,20 +82,38 @@ describe('notification table DDL — cross-dialect (stacksjs/stacks#1937)', () =
     expect(isDuplicateIndexError(new Error("Duplicate key name 'notifications_uuid_unique'"))).toBe(true)
     expect(isDuplicateIndexError(new Error('connection refused'))).toBe(false)
   })
+
+  test('preflights legacy corpora that reference tables without creating them', () => {
+    const sql = `
+      CREATE TABLE "_qb_tmp_notifications" ("id" INTEGER PRIMARY KEY);
+      INSERT INTO "_qb_tmp_notifications" SELECT "id" FROM "notifications";
+      UPDATE notification_deliveries SET user_id = NULL;
+    `
+
+    expect(notificationTablesMissingCreateStatements(sql)).toEqual([
+      'notifications',
+      'notification_preferences',
+      'notification_deliveries',
+    ])
+  })
+
+  test('leaves model-owned notification table creates authoritative', () => {
+    const sql = `
+      CREATE TABLE IF NOT EXISTS "notifications" ("id" INTEGER PRIMARY KEY, "user_id" INTEGER REFERENCES "users"("id"));
+      CREATE TABLE \`notification_deliveries\` (\`id\` BIGINT PRIMARY KEY, \`user_id\` BIGINT);
+    `
+
+    expect(notificationTablesMissingCreateStatements(sql)).toEqual(['notification_preferences'])
+  })
 })
 
 /**
  * The foreign keys, and why they need a second pass.
  *
- * `migrateNotificationTables` runs *before* the model migration batch on
- * purpose - a generated model migration may normalize or rebuild these tables
- * and needs them to exist first. That ordering is also why the keys never
- * landed: the guarantee created `notifications` without them, and the model's
- * own `CREATE TABLE IF NOT EXISTS … REFERENCES users(id) ON DELETE CASCADE`
- * became a no-op against a table that already existed.
- *
- * The migration ran, the corpus declared the key, and the key was not there -
- * which is the shape that made it survive a tick on somebody's roadmap.
+ * A legacy corpus may need selected framework tables before its model batch,
+ * while a corpus with its own CREATE statements must keep those model-owned
+ * schemas authoritative. Either way, the foreign-key pass runs after `users`
+ * exists and can safely repair preflighted tables on supported dialects.
  */
 describe('ensureNotificationForeignKeys', () => {
   test('is exported, so the migration runner can call it after the batch', async () => {


### PR DESCRIPTION
## What changed

- detect framework notification tables missing from a generated migration corpus
- pre-create only those missing tables before the model migration batch
- keep model-owned `CREATE TABLE` statements authoritative
- retain the post-batch table and foreign-key guarantees
- add regression coverage for SQLite rebuild corpora and model-owned schemas

## Why

A fresh generated application can contain `UPDATE` and SQLite rebuild statements for `notifications` and `notification_deliveries` without the original table-creation migrations. Moving the framework guarantee after the model batch caused those corpora to fail before the guarantee could run.

The conditional preflight handles legacy corpora without restoring the earlier behavior that overrode model-owned table shapes.

## Validation

- `bun test ./storage/framework/core/database/tests/notification-tables.test.ts`
- `bun run build` in `storage/framework/core/database`
- `./buddy lint`

The package-wide isolated-declarations typecheck currently reports existing errors across unrelated packages and configuration files; this change adds no build errors.
