### PR TITLE
fix(preloader): never boot against the global install cache

### DIFF
--- a/storage/framework/defaults/resources/plugins/preloader.ts
+++ b/storage/framework/defaults/resources/plugins/preloader.ts
@@ -189,7 +189,43 @@ export async function loadAutoImports() {
     '@stacksjs/browser',
   ]
 
+  // Only load a framework package that belongs to THIS project.
+  //
+  // A bare `@stacksjs/*` specifier resolves through node_modules, and when that
+  // is missing or half-installed bun falls back to its global install cache. So
+  // a project with a broken install did not fail: it silently booted against
+  // whatever published version happened to be sitting in ~/.bun/install/cache,
+  // which is a worse outcome than loading nothing, and an invisible one.
+  //
+  // It also hung. On Linux the first such cache-resolved import never settles -
+  // no rejection, no active handles, the process simply stops - so every stage
+  // of the preloader below this loop became unreachable. The `catch` here was
+  // written for "not installed yet" and only ever worked because an
+  // unresolvable specifier rejects promptly; one that resolves to a stale copy
+  // does not. Found via stacksjs/stacks#2279's preloader test, which spawns a
+  // child into a directory with nothing linked and is the only place this
+  // shows up.
+  //
+  // Accepted: anything under a `node_modules/` (a real install, whether the
+  // app's own or a vendored checkout's) and anything inside this framework tree
+  // (the core packages next to this file). Both are cwd-independent, so running
+  // a command from a subdirectory does not change what loads.
+  const nodePath = await import('node:path')
+  const frameworkRoot = nodePath.resolve(import.meta.dir, '../../..')
+  const nodeModulesSegment = `${nodePath.sep}node_modules${nodePath.sep}`
+
   for (const pkg of stacksPackages) {
+    let resolved: string
+    try {
+      resolved = Bun.resolveSync(pkg, import.meta.dir)
+    }
+    catch {
+      continue // Not installed, and not in the cache either
+    }
+
+    if (!resolved.includes(nodeModulesSegment) && !resolved.startsWith(frameworkRoot + nodePath.sep))
+      continue // Resolved outside this project, e.g. the global install cache
+
     try {
       const module = await import(pkg)
       for (const [name, value] of Object.entries(module)) {

--- a/storage/framework/defaults/resources/plugins/preloader.ts
+++ b/storage/framework/defaults/resources/plugins/preloader.ts
@@ -128,6 +128,43 @@ if (!isRepl && !isPostinstall) {
 // eslint-disable-next-line antfu/no-top-level-await
 // await import('bun-plugin-stx')
 
+/**
+ * Whether a bare `@stacksjs/*` specifier resolves to something belonging to
+ * THIS project, and is therefore safe to import.
+ *
+ * A bare specifier resolves through node_modules, and when that is missing or
+ * half-installed bun falls back to its GLOBAL install cache. So a project with
+ * a broken install did not fail. It silently booted against whatever published
+ * version happened to be sitting in ~/.bun/install/cache, which is worse than
+ * loading nothing and completely invisible.
+ *
+ * It also hung, and that is how it was found. On Linux the first such
+ * cache-resolved import never settles: no rejection, no active handles, the
+ * process simply stops, so every stage of the preloader after it is silently
+ * unreachable. Both callers wrap their import in a `catch` that assumes a bad
+ * specifier fails FAST. That holds for one that cannot be resolved at all. It
+ * does not hold for one that resolves to a stale copy.
+ *
+ * Accepted: anything under a `node_modules/` (a real install, the app's own or
+ * a vendored checkout's) and anything inside this framework tree (the core
+ * packages beside this file). Both are cwd-independent, so running a command
+ * from a subdirectory does not change what loads.
+ */
+async function belongsToThisProject(specifier: string): Promise<boolean> {
+  let resolved: string
+  try {
+    resolved = Bun.resolveSync(specifier, import.meta.dir)
+  }
+  catch {
+    return false // Not installed, and not in the cache either
+  }
+
+  const { resolve, sep } = await import('node:path')
+  const frameworkRoot = resolve(import.meta.dir, '../../..')
+
+  return resolved.includes(`${sep}node_modules${sep}`) || resolved.startsWith(frameworkRoot + sep)
+}
+
 // Auto-import ALL Stacks framework modules into globalThis
 // This allows using Action, response, Activity, etc. without ANY imports.
 // Exported so server entrypoints (e.g. `dev/api.ts`) can opt back in
@@ -189,42 +226,12 @@ export async function loadAutoImports() {
     '@stacksjs/browser',
   ]
 
-  // Only load a framework package that belongs to THIS project.
-  //
-  // A bare `@stacksjs/*` specifier resolves through node_modules, and when that
-  // is missing or half-installed bun falls back to its global install cache. So
-  // a project with a broken install did not fail: it silently booted against
-  // whatever published version happened to be sitting in ~/.bun/install/cache,
-  // which is a worse outcome than loading nothing, and an invisible one.
-  //
-  // It also hung. On Linux the first such cache-resolved import never settles -
-  // no rejection, no active handles, the process simply stops - so every stage
-  // of the preloader below this loop became unreachable. The `catch` here was
-  // written for "not installed yet" and only ever worked because an
-  // unresolvable specifier rejects promptly; one that resolves to a stale copy
-  // does not. Found via stacksjs/stacks#2279's preloader test, which spawns a
-  // child into a directory with nothing linked and is the only place this
-  // shows up.
-  //
-  // Accepted: anything under a `node_modules/` (a real install, whether the
-  // app's own or a vendored checkout's) and anything inside this framework tree
-  // (the core packages next to this file). Both are cwd-independent, so running
-  // a command from a subdirectory does not change what loads.
-  const nodePath = await import('node:path')
-  const frameworkRoot = nodePath.resolve(import.meta.dir, '../../..')
-  const nodeModulesSegment = `${nodePath.sep}node_modules${nodePath.sep}`
-
   for (const pkg of stacksPackages) {
-    let resolved: string
-    try {
-      resolved = Bun.resolveSync(pkg, import.meta.dir)
-    }
-    catch {
-      continue // Not installed, and not in the cache either
-    }
-
-    if (!resolved.includes(nodeModulesSegment) && !resolved.startsWith(frameworkRoot + nodePath.sep))
-      continue // Resolved outside this project, e.g. the global install cache
+    // See `belongsToThisProject`. Skipping is what the `catch` below always
+    // meant to do; it just never got the chance for a specifier that resolves
+    // to a stale copy instead of failing.
+    if (!(await belongsToThisProject(pkg)))
+      continue
 
     try {
       const module = await import(pkg)
@@ -383,12 +390,14 @@ if (!skipAutoImports) {
   await loadAutoImports()
 
   // Run package auto-discovery after all imports are loaded
-  try {
-    const actionsPackage = '@stacksjs/' + 'actions'
-    const { discoverPackages } = await import(actionsPackage)
-    await discoverPackages()
-  }
-  catch {
-    // Discovery may fail during early bootstrap — not critical
+  const actionsPackage = '@stacksjs/' + 'actions'
+  if (await belongsToThisProject(actionsPackage)) {
+    try {
+      const { discoverPackages } = await import(actionsPackage)
+      await discoverPackages()
+    }
+    catch {
+      // Discovery may fail during early bootstrap — not critical
+    }
   }
 }


### PR DESCRIPTION
Closes the last red in the `test` job.

## What was actually wrong

The auto-import loop imports twenty framework packages by bare specifier. A bare `@stacksjs/*` specifier resolves through node_modules, and **when that is missing or half-installed bun falls back to its global install cache**. A project with a broken install therefore did not fail. It silently booted against whatever published version was sitting in `~/.bun/install/cache`.

That is worse than loading nothing, and invisible.

It also hung, which is how it surfaced. On Linux the first cache-resolved import never settles, so everything below the loop (resources/functions, models, jobs, the auto-import barrel) becomes unreachable in silence.

The existing `catch` was written for *"package might not exist or not be built yet"* and only ever worked because an unresolvable specifier rejects promptly. One that resolves to a stale copy does not reject at all.

## The fix

Resolve first, and require the result to belong to this project:

- under a `node_modules/` (a real install, the app's own or a vendored checkout's), or
- inside this framework tree (the core packages beside this file)

Both are cwd-independent, so running a command from a subdirectory does not change what loads.

## How it was found

Unreproducible on macOS under every environment and bun version tried, including CI's own 1.3.14 via `bunx`. So I instrumented CI instead, one question per round (#2289):

| round | question | answer |
|---|---|---|
| 1 | is a handle holding the loop? | no. `getActiveResourcesInfo()` is **empty**, the import just never settles |
| 2 | is it env or path? | neither, both import in 3ms |
| 3 | which line? | L194, printed **once**, so the first bare specifier |
| 4 | what is it loading? | see below |

```
[preloader importing @stacksjs/actions ->
  /home/runner/.bun/install/cache/@stacksjs/actions@0.70.352@@@1/dist/index.js]
[mark +3001ms] STILL ALIVE at 3s, active resources: []
```

Round 4 is why this PR exists in its current form. My first instinct was a `Bun.resolveSync` existence guard, and I tested it before writing it: it resolves fine, so it would not have prevented anything. The problem was never that the package was missing.

## Verification

**2916 globals before the change, 2916 after**, so nothing that used to load stops loading. Sample: `User`, `Job`, `Activity`, `Author`, `Board`, `Campaign`, `Cart`. `core/defaults` passes locally, exercising the unlinked path for the first time.

Once this is in, the `test` job should be fully green for the first time since 2026-07-31. #2289 is the diagnostic branch and can be closed unmerged.