### PR TITLE
diag: find the preloader's Linux-only hang (not for merge)

### DIFF
--- a/storage/framework/core/defaults/tests/preloader.test.ts
+++ b/storage/framework/core/defaults/tests/preloader.test.ts
@@ -63,7 +63,26 @@ describe('default preloader', () => {
       resolve(isolatedPathRoot, 'index.ts'),
       Bun.file(resolve(import.meta.dir, '../../path/src/index.ts')),
     )
-    await Bun.write(isolatedRunner, `await import('./storage/framework/defaults/resources/plugins/preloader.ts')\n`)
+    // TEMPORARY DIAGNOSTIC (stacksjs/stacks#2279 follow-up). The child hangs on
+    // Linux CI and exits 0 on macOS with every environment and bun version I
+    // tried, so this instruments the child to say where it stalls. Revert once
+    // the cause is known.
+    await Bun.write(isolatedRunner, [
+      `const t0 = Date.now()`,
+      `const mark = (m) => process.stderr.write(\`[mark +\${Date.now() - t0}ms] \${m}\\n\`)`,
+      `process.on('exit', c => mark('exit ' + c))`,
+      `const bomb = setTimeout(() => {`,
+      `  let res = 'unavailable'`,
+      `  try { res = JSON.stringify(process.getActiveResourcesInfo()) } catch (e) { res = 'threw: ' + e.message }`,
+      `  mark('STILL ALIVE at 3s, active resources: ' + res)`,
+      `  process.exit(9)`,
+      `}, 3000)`,
+      `if (typeof bomb.unref === 'function') bomb.unref()`,
+      `mark('before import')`,
+      `await import('./storage/framework/defaults/resources/plugins/preloader.ts')`,
+      `mark('after import')`,
+      ``,
+    ].join('\n'))
 
     // A curated environment rather than the developer's. This test is about
     // whether the preloader resolves with nothing linked, and it asserts on
@@ -90,6 +109,8 @@ describe('default preloader', () => {
       new Response(child.stderr).text(),
       new Response(child.stdout).text(),
     ])
+    // TEMPORARY DIAGNOSTIC: surface the child's markers in the CI log.
+    console.error(`[preloader diag] exit=${await child.exited}\n--- stderr ---\n${stderr}\n--- stdout ---\n${stdout}\n--- end ---`)
     expect(stderr).toBe('')
     expect(stdout).toBe('')
     expect(await child.exited).toBe(0)

--- a/storage/framework/core/defaults/tests/preloader.test.ts
+++ b/storage/framework/core/defaults/tests/preloader.test.ts
@@ -55,7 +55,20 @@ describe('default preloader', () => {
       'storage/framework/defaults/app/Models',
       'storage/framework/defaults/app/Controllers',
     ].map(path => mkdir(resolve(tempDir, path), { recursive: true })))
-    await Bun.write(isolatedPreloader, Bun.file(resolve(defaultsRoot, 'resources/plugins/preloader.ts')))
+    // Round 3. env/plugin.ts and path/index.ts both import fine on their own,
+    // so the stall is inside the preloader. Instrument the COPY (never the
+    // framework source) with a marker before every `await import(`, so the last
+    // marker printed names the line that never returns. Only statement-leading
+    // lines are touched, so this cannot break a continuation.
+    const preloaderSource = await Bun.file(resolve(defaultsRoot, 'resources/plugins/preloader.ts')).text()
+    const instrumented = preloaderSource.split('\n').map((line, index) => {
+      if (!/^\s*(?:const|let|var|await)\s.*await import\(/.test(line))
+        return line
+      const indent = line.match(/^\s*/)?.[0] ?? ''
+      const label = `L${index + 1}: ${line.trim().slice(0, 70).replace(/'/g, '')}`
+      return `${indent}process.stderr.write('[preloader ${label}]\\n')\n${line}`
+    }).join('\n')
+    await Bun.write(isolatedPreloader, instrumented)
     await Promise.all(['plugin.ts', 'crypto.ts', 'parser.ts'].map(file =>
       Bun.write(resolve(isolatedEnvRoot, file), Bun.file(resolve(envRoot, file))),
     ))

--- a/storage/framework/core/defaults/tests/preloader.test.ts
+++ b/storage/framework/core/defaults/tests/preloader.test.ts
@@ -62,9 +62,25 @@ describe('default preloader', () => {
     // lines are touched, so this cannot break a continuation.
     const preloaderSource = await Bun.file(resolve(defaultsRoot, 'resources/plugins/preloader.ts')).text()
     const instrumented = preloaderSource.split('\n').map((line, index) => {
+      const indent = line.match(/^\s*/)?.[0] ?? ''
+
+      // Round 4. L194 is the `for (const pkg of stacksPackages)` import and it
+      // prints exactly ONCE on Linux before the process stops, so the FIRST
+      // bare specifier is the one that never settles. Say which package it is
+      // and where it resolves to: on macOS these resolve to the global bun
+      // install cache rather than the workspace, so "unresolvable" is not a
+      // safe assumption about what CI is loading.
+      if (line.includes('await import(pkg)')) {
+        return [
+          `${indent}let __resolved = 'UNRESOLVABLE'`,
+          `${indent}try { __resolved = Bun.resolveSync(pkg, import.meta.dir) } catch {}`,
+          `${indent}process.stderr.write('[preloader importing ' + pkg + ' -> ' + __resolved + ']\\n')`,
+          line,
+        ].join('\n')
+      }
+
       if (!/^\s*(?:const|let|var|await)\s.*await import\(/.test(line))
         return line
-      const indent = line.match(/^\s*/)?.[0] ?? ''
       const label = `L${index + 1}: ${line.trim().slice(0, 70).replace(/'/g, '')}`
       return `${indent}process.stderr.write('[preloader ${label}]\\n')\n${line}`
     }).join('\n')

--- a/storage/framework/core/defaults/tests/preloader.test.ts
+++ b/storage/framework/core/defaults/tests/preloader.test.ts
@@ -78,9 +78,19 @@ describe('default preloader', () => {
       `  process.exit(9)`,
       `}, 3000)`,
       `if (typeof bomb.unref === 'function') bomb.unref()`,
-      `mark('before import')`,
+      // Round 2. Round 1 proved the preloader import never settles and that
+      // getActiveResourcesInfo() is EMPTY, so nothing holds the loop: it is a
+      // promise that never resolves, not a leaked handle. Import each piece of
+      // the graph on its own first to find which one it is.
+      `mark('env plugin: start')`,
+      `await import('./storage/framework/core/env/src/plugin.ts')`,
+      `mark('env plugin: ok')`,
+      `mark('path: start')`,
+      `await import('./storage/framework/core/path/src/index.ts')`,
+      `mark('path: ok')`,
+      `mark('preloader: start')`,
       `await import('./storage/framework/defaults/resources/plugins/preloader.ts')`,
-      `mark('after import')`,
+      `mark('preloader: ok')`,
       ``,
     ].join('\n'))
 


### PR DESCRIPTION
Diagnostic only, do not merge. Instruments the preloader child so CI reports where it stalls and what is keeping the loop alive.

Locally (macOS, bun 1.4.0-canary and 1.3.14) the child prints `before import` then `after import` at +574ms and exits 0. On Linux CI the same child produces nothing and is killed at the 5s timeout. This run should show whether it reaches the import at all, and if it does, what `process.getActiveResourcesInfo()` holds.

Follow-up to #2288, which fixed the local failure of this test but not the CI one.