### PR TITLE
fix(auth): create password_resets.expires_at, and three red core packages

### DIFF
--- a/storage/framework/core/auth/tests/helpers/auth-schema.ts
+++ b/storage/framework/core/auth/tests/helpers/auth-schema.ts
@@ -1,0 +1,35 @@
+/**
+ * The `oauth_*` and `password_resets` schema for auth tests.
+ *
+ * These tests used to carry their own `CREATE TABLE` copies of that schema.
+ * That made the fixtures a third definition of it, alongside the migrator in
+ * `@stacksjs/database` and the columns `tokens.ts` actually writes, and the
+ * three drifted the moment anyone added a column: `user_agent` and
+ * `ip_address` landed in `auth-tables.ts` and in the INSERT in `tokens.ts`
+ * for the session list in stacksjs/stacks#2286, the fixtures kept their
+ * older shape, and eleven tests started failing on `table
+ * oauth_access_tokens has no column named user_agent` for a feature none of
+ * them exercise.
+ *
+ * So they call the migrator instead. It is the same code path `buddy
+ * migrate` runs, it is `CREATE TABLE IF NOT EXISTS` throughout plus
+ * idempotent ALTERs, and it seeds the personal access client the token
+ * helpers need. A column added to the real schema now reaches these tests
+ * for free.
+ *
+ * `users` and `sessions` stay with each test. The auth migrator does not own
+ * them (they come from model migrations), and the tests that care about an
+ * un-migrated `users` need to shape it themselves.
+ *
+ * Import this only AFTER the test file has set `DB_CONNECTION` /
+ * `DB_DATABASE_PATH` and awaited `initializeDbConfig`, the same ordering
+ * constraint every one of these files already observes for
+ * `@stacksjs/database` itself.
+ */
+export async function ensureFrameworkAuthTables(): Promise<void> {
+  const { migrateAuthTables } = await import('@stacksjs/database')
+
+  const result = await migrateAuthTables()
+  if (!result.success)
+    throw new Error(`auth tables failed to migrate for this test: ${result.error}`)
+}

--- a/storage/framework/core/auth/tests/logout-all.test.ts
+++ b/storage/framework/core/auth/tests/logout-all.test.ts
@@ -24,6 +24,7 @@ process.env.DB_DATABASE_PATH = DB_PATH
 process.env.APP_ENV = 'testing'
 
 const { acquireDbConfigLock, db, ensureDatabaseConfigLoaded, initializeDbConfig } = await import('@stacksjs/database')
+const { ensureFrameworkAuthTables } = await import('./helpers/auth-schema')
 const { createToken, findToken, revokeAllTokens, validateRefreshToken } = await import('../src/tokens')
 const { sessionCheck, sessionDestroyAll } = await import('../src/session-auth')
 const { makeHash } = await import('@stacksjs/security')
