### PR TITLE
fix(dashboard): the desktop sidebar renders its rows again

### DIFF
--- a/storage/framework/defaults/views/dashboard/layouts/default.stx
+++ b/storage/framework/defaults/views/dashboard/layouts/default.stx
@@ -620,9 +620,9 @@ onDestroy(() => {
     theme="macos"
     width="250"
     placement="fixed"
-    persist-key="stacks-dashboard-sidebar"
-    shell-selector="[data-stx-content]"
-    :follow-system-appearance="false"
+    persistKey="stacks-dashboard-sidebar"
+    shellSelector="[data-stx-content]"
+    :followSystemAppearance="false"
     @itemClick="handleSidebarItemClick($event)"
   >
     <template #header>
@@ -630,7 +630,7 @@ onDestroy(() => {
           titlebarHidden), so this reserves their space and acts as the window
           drag region; in a plain browser it is the same empty strip macOS
           sidebars carry above their first row. -->
-      <SidebarHeader :show-window-controls="false" />
+      <SidebarHeader :showWindowControls="false" />
     </template>
   </Sidebar>
 </div>


### PR DESCRIPTION
Closes #2279.

## What #2279 described, and what is actually there

The issue reads the two `<aside data-stx-sidebar>` elements as one component rendered twice, with a working second pass painting over a broken first, and asks for the first pass to stop being emitted.

That is not what the markup is. The two asides are the two sidebars this layout deliberately writes:

| | classes | width | source |
|---|---|---|---|
| first | `fixed inset-y-0 z-50 left-0 …` | 250px | desktop pane, `placement="fixed"` |
| second | `relative h-full … max-w-full` | 320px | mobile drawer, `placement="static"`, inside `<MobileSidebar>` |

Only the desktop one was broken, and nothing painted over it. `[data-dashboard-web-sidebar]` is `display: none` under 1024px and the drawer is hidden above it, so the two never overlap. On a desktop viewport the sidebar was twelve section headers with no rows beneath them.

Swapping the two blocks in the layout moves the failure with the desktop usage, not with render position, which rules out the ordering and `<script server cache>` theories.

## Root cause

Prop casing. `Sidebar.stx` declares `$props.persistKey` and `$props.shellSelector`; the layout passed `persist-key` and `shell-selector`. With the kebab-case names, every nested `<SidebarSection>` loses its `items`, its `rows` export never evaluates, and each of the twelve `@foreach(rows as row)` blocks renders `<!-- [Foreach Error [1102]]: Error in @foreach: rows is not iterable -->`.

Bisected against a running dev server, three renders per configuration, nothing else changed:

| desktop props | foreach errors | section rows |
|---|---|---|
| as shipped | 12 | 0 |
| mobile's prop set | 0 | all |
| `+ shell-selector="[data-stx-content]"` | 12 | 0 |
| `+ shell-selector="main"` | 12 | 0 |
| `+ persist-key="…"` | 12 | 0 |
| `+ persistKey="…"` | 0 | all |

Either kebab-case name alone reproduces it, and the bracketed selector value is irrelevant, so this is the casing rather than one specific prop.

After the fix the desktop pane renders 140 rows and the page has zero foreach errors. The other dashboard routes I checked (`/commerce/orders`, `/commerce/delivery/shipping-rates`, `/content/posts`, `/data/users`, `/settings`) were already clean and stay clean.

## What this does not fix

`Sidebar.stx` interpolates its string props into `<script client>` unquoted:

```js
const collapsedClassProp = ;                        // SyntaxError, block never parses
const persistKeyProp = stacks-dashboard-sidebar;    // parses as subtraction
const shellSelectorProp = [data-stx-content];
const widthVarProp = --stx-sidebar-width;
```

`const collapsedClassProp = ;` is a hard syntax error present in both sidebar instances, so the controller never runs. Server-rendered rows and their hrefs work; collapse, width persistence and active-row sync do not. That lives in `@stacksjs/components`, not here, and is filed separately.

## Verification

- `./buddy lint`: 58 problems before and after, none in the changed file.
- Dashboard dev server, `/` plus five routes, zero render errors.
