### PR TITLE
fix(queue): atomic batch.add, and a shutdown drain the Redis driver reaches

### DIFF
--- a/storage/framework/core/queue/src/batch.ts
+++ b/storage/framework/core/queue/src/batch.ts
@@ -496,13 +496,8 @@ export class DispatchedBatch {
     if (record.finished_at) throw new Error(`Batch ${this.id} has already finished`)
 
     const batchableJobs = jobs.map(j => 'job' in j ? j : { job: j })
-    const newTotal = record.total_jobs + batchableJobs.length
-    const newPending = record.pending_jobs + batchableJobs.length
 
-    await updateBatchRecord(this.id, {
-      total_jobs: newTotal,
-      pending_jobs: newPending,
-    })
+    await incrementBatchCounters(this.id, batchableJobs.length)
 
     // Dispatch the new jobs
     const options = JSON.parse(record.options || '{}')
@@ -638,6 +633,73 @@ async function updateBatchRecord(id: string, updates: Partial<BatchRecord>): Pro
   }
   else {
     await updateBatchInDatabase(id, updates)
+  }
+}
+
+/**
+ * Add `delta` to a batch's `total_jobs` and `pending_jobs`, atomically.
+ *
+ * `DispatchedBatch.add` used to read the record, add in JavaScript, and write
+ * the absolute result back. Two callers adding to the same in-flight batch at
+ * the same instant both read total=N and both wrote total=N+their own count,
+ * so one add vanished: the batch then reported fewer jobs than it was actually
+ * running and `pending_jobs` could never reach zero, leaving the terminal
+ * `then`/`finally` callbacks unfired (stacksjs/stacks#2282 item 3).
+ *
+ * That is the same race `recordBatchJobCompletion` was given an atomic
+ * decrement for; this is the other half of it, on the way in.
+ *
+ * Both drivers can do this without a read. Postgres/MySQL/SQLite take
+ * `column + n` in the SET clause, and Redis has `HINCRBY` on the hash the
+ * batch is stored as. The Redis path falls back to the database on a
+ * connection error, matching `updateBatchInRedis`.
+ */
+async function incrementBatchCounters(id: string, delta: number): Promise<void> {
+  if (delta === 0)
+    return
+
+  if (getQueueDriver() === 'redis') {
+    try {
+      const client = await connectBatchRedis()
+      const key = `${REDIS_BATCH_PREFIX}${id}`
+      await client.hincrby(key, 'total_jobs', delta)
+      await client.hincrby(key, 'pending_jobs', delta)
+      client.close()
+      return
+    }
+    catch {
+      // Fall through to the database, as updateBatchInRedis does.
+    }
+  }
+
+  const { db, sql } = await import('@stacksjs/database')
+
+  await (db as any)
+    .updateTable('job_batches')
+    .set(batchCounterIncrements(sql, delta))
+    .where('id', '=', id)
+    .execute()
+}
+
+/**
+ * The SET payload that adds `delta` to both batch counters.
+ *
+ * Split out from {@link incrementBatchCounters} purely so the shape is
+ * assertable. The thing worth testing is that these are RELATIVE expressions
+ * evaluated by the database rather than absolute numbers this process worked
+ * out, and checking that through the real call would mean mocking
+ * `@stacksjs/database`. `mock.module` is process-global and bun runs a
+ * package's test files in one process, so mocking a module this widely used
+ * takes out every other test in the package (it dropped the queue suite from
+ * 299 passing to 202 when tried).
+ */
+export function batchCounterIncrements(
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => unknown,
+  delta: number,
+): { total_jobs: unknown, pending_jobs: unknown } {
+  return {
+    total_jobs: sql`total_jobs + ${delta}`,
+    pending_jobs: sql`pending_jobs + ${delta}`,
   }
 }
 

--- a/storage/framework/core/queue/src/worker.ts
+++ b/storage/framework/core/queue/src/worker.ts
@@ -813,7 +813,7 @@ async function processJobsFromRedis(queueName: string, concurrency: number): Pro
   const { emitQueueEvent, getWorkerTracker } = await import('./events')
   const tracker = getWorkerTracker()
 
-  queue.process(concurrency, async (bunJob: any) => {
+  const handleRedisJob = async (bunJob: any): Promise<void> => {
     activeJobCount++
     tracker.markActive(workerId)
     const startTime = Date.now()
@@ -916,7 +916,22 @@ async function processJobsFromRedis(queueName: string, concurrency: number): Pro
       activeJobCount--
       tracker.markIdle(workerId)
     }
-  })
+  }
+
+  // Registered through `trackInFlight` so `stopProcessor` can await a Redis
+  // job the same way it awaits a database one.
+  //
+  // It could not before. The drain added in stacksjs/stacks#1984 item 3
+  // (fdbfbba0ff) awaits the `inFlightJobs` set, and only the database path ever
+  // put anything in it, so under the Redis driver the drain had nothing to wait
+  // for and returned immediately. A deploy or a SIGTERM killed Redis jobs
+  // mid-run while the identical deploy against the database driver waited for
+  // them to finish (stacksjs/stacks#2282 item 5).
+  //
+  // Wrapping at the registration rather than inside the handler keeps the
+  // tracked promise the SAME one bun-queue awaits, so a throw still reaches its
+  // retry logic unchanged.
+  queue.process(concurrency, (bunJob: any) => trackInFlight(handleRedisJob(bunJob)))
 
   log.info(`Listening for Redis jobs on queue "${queueName}" with concurrency ${concurrency}...`)
 