@@ -76,47 +77,6 @@ beforeAll(async () => {
   `).execute()
 
   await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS oauth_clients (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      name VARCHAR(255) NOT NULL,
-      secret VARCHAR(100),
-      provider VARCHAR(255),
-      redirect VARCHAR(2000) NOT NULL,
-      personal_access_client BOOLEAN NOT NULL DEFAULT 0,
-      password_client BOOLEAN NOT NULL DEFAULT 0,
-      revoked BOOLEAN NOT NULL DEFAULT 0,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-      updated_at TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS oauth_access_tokens (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      user_id INTEGER NOT NULL,
-      oauth_client_id INTEGER NOT NULL,
-      token TEXT NOT NULL,
-      name VARCHAR(255),
-      scopes TEXT,
-      revoked BOOLEAN NOT NULL DEFAULT 0,
-      expires_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-      updated_at TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS oauth_refresh_tokens (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      access_token_id INTEGER NOT NULL,
-      token TEXT NOT NULL,
-      revoked BOOLEAN NOT NULL DEFAULT 0,
-      expires_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
     CREATE TABLE IF NOT EXISTS sessions (
       id VARCHAR(255) PRIMARY KEY,
       user_id INTEGER NOT NULL,
@@ -128,10 +88,7 @@ beforeAll(async () => {
     )
   `).execute()
 
-  await db.unsafe(`
-    INSERT INTO oauth_clients (name, secret, provider, redirect, personal_access_client, password_client, revoked, created_at)
-    VALUES (?, ?, ?, ?, 1, 0, 0, datetime('now'))
-  `, ['Personal Access Client', 'test-secret', 'local', 'http://localhost']).execute()
+  await ensureFrameworkAuthTables()
 })
 
 afterAll(() => {

--- a/storage/framework/core/auth/tests/password-changed-at-binding.test.ts
+++ b/storage/framework/core/auth/tests/password-changed-at-binding.test.ts
@@ -45,6 +45,7 @@ mock.module('@stacksjs/email', () => ({
 }))
 
 const { acquireDbConfigLock, db, ensureDatabaseConfigLoaded, initializeDbConfig } = await import('@stacksjs/database')
+const { ensureFrameworkAuthTables } = await import('./helpers/auth-schema')
 const { createToken, findToken, refreshToken, validateRefreshToken } = await import('../src/tokens')
 const { passwordResets } = await import('../src/password/reset')
 const { makeHash } = await import('@stacksjs/security')
@@ -135,61 +136,7 @@ beforeAll(async () => {
     )
   `).execute()
 
-  await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS password_resets (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      email VARCHAR(255) NOT NULL,
-      token VARCHAR(255) NOT NULL,
-      expires_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS oauth_clients (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      name VARCHAR(255) NOT NULL,
-      secret VARCHAR(100),
-      provider VARCHAR(255),
-      redirect VARCHAR(2000) NOT NULL,
-      personal_access_client BOOLEAN NOT NULL DEFAULT 0,
-      password_client BOOLEAN NOT NULL DEFAULT 0,
-      revoked BOOLEAN NOT NULL DEFAULT 0,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-      updated_at TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS oauth_access_tokens (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      user_id INTEGER NOT NULL,
-      oauth_client_id INTEGER NOT NULL,
-      token TEXT NOT NULL,
-      name VARCHAR(255),
-      scopes TEXT,
-      revoked BOOLEAN NOT NULL DEFAULT 0,
-      expires_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-      updated_at TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS oauth_refresh_tokens (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      access_token_id INTEGER NOT NULL,
-      token TEXT NOT NULL,
-      revoked BOOLEAN NOT NULL DEFAULT 0,
-      expires_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
-    INSERT INTO oauth_clients (name, secret, provider, redirect, personal_access_client, password_client, revoked, created_at)
-    VALUES (?, ?, ?, ?, 1, 0, 0, datetime('now'))
-  `, ['Personal Access Client', 'test-secret', 'local', 'http://localhost']).execute()
+  await ensureFrameworkAuthTables()
 })
 
 afterAll(() => {

--- a/storage/framework/core/auth/tests/password-reset-revocation.test.ts
+++ b/storage/framework/core/auth/tests/password-reset-revocation.test.ts
@@ -51,6 +51,7 @@ mock.module('@stacksjs/email', () => ({
 }))
 
 const { acquireDbConfigLock, db, ensureDatabaseConfigLoaded, initializeDbConfig } = await import('@stacksjs/database')
+const { ensureFrameworkAuthTables } = await import('./helpers/auth-schema')
 const { createToken, findToken, refreshToken, validateRefreshToken } = await import('../src/tokens')
 const { passwordResets } = await import('../src/password/reset')
 const { sessionCheck } = await import('../src/session-auth')
@@ -146,57 +147,6 @@ beforeAll(async () => {
   `).execute()
 
   await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS password_resets (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      email VARCHAR(255) NOT NULL,
-      token VARCHAR(255) NOT NULL,
-      expires_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS oauth_clients (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      name VARCHAR(255) NOT NULL,
-      secret VARCHAR(100),
-      provider VARCHAR(255),
-      redirect VARCHAR(2000) NOT NULL,
-      personal_access_client BOOLEAN NOT NULL DEFAULT 0,
-      password_client BOOLEAN NOT NULL DEFAULT 0,
-      revoked BOOLEAN NOT NULL DEFAULT 0,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-      updated_at TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS oauth_access_tokens (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      user_id INTEGER NOT NULL,
-      oauth_client_id INTEGER NOT NULL,
-      token TEXT NOT NULL,
-      name VARCHAR(255),
-      scopes TEXT,
-      revoked BOOLEAN NOT NULL DEFAULT 0,
-      expires_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-      updated_at TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
-    CREATE TABLE IF NOT EXISTS oauth_refresh_tokens (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      access_token_id INTEGER NOT NULL,
-      token TEXT NOT NULL,
-      revoked BOOLEAN NOT NULL DEFAULT 0,
-      expires_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )
-  `).execute()
-
-  await db.unsafe(`
     CREATE TABLE IF NOT EXISTS sessions (
       id VARCHAR(255) PRIMARY KEY,
       user_id INTEGER NOT NULL,
@@ -208,11 +158,8 @@ beforeAll(async () => {
     )
   `).execute()
 
-  // createToken() requires a personal-access client.
-  await db.unsafe(`
-    INSERT INTO oauth_clients (name, secret, provider, redirect, personal_access_client, password_client, revoked, created_at)
-    VALUES (?, ?, ?, ?, 1, 0, 0, datetime('now'))
-  `, ['Personal Access Client', 'test-secret', 'local', 'http://localhost']).execute()
+  // Also seeds the personal-access client that createToken() requires.
+  await ensureFrameworkAuthTables()
 })
 
 afterAll(() => {

--- a/storage/framework/core/composables/tests/timing.test.ts
+++ b/storage/framework/core/composables/tests/timing.test.ts
@@ -792,13 +792,20 @@ describe('useTimeAgo', () => {
     expect(result.value).toBe('1 year ago')
   })
 
+  // Future targets get a margin INSIDE the bucket rather than sitting on its
+  // edge. formatTimeAgo floors, and time passes between the Date.now() here
+  // and the one inside useTimeAgo, so an exact `+ 2 hours` is 7199999ms by the
+  // time it is measured and floors to "in 1 hour". Past targets do not need
+  // this: elapsed time grows their difference, which keeps them in the same
+  // bucket. The margin has to be small enough not to reach the next bucket and
+  // large enough to survive a loaded CI runner.
   it('should format future dates', () => {
-    const result = useTimeAgo(Date.now() + 5 * 60 * 1000 + 500)
-    expect(['in 5 minutes', 'in 4 minutes']).toContain(result.value)
+    const result = useTimeAgo(Date.now() + 5 * 60 * 1000 + 30 * 1000)
+    expect(result.value).toBe('in 5 minutes')
   })
 
   it('should format future hours', () => {
-    const result = useTimeAgo(Date.now() + 2 * 60 * 60 * 1000)
+    const result = useTimeAgo(Date.now() + 2 * 60 * 60 * 1000 + 30 * 1000)
     expect(result.value).toBe('in 2 hours')
   })
 

--- a/storage/framework/core/database/src/auth-tables.ts
+++ b/storage/framework/core/database/src/auth-tables.ts
@@ -120,6 +120,26 @@ export function oauthAccessTokenDeviceColumnsSql(): string[] {
 }
 
 /**
+ * Defensive ALTER guaranteeing `password_resets.expires_at`.
+ *
+ * `createResetToken` in `core/auth/src/password/reset.ts` has always written
+ * this column on insert, and the CREATE here never declared it, so on any
+ * install whose table came from this migrator "forgot my password" failed with
+ * `table password_resets has no column named expires_at`. It went unnoticed
+ * because the tests that cover the reset flow hand-rolled their own
+ * `password_resets` DDL and invented the column the migrator was missing.
+ *
+ * The read path deliberately tolerates its absence (see `isWithinExpiry`,
+ * which falls back to `created_at` plus the configured expiry), so adding it
+ * changes no behaviour for rows already written.
+ */
+export function passwordResetsExpiresAtSql(): string[] {
+  return [
+    `ALTER TABLE password_resets ADD COLUMN expires_at TIMESTAMP`,
+  ]
+}
+
+/**
  * Runs every `users` guarantee-column ALTER (email_verified_at,
  * password_changed_at, two_factor_secret, two_factor_enabled,
  * stripe_id), each independently try/catch-swallowed so one
@@ -243,9 +263,27 @@ export async function migrateAuthTables(options: { verbose?: boolean } = {}): Pr
         ${pkColumn},
         email VARCHAR(255) NOT NULL,
         token VARCHAR(255) NOT NULL,
+        -- createResetToken writes this on every insert, so the table has to
+        -- have it or requesting a reset throws. The read side (isWithinExpiry)
+        -- still falls back to clock arithmetic against created_at, because
+        -- rows written before the column existed have to keep verifying.
+        expires_at ${nullableTimestamp},
         created_at ${datetime} DEFAULT CURRENT_TIMESTAMP
       )
     `).execute()
+
+    // For installs whose password_resets predates the column. Same
+    // CREATE-plus-idempotent-ALTER pairing as the oauth device columns above,
+    // and for the same reason: no generated migration creates this table, so
+    // both schema paths have to end up somewhere identical.
+    for (const alterSql of passwordResetsExpiresAtSql()) {
+      try {
+        await db.unsafe(alterSql).execute()
+      }
+      catch {
+        if (options.verbose) log.debug(`[auth-tables] Skipped (already applied): ${alterSql}`)
+      }
+    }
 
     try {
       await db.unsafe(indexSqlForDialect(`CREATE INDEX IF NOT EXISTS idx_password_resets_email ON password_resets(email)`, dbDriver)).execute()

--- a/storage/framework/core/defaults/tests/preloader.test.ts
+++ b/storage/framework/core/defaults/tests/preloader.test.ts
@@ -77,6 +77,10 @@ describe('default preloader', () => {
       env: {
         PATH: process.env.PATH ?? '',
         HOME: process.env.HOME ?? tempDir,
+        // Passed through deliberately. Code in this graph gates on it, and a
+        // child that believes it is interactive can sit on a prompt instead of
+        // exiting, which reads as a hang rather than a failure.
+        ...(process.env.CI ? { CI: process.env.CI } : {}),
       },
       stderr: 'pipe',
       stdout: 'pipe',

--- a/storage/framework/core/defaults/tests/preloader.test.ts
+++ b/storage/framework/core/defaults/tests/preloader.test.ts
@@ -65,9 +65,19 @@ describe('default preloader', () => {
     )
     await Bun.write(isolatedRunner, `await import('./storage/framework/defaults/resources/plugins/preloader.ts')\n`)
 
+    // A curated environment rather than the developer's. This test is about
+    // whether the preloader resolves with nothing linked, and it asserts on
+    // empty stdout/stderr, so inheriting the ambient environment made it
+    // assert on whatever database the machine running it happened to have
+    // configured: a local `DB_CONNECTION=postgres` is enough to put a
+    // bun-query-builder dialect warning on stderr and fail a test that has
+    // nothing to do with databases.
     const child = Bun.spawn([process.execPath, isolatedRunner], {
       cwd: tempDir,
-      env: { ...process.env },
+      env: {
+        PATH: process.env.PATH ?? '',
+        HOME: process.env.HOME ?? tempDir,
+      },
       stderr: 'pipe',
       stdout: 'pipe',
     })


### PR DESCRIPTION
CI's `test` job has been red on main since 2026-08-09 (`d3a60410f1`). The `Core tests` step reported `Failing core packages: auth composables defaults`. All three are fixed here, and one of them was covering a real bug.

## The real bug: `password_resets.expires_at` never existed

`createResetToken` (`core/auth/src/password/reset.ts:122`) writes `expires_at` on every insert. `migrateAuthTables` never created the column. Every install whose `password_resets` table came from the auth migrator would fail "forgot my password" with:

```
table password_resets has no column named expires_at
```

It went unseen because the three tests covering the reset flow hand-rolled their own `password_resets` DDL **and invented the column the migrator was missing**. The fixtures were not merely failing to catch it, they were supplying the schema that hid it.

Fixed by adding the column to the CREATE plus an idempotent ALTER for existing installs, matching the pairing this file already uses for the oauth device columns. The read path (`isWithinExpiry`) already falls back to `created_at`, so rows written before the column existed keep verifying and nothing changes for them.

## auth (11 failures)

`user_agent` / `ip_address` were added to `oauth_access_tokens` in `auth-tables.ts` and to the INSERT in `tokens.ts`. The fixtures were a third definition of that schema, kept their older shape, and eleven tests failed on an unknown column for a feature none of them exercise.

They now call `migrateAuthTables()` rather than copying it: same code path `buddy migrate` runs, `CREATE TABLE IF NOT EXISTS` throughout, and it seeds the personal access client the token helpers need. A column added to the real schema now reaches these tests for free.

`users` and `sessions` stay per-test. The auth migrator does not own them, and the graceful-degradation test needs to shape `users` without the column itself.

Net **100 fewer lines** of duplicated DDL.

## composables (1 failure, CI-only)

`useTimeAgo > should format future hours` asserted `Date.now() + 2 hours` renders `"in 2 hours"`. `formatTimeAgo` floors, so by the time it is measured the difference is 7199999ms and it renders `"in 1 hour"`. It passed locally only because both `Date.now()` calls landed in the same millisecond; a loaded CI runner ticks.

Both future-time tests now aim 30 seconds inside their bucket. That also lets the minutes test assert an exact string instead of accepting either answer, which is what it was reduced to. Past-time tests need no change: elapsed time grows their difference and keeps them in the same bucket.

## defaults (1 failure locally, still red in CI)

Two different failures wear the same name here, and only one is fixed.

**Locally** the test failed because `loads without workspace packages being linked` spawns a child, asserts empty stdout and stderr, and passed it `{ ...process.env }`. A local `DB_CONNECTION=postgres` is enough to put a bun-query-builder dialect warning on stderr and fail a test about module resolution. It gets a curated environment now (plus `CI` passed through deliberately, since code in this graph gates on it and a child that believes it is interactive can sit on a prompt). That is a real fix and it holds 3/3 runs.

**In CI it is a different failure and it is not fixed.** The child hangs and bun kills it at the 5s timeout with `killed 1 dangling process`, both before and after this change. I could not reproduce it: it exits 0 on macOS with the ambient env, with a sanitised env, with `AWS_DYNAMODB_ENDPOINT` set, and under CI's exact bun (1.3.14, via `bunx`). So it is Linux-specific. The preloader itself has no timer, server or watcher, and the one unbounded-looking loop in its import graph (`projectPath`, `path/src/index.ts:1048`) has a termination guard.

This red predates the branch. Calling it out rather than leaving it to look fixed.

## Verification

| package | result |
|---|---|
| auth | 286 pass, 0 fail |
| composables | 1114 pass, 0 fail |
| defaults | 2 pass, 0 fail |
| database | 756 pass, 0 fail |
| orm | 1463 pass, 0 fail |
| testing | 28 pass, 0 fail |

Lint: 58 problems before and after, none in changed files. Typecheck: 13 before and after, none in changed files. `cache` and `queue` keep their pre-existing local failures, untouched by this.

## Still red, and not fixed here

The `test` job has a **second** failing step. `Test Suite` (`bun run test`) fails with:

```
Cannot find module '@stacksjs/browser/composables/csrf'
  from storage/framework/defaults/functions/dashboard-api.ts
```

Reproduced locally by hiding `core/browser/dist`, which gives the identical single failure. The cause is that `@stacksjs/browser`'s exports map resolves only into `./dist/**`, `dist` is gitignored, and the `test` job runs `bun install` then straight to `bun test` with no build. It passes on a developer machine only when a stale `dist` happens to be present, which is the worst kind of green.

This needs a decision rather than a patch, so I have left it:

- `browser-package-contract.test.ts` records that a `development` condition was **deliberately removed** ("it resolved to `./src/*`, which is not published"), and says in-repo source resolution comes from `@stacksjs/alias`. But nothing wires that alias into resolution for `bun test`: there is no `paths` entry in the tsconfig chain, so the claim does not hold for the test runner.
- Adding a `paths` entry does fix that import, and immediately surfaces the same problem one layer down (`@stacksjs/path`'s `dist` is stale and missing `applyRuntimeDirectoryEnv`), so it is systemic rather than one package.
- Bun does not honour exports fallback arrays, so `["./dist/x.js", "./src/x.ts"]` is not an option.

The candidates are: build the core packages before the test suite in CI, wire the alias into tsconfig `paths` for every package, or ship `src` and resolve through the `bun` condition. That is a publish-shape call.

