### PR TITLE
fix(scaffold): isolate generated app infrastructure

### DIFF
--- a/storage/framework/core/buddy/src/commands/create.ts
+++ b/storage/framework/core/buddy/src/commands/create.ts
@@ -1,5 +1,5 @@
 import type { CLI, CreateOptions } from '@stacksjs/types'
-import { chmodSync, cpSync, existsSync, readdirSync, rmSync } from 'node:fs'
+import { chmodSync, cpSync, existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 import { runAction } from '@stacksjs/actions'
 import { bold, cyan, dim, intro, log, onUnknownSubcommand, runCommand } from "@stacksjs/cli"
@@ -78,6 +78,7 @@ export function create(buddy: CLI): void {
   // has not happened yet.
   ensureExecutableScripts(path)
   applyAppVcsTemplate(path)
+  applyAppConfigTemplate(path)
   removeFrameworkTests(path)
   await ensureEnv(path, options)
 
@@ -233,6 +234,56 @@ function applyAppVcsTemplate(path: string) {
   }
   catch (error) {
     log.warn(`Could not install the app CI template: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+/**
+ * Replace the framework repository's owner-specific infrastructure settings
+ * with safe application defaults.
+ *
+ * `buddy new` downloads this repository as its template, so without this pass
+ * a new app inherits the Stacks production project slug, attached tenants,
+ * hosted-zone id, mailboxes, forwards, and team roster. A later `buddy deploy`
+ * can then target infrastructure owned by the framework repository. The app
+ * template keeps the useful cloud primitives while making every external
+ * integration opt-in and disabling mail-server reconciliation by default.
+ *
+ * Runs before unvendoring because its source lives under the defaults tree.
+ */
+function applyAppConfigTemplate(path: string) {
+  const source = resolve(path, 'storage/framework/defaults/scaffold/config')
+  const destination = resolve(path, 'config')
+
+  if (!existsSync(source)) {
+    log.warn('No app config template found at storage/framework/defaults/scaffold/config - leaving config as downloaded.')
+    return
+  }
+
+  const slug = path.replace(/\/+$/, '').split('/').pop() || 'stacks-app'
+  const displayName = slug
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(part => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ')
+
+  log.info('Installing app-safe infrastructure configuration...')
+
+  try {
+    for (const file of readdirSync(source)) {
+      if (!file.endsWith('.ts'))
+        continue
+
+      const template = readFileSync(resolve(source, file), 'utf8')
+      const rendered = template
+        .replaceAll('__APP_NAME__', displayName)
+        .replaceAll('__APP_SLUG__', slug)
+
+      writeFileSync(resolve(destination, file), rendered)
+    }
+    log.success('App-safe infrastructure configuration installed')
+  }
+  catch (error) {
+    log.warn(`Could not install the app config template: ${error instanceof Error ? error.message : String(error)}`)
   }
 }
 

--- a/storage/framework/core/buddy/tests/scaffold-app-config.test.ts
+++ b/storage/framework/core/buddy/tests/scaffold-app-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const APP_CONFIG = join(import.meta.dir, '../../../defaults/scaffold/config')
+const CREATE_COMMAND = join(import.meta.dir, '../src/commands/create.ts')
+
+const templates = existsSync(APP_CONFIG)
+  ? readdirSync(APP_CONFIG).filter(file => file.endsWith('.ts'))
+  : []
+
+describe('the generated app config template', () => {
+  test('contains every infrastructure-sensitive config file', () => {
+    expect(templates.sort()).toEqual(['cloud.ts', 'dns.ts', 'email.ts', 'team.ts'])
+  })
+
+  test('contains no Stacks production ownership', () => {
+    const forbidden = [
+      "attachTo: 'stacks'",
+      'Z01455702Q7952O6RCY37',
+      'stacks-production-app',
+      "domain: 'stacksjs.com'",
+      "enabled: true",
+      "chris@stacksjs.com",
+    ]
+
+    const offenders: string[] = []
+    for (const file of templates) {
+      const source = readFileSync(join(APP_CONFIG, file), 'utf8')
+      for (const value of forbidden) {
+        if (source.includes(value))
+          offenders.push(`${file}: ${value}`)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  test('keeps external infrastructure opt-in', () => {
+    const cloud = readFileSync(join(APP_CONFIG, 'cloud.ts'), 'utf8')
+    const dns = readFileSync(join(APP_CONFIG, 'dns.ts'), 'utf8')
+    const email = readFileSync(join(APP_CONFIG, 'email.ts'), 'utf8')
+    const team = readFileSync(join(APP_CONFIG, 'team.ts'), 'utf8')
+
+    expect(cloud).toContain('APP_DOMAIN = env.APP_DOMAIN || undefined')
+    expect(cloud).not.toContain('hostedZoneId')
+    expect(dns).toContain('a: []')
+    expect(email).toContain('enabled: false')
+    expect(email).toContain('mailboxes: []')
+    expect(team).toContain('members: {}')
+  })
+})
+
+describe('buddy new installs the app config template', () => {
+  const source = readFileSync(CREATE_COMMAND, 'utf8')
+
+  test('renders project identity tokens', () => {
+    expect(source).toContain('applyAppConfigTemplate(path)')
+    expect(source).toContain("replaceAll('__APP_NAME__', displayName)")
+    expect(source).toContain("replaceAll('__APP_SLUG__', slug)")
+  })
+
+  test('runs before the framework tree is removed', () => {
+    expect(source.indexOf('applyAppConfigTemplate(path)'))
+      .toBeLessThan(source.indexOf('await unvendorCore(path, options)'))
+  })
+})

--- a/storage/framework/defaults/scaffold/config/cloud.ts
+++ b/storage/framework/defaults/scaffold/config/cloud.ts
@@ -1,0 +1,95 @@
+import type { CloudConfig } from '@stacksjs/types'
+import type { CloudConfig as TsCloudConfig } from '@stacksjs/ts-cloud'
+import { env } from '@stacksjs/env'
+
+const APP_SLUG = '__APP_SLUG__'
+const APP_DOMAIN = env.APP_DOMAIN || undefined
+
+/**
+ * Safe application cloud defaults.
+ *
+ * Set APP_DOMAIN and provider credentials before the first deploy. Use
+ * `cloud.attachTo` only when this app is intentionally joining a server owned
+ * by another ts-cloud project.
+ */
+export const tsCloud: TsCloudConfig = {
+  project: {
+    name: APP_SLUG,
+    slug: APP_SLUG,
+    region: 'us-east-1',
+  },
+
+  stateDir: 'storage/cloud',
+
+  cloud: {
+    provider: 'hetzner',
+  },
+
+  mode: 'server',
+
+  environments: {
+    production: {
+      type: 'production',
+      deployBranch: 'main',
+      region: 'us-east-1',
+      variables: {
+        APP_ENV: 'production',
+        NODE_ENV: 'production',
+        LOG_LEVEL: 'info',
+      },
+    },
+  },
+
+  infrastructure: {
+    compute: {
+      instances: 1,
+      size: 'small',
+      disk: {
+        size: 20,
+        type: 'ssd',
+        encrypted: true,
+      },
+      webServer: 'rpx',
+      proxy: {
+        engine: 'rpx',
+        onDemandTls: true,
+      },
+    },
+  },
+
+  sites: {
+    main: {
+      root: '.',
+      path: '/',
+      domain: APP_DOMAIN,
+      start: 'bun node_modules/@stacksjs/buddy/dist/serve-entry.js',
+      port: 3000,
+      preStart: [
+        'bun install --frozen-lockfile',
+        'bun node_modules/@stacksjs/buddy/dist/cli.js migrate',
+      ],
+      env: {
+        APP_ENV: 'production',
+        NODE_ENV: 'production',
+        PORT_API: '3008',
+        API_URL: 'http://127.0.0.1:3008',
+      },
+    },
+
+    api: {
+      root: '.',
+      start: 'bun node_modules/@stacksjs/actions/dist/serve/api.js',
+      port: 3008,
+      preStart: ['bun install --frozen-lockfile'],
+      env: {
+        HOST: '127.0.0.1',
+        APP_ENV: 'production',
+        NODE_ENV: 'production',
+      },
+    },
+  },
+}
+
+const config: CloudConfig = {}
+
+export default config

--- a/storage/framework/defaults/scaffold/config/dns.ts
+++ b/storage/framework/defaults/scaffold/config/dns.ts
@@ -1,0 +1,16 @@
+import type { DnsConfig } from '@stacksjs/types'
+
+/**
+ * Additional DNS records owned by this application.
+ *
+ * Server records are derived from config/cloud.ts during deployment. Add
+ * provider and zone details there before asking Buddy to reconcile DNS.
+ */
+export default {
+  a: [],
+  aaaa: [],
+  cname: [],
+  mx: [],
+  txt: [],
+  nameservers: [],
+} satisfies DnsConfig

--- a/storage/framework/defaults/scaffold/config/email.ts
+++ b/storage/framework/defaults/scaffold/config/email.ts
@@ -1,0 +1,23 @@
+import type { EmailConfig } from '@stacksjs/types'
+import { env } from '@stacksjs/env'
+
+export default {
+  from: {
+    name: env.MAIL_FROM_NAME || '__APP_NAME__',
+    address: env.MAIL_FROM_ADDRESS || 'hello@example.com',
+  },
+
+  domain: env.MAIL_DOMAIN || env.APP_DOMAIN || 'example.com',
+  mailboxes: [],
+  forwards: {},
+  url: env.APP_URL || '__APP_SLUG__.localhost',
+  charset: 'UTF-8',
+
+  server: {
+    // Explicit opt-in: a generated application must never reconcile the
+    // framework repository's shared mail server or mailboxes.
+    enabled: false,
+    scan: true,
+    subdomain: 'mail',
+  },
+} satisfies EmailConfig

--- a/storage/framework/defaults/scaffold/config/team.ts
+++ b/storage/framework/defaults/scaffold/config/team.ts
@@ -1,0 +1,6 @@
+import type { Team } from '@stacksjs/types'
+
+export default {
+  name: '__APP_NAME__',
+  members: {},
+} satisfies Team


### PR DESCRIPTION
## What changed

- add an application-owned config template for cloud, DNS, email, and team settings
- render the generated project's slug and display name into those files
- install the safe config before the default unvendor step removes the template source
- keep external DNS and mail-server reconciliation opt-in
- add regression coverage that rejects Stacks production ownership in generated app config

## Why

`buddy new` downloads the Stacks framework repository as its source template. It replaced framework GitHub workflows and tests, but still left the framework repository's own production cloud project, hosted-zone id, shared mailboxes, forwards, and team roster in every new application.

The new template keeps useful server and API deployment defaults while preventing a generated app from targeting infrastructure owned by the Stacks repository.

## Validation

- 17 scaffold tests pass across the app config, VCS template, and test-suite cleanup
- `./buddy lint`
- `bun run build` in `storage/framework/core/buddy`
- targeted TypeScript check for all four generated config templates