--- a/storage/framework/core/queue/tests/batch-add-atomicity.test.ts
+++ b/storage/framework/core/queue/tests/batch-add-atomicity.test.ts
@@ -1,0 +1,88 @@
+/**
+ * stacksjs/stacks#2282 item 3 — `DispatchedBatch.add` was read-modify-write.
+ *
+ * It read the record, added in JavaScript, and wrote the absolute result back:
+ *
+ *     const newTotal = record.total_jobs + batchableJobs.length
+ *     await updateBatchRecord(this.id, { total_jobs: newTotal, ... })
+ *
+ * Two callers adding to the same in-flight batch at the same instant both read
+ * total=N and both wrote total=N+their own count, so one add vanished. The
+ * batch then reported fewer jobs than it was really running, `pending_jobs`
+ * could never reach zero, and the terminal `then`/`finally` callbacks never
+ * fired — the same race `recordBatchJobCompletion` was given an atomic
+ * decrement for, on the way in rather than on the way out.
+ *
+ * The payload assertions below are behavioural: they run the real function and
+ * inspect what it hands the driver. They deliberately do NOT mock
+ * `@stacksjs/database` to reach further. `mock.module` is process-global and
+ * bun runs a package's test files in one process, so mocking a module this
+ * widely used takes the rest of the package down with it — tried, and the queue
+ * suite went from 299 passing to 202.
+ */
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { batchCounterIncrements } from '../src/batch'
+
+/** Stands in for the query builder's tagged template, keeping the literal SQL. */
+interface SqlFragment { text: string, values: unknown[] }
+
+const sql = (strings: TemplateStringsArray, ...values: unknown[]): SqlFragment => ({
+  text: strings.raw.join('?'),
+  values,
+})
+
+describe('batch counter increments are relative, not computed (#2282 item 3)', () => {
+  it('asks the database to add, rather than supplying a total', () => {
+    const set = batchCounterIncrements(sql as any, 2) as { total_jobs: SqlFragment, pending_jobs: SqlFragment }
+
+    // A bare number here is the old read-modify-write, and therefore lossy
+    // whenever two adds overlap.
+    expect(typeof set.total_jobs).not.toBe('number')
+    expect(typeof set.pending_jobs).not.toBe('number')
+
+    expect(set.total_jobs.text).toBe('total_jobs + ?')
+    expect(set.pending_jobs.text).toBe('pending_jobs + ?')
+    expect(set.total_jobs.values).toEqual([2])
+    expect(set.pending_jobs.values).toEqual([2])
+  })
+
+  it('carries the delta through rather than a resolved total', () => {
+    const set = batchCounterIncrements(sql as any, 7) as { total_jobs: SqlFragment }
+    expect(set.total_jobs.values).toEqual([7])
+  })
+
+  it('moves both counters together, so pending can still reach zero', () => {
+    const set = batchCounterIncrements(sql as any, 3) as Record<string, SqlFragment>
+    expect(Object.keys(set).sort()).toEqual(['pending_jobs', 'total_jobs'])
+    expect(set.total_jobs.values).toEqual(set.pending_jobs.values)
+  })
+})
+
+/**
+ * The wiring, pinned separately. Proving `add` reaches the atomic path needs a
+ * database, so what is checkable here is that it no longer does the arithmetic
+ * itself. Kept narrow on purpose: it asserts the absence of the specific
+ * lossy expression, not the presence of any particular replacement.
+ */
+describe('DispatchedBatch.add no longer computes its own totals (#2282 item 3)', () => {
+  const src = readFileSync(resolve(__dirname, '..', 'src', 'batch.ts'), 'utf-8')
+  const add = src.slice(src.indexOf('async add('), src.indexOf('async add(') + 1200)
+
+  it('does not read a total and write it back', () => {
+    expect(add).not.toMatch(/record\.total_jobs \+ batchableJobs\.length/)
+    expect(add).not.toMatch(/record\.pending_jobs \+ batchableJobs\.length/)
+  })
+
+  it('goes through the atomic increment instead', () => {
+    expect(add).toContain('incrementBatchCounters(this.id, batchableJobs.length)')
+  })
+
+  it('increments the redis hash in place, rather than rewriting it', () => {
+    // Redis stores a batch as a hash, so HINCRBY is its equivalent of the SQL
+    // `column + n`; `hset` of a computed value would carry the same race.
+    const fn = src.slice(src.indexOf('async function incrementBatchCounters'))
+    expect(fn.slice(0, 800)).toContain('hincrby')
+  })
+})

