### PR TITLE
fix(ci): build the one package the suite imports by subpath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,20 @@ jobs:
       # red. It stayed green on developer machines because a stale `dist` was
       # already sitting there.
       #
-      # 182ms, and only this package: it is the only one whose subpaths the
-      # suite reaches. If another package starts being imported by subpath and
-      # its tests fail to resolve, build it here too, or import its root.
+      # Both packages 80090bbe7a touched, in dependency order: browser's built
+      # `composables/useStorage.js` imports `@stacksjs/composables/useStorage`,
+      # so composables has to exist first or the same error just moves one
+      # level down. Under half a second for the pair.
+      #
+      # If another package starts being imported by subpath and the suite
+      # cannot resolve it, add it here, or import its root instead.
       - name: Build packages imported by subpath
-        working-directory: storage/framework/core/browser
-        run: bun run build
+        run: |
+          for pkg in composables browser; do
+            echo "::group::build @stacksjs/$pkg"
+            (cd "storage/framework/core/$pkg" && bun run build)
+            echo "::endgroup::"
+          done
 
       - name: Test Suite
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,22 @@ jobs:
         id: install
         run: bun install --frozen-lockfile
 
+      # Bun resolves a workspace package's ROOT export from source when its
+      # `dist` is missing, but it does NOT do that for subpath patterns like
+      # `./composables/*`. `dist` is gitignored and nothing here builds, so the
+      # moment `storage/framework/defaults/functions/*` moved from
+      # `@stacksjs/browser` to `@stacksjs/browser/composables/csrf` (80090bbe7a,
+      # for tree-shaking) the suite could no longer resolve it and this job went
+      # red. It stayed green on developer machines because a stale `dist` was
+      # already sitting there.
+      #
+      # 182ms, and only this package: it is the only one whose subpaths the
+      # suite reaches. If another package starts being imported by subpath and
+      # its tests fail to resolve, build it here too, or import its root.
+      - name: Build packages imported by subpath
+        working-directory: storage/framework/core/browser
+        run: bun run build
+
       - name: Test Suite
         env:
           AWS_DYNAMODB_ENDPOINT: http://localhost:8000


### PR DESCRIPTION
The `Test Suite` step has been red since 2026-07-31 on:

```
Cannot find module '@stacksjs/browser/composables/csrf'
  from storage/framework/defaults/functions/dashboard-api.ts
```

## Cause

**Bun resolves a workspace package's root export from source when `dist` is missing. It does not do that for subpath patterns.** Verified directly, with `core/browser/dist` moved aside:

| specifier | result |
|---|---|
| `import('@stacksjs/browser')` | resolves, 194 exports |
| `import('@stacksjs/browser/composables/csrf')` | Cannot find module |
| `import('@stacksjs/path')` | resolves |

`dist` is gitignored and this job runs `bun install` then straight to `bun test`, so nothing builds it. That was harmless while these files imported the package root. 80090bbe7a moved them to `@stacksjs/browser/composables/*` for tree-shaking, and the suite could no longer resolve them.

It kept passing locally because a stale `dist` was already on disk. Reproduce the CI failure on any machine with `mv storage/framework/core/browser/dist /tmp/` and it gives the identical single failure.

## Two packages, in dependency order

Building only browser moved the error one level down: browser's built `composables/useStorage.js` imports `@stacksjs/composables/useStorage`, another subpath from the same commit. So composables builds first. Both are packages 80090bbe7a converted.

## Why a build step

Building that package takes **182ms**. Only browser is built: it is the only package whose subpaths the suite reaches, and building the whole framework here would cost minutes to fix one import. The comment in the workflow says what to do if another package joins it.

Three alternatives were tried and rejected first:

- **exports fallback arrays** (`["./dist/x.js", "./src/x.ts"]`) are not honoured by bun
- **a `development` condition** works under `bun --conditions development` but `bun test` does not inherit it, and `tests/unit/browser-package-contract.test.ts` records that it was *deliberately removed* because `src` is not published
- **a tsconfig `paths` entry** fixes this import and immediately surfaces the same problem one layer down (`@stacksjs/path`'s dist missing `applyRuntimeDirectoryEnv`)

If you would rather not build in CI at all, the other honest option is reverting those imports to the package root: `@stacksjs/browser` is `"sideEffects": false`, so a real bundler tree-shakes the root import anyway, which makes the subpath split cheap to give up.

## Verification

`bun run test`: **222 pass, 0 fail** against a `dist` built from clean.

Follow-up to #2288, which greened `auth` and `composables` in the other step of this job.


## Result

CI on this branch: `Build packages imported by subpath` **success**, `Test Suite` **success** (was 1 fail). `Core tests (all packages)` still fails on the unrelated `defaults` preloader hang, which is being chased in #2289.