--- a/storage/framework/core/queue/tests/graceful-shutdown-wiring.test.ts
+++ b/storage/framework/core/queue/tests/graceful-shutdown-wiring.test.ts
@@ -49,4 +49,35 @@ describe('queue worker graceful-shutdown wiring (#1984)', () => {
       expect(workCmd).toContain('PARENT_BACKSTOP_MS = SHUTDOWN_GRACE_MS + 5_000')
     })
   })
+
+  // stacksjs/stacks#2282 item 5 — the drain above awaits the `inFlightJobs`
+  // set, and ONLY the database path ever added to it. Under the Redis driver
+  // the set stayed empty, so the drain had nothing to wait for and returned
+  // immediately: a deploy or SIGTERM killed Redis jobs mid-run, while the
+  // identical deploy against the database driver waited for them.
+  //
+  // Pinned as wiring rather than behaviour for the same reason as the rest of
+  // this file: proving a job survives a signal needs a live Redis and a real
+  // process to kill, neither of which a unit test has. What is checkable is
+  // that both drivers register their handler through the same tracker.
+  describe('both drivers register their handler with the drain (#2282 item 5)', () => {
+    const worker = read('../src/worker.ts')
+
+    it('tracks the redis handler, not just the database one', () => {
+      expect(worker).toMatch(/queue\.process\(\s*concurrency\s*,\s*\(?bunJob[^)]*\)?\s*(:\s*any\s*)?=>\s*trackInFlight\(/)
+    })
+
+    it('keeps the database path tracked too', () => {
+      expect(worker).toContain('await trackInFlight(processJob(job))')
+    })
+
+    it('wraps at registration, so a throw still reaches bun-queue retry logic', () => {
+      // `trackInFlight` returns the promise it was given. Registering
+      // `() => trackInFlight(handler(job))` therefore hands bun-queue the same
+      // promise it would have had, rejection included. Swallowing it here
+      // (e.g. `.catch(() => {})`) would silently disable Redis retries.
+      const registration = worker.slice(worker.indexOf('queue.process(concurrency'))
+      expect(registration.slice(0, 200)).not.toContain('.catch(')
+    })
+  })
 })


### PR DESCRIPTION
#2282 items **3** and **5**. Both are the second half of a mechanism that only ever got its first half.

## Item 3 — `DispatchedBatch.add` was read-modify-write

It read the record, added in JavaScript, wrote the absolute result back. Two callers adding to the same in-flight batch at the same instant both read total=N and both wrote total=N+their own count, so **one add vanished**. The batch then reported fewer jobs than it was running, `pending_jobs` could never reach zero, and the terminal `then`/`finally` callbacks never fired.

`recordBatchJobCompletion` was already given an atomic decrement for exactly this race on the way *out* (`GREATEST(pending_jobs - 1, 0)`). This is the same treatment on the way *in*.

Both drivers manage it without a read: SQL takes `column + n` in the SET clause, and Redis has `HINCRBY` on the hash a batch is stored as. Neither path computes a total in-process any more.

## Item 5 — Redis jobs were invisible to the graceful-shutdown drain

`stopProcessor` awaits the `inFlightJobs` set, and `trackInFlight` had **exactly one call site**: the database path. Under Redis the set stayed empty, so #1984's drain had nothing to wait for and returned immediately. A deploy or SIGTERM killed Redis jobs mid-run, while the identical deploy against the database driver waited for them.

Wrapped at the registration rather than inside the handler, so the tracked promise is the same one bun-queue awaits and a throw still reaches its retry logic unchanged.

## On the tests

**Both are verified to fail against the previous code**, not merely to pass against the new one.

The counter assertions are behavioural: they call the real function and inspect what it hands the driver, checking the expressions are *relative* rather than numbers this process resolved.

They deliberately stop short of mocking `@stacksjs/database` to reach further, and that is worth recording. `mock.module` is process-global and bun runs a package's test files in one process, so mocking a module this widely used **takes the rest of the package down with it** — I tried it, and the queue suite went from 299 passing to 202. `batchCounterIncrements` is exported as a small pure seam so the shape stays assertable without that.

The Redis drain is pinned as wiring in `graceful-shutdown-wiring.test.ts`, beside the #1984 checks it extends, for the reason that file already states: proving a job survives a signal needs a live Redis and a real process to kill.

## Verification

| | |
|---|---|
| queue suite | **305 pass / 1 fail** (baseline 299 / 1) |
| the 1 fail | `redis-contract.test.ts` against a local Redis reporting `MISCONF`; passes in CI, which runs a healthy service |
| lint | unchanged, 18 errors / 42 warnings, no new findings in these files |
| typecheck | unchanged at 13, none in queue |

Items 1, 2 and 4 of #2282 remain open. Item 1 asks for a semantics decision rather than an implementation, and item 4 needs a fence-token design.