### PR TITLE
fix(queue): spread retries so an outage cannot resynchronise the herd

### DIFF
--- a/storage/framework/core/queue/src/worker.ts
+++ b/storage/framework/core/queue/src/worker.ts
@@ -67,6 +67,54 @@ function getReservationTtlSec(): number {
 }
 
 /**
+ * How far retries are spread past their backoff delay, as a fraction of it.
+ * Override with `STACKS_QUEUE_RETRY_JITTER`; `0` disables spreading entirely.
+ * Clamped to 0..1.
+ */
+function getRetryJitterRatio(): number {
+  const raw = process.env.STACKS_QUEUE_RETRY_JITTER
+  if (raw === undefined)
+    return 0.2
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n < 0)
+    return 0.2
+  return Math.min(n, 1)
+}
+
+/**
+ * Spread a retry across a window so a downstream outage does not resynchronise
+ * every failed job onto the same second.
+ *
+ * Without this, a provider going down for a minute failed N jobs at once, and
+ * `backoff[0]` sent all N back at once, and they failed together again: the
+ * herd never breaks up, and each wave hits the recovering dependency harder
+ * than the last (stacksjs/stacks#2282 item 2).
+ *
+ * The spread is **additive only**. Classic full jitter picks uniformly from
+ * `[0, delay]`, which retries sooner than asked, and `backoff` here is
+ * frequently a rate-limit accommodation ("wait 60s, the API says so") rather
+ * than a politeness hint. Retrying at 12s because a coin came up short would
+ * be a behaviour change with a real failure mode, so the window opens after
+ * the configured delay, never before it.
+ *
+ * A delay of zero stays zero: someone who asked for an immediate retry gets
+ * one.
+ *
+ * Exported for testing with a supplied `random`, since asserting on a spread
+ * needs a deterministic source.
+ */
+export function applyRetryJitter(
+  delaySeconds: number,
+  ratio: number,
+  random: () => number = Math.random,
+): number {
+  if (!(delaySeconds > 0) || ratio <= 0)
+    return delaySeconds
+
+  return Math.round(delaySeconds + delaySeconds * ratio * random())
+}
+
+/**
  * Sweep frequency — how often the database loop checks for orphaned
  * reservations. Default 60s; override via
  * `STACKS_QUEUE_SWEEP_INTERVAL_SEC`. Cheap (one indexed UPDATE), so
@@ -606,6 +654,10 @@ async function processJob(job: any): Promise<void> {
       retryDelay = Number(retryDelay)
       if (!Number.isFinite(retryDelay) || retryDelay < 0)
         retryDelay = 30
+
+      // Spread the retry so a downstream outage doesn't send every job it
+      // failed back at the same instant. See applyRetryJitter.
+      retryDelay = applyRetryJitter(retryDelay, getRetryJitterRatio())
 
       log.info(`[Queue] Job ${jobId} will be retried in ${retryDelay}s (attempt ${currentAttempts}/${maxAttempts})`)
       try {

--- a/storage/framework/core/queue/tests/retry-jitter.test.ts
+++ b/storage/framework/core/queue/tests/retry-jitter.test.ts
@@ -1,0 +1,69 @@
+/**
+ * stacksjs/stacks#2282 item 2 — retry backoff had no randomisation.
+ *
+ * A provider going down for a minute fails N jobs at once, `backoff[0]` sends
+ * all N back at once, and they fail together again. The herd never breaks up,
+ * and each wave hits the recovering dependency harder than the last.
+ *
+ * `applyRetryJitter` takes its randomness as an argument precisely so this can
+ * be asserted rather than sampled: every case below is deterministic.
+ */
+import { describe, expect, it } from 'bun:test'
+import { applyRetryJitter } from '../src/worker'
+
+/** A `random` that walks a fixed sequence, so a "spread" is checkable. */
+function sequence(values: number[]): () => number {
+  let i = 0
+  return () => values[i++ % values.length]!
+}
+
+describe('retry jitter (#2282 item 2)', () => {
+  it('never retries EARLIER than the configured backoff', () => {
+    // The property that matters. `backoff` is often a rate-limit
+    // accommodation, so classic full jitter over [0, delay] would be a
+    // behaviour change with a real failure mode.
+    for (const r of [0, 0.01, 0.5, 0.99, 1]) {
+      expect(applyRetryJitter(60, 0.2, () => r)).toBeGreaterThanOrEqual(60)
+    }
+  })
+
+  it('stays within the configured window above it', () => {
+    // ratio 0.2 on 60s => 60..72
+    expect(applyRetryJitter(60, 0.2, () => 0)).toBe(60)
+    expect(applyRetryJitter(60, 0.2, () => 1)).toBe(72)
+    expect(applyRetryJitter(60, 0.2, () => 0.5)).toBe(66)
+  })
+
+  it('actually separates a herd that shared one delay', () => {
+    const random = sequence([0, 0.25, 0.5, 0.75, 1])
+    const herd = Array.from({ length: 5 }, () => applyRetryJitter(40, 0.5, random))
+
+    // The point of the change: five jobs that would all have come back at 40s
+    // now come back at five different times.
+    expect(new Set(herd).size).toBe(5)
+    expect(Math.min(...herd)).toBe(40)
+    expect(Math.max(...herd)).toBe(60)
+  })
+
+  it('leaves an explicit immediate retry immediate', () => {
+    expect(applyRetryJitter(0, 0.2, () => 1)).toBe(0)
+  })
+
+  it('is a no-op when spreading is disabled', () => {
+    expect(applyRetryJitter(30, 0, () => 1)).toBe(30)
+  })
+
+  it('returns whole seconds, since available_at is a unix timestamp', () => {
+    for (const r of [0.111, 0.333, 0.777]) {
+      const out = applyRetryJitter(37, 0.3, () => r)
+      expect(Number.isInteger(out)).toBe(true)
+    }
+  })
+
+  it('does not turn a negative or non-finite delay into a retry storm', () => {
+    // The clamp upstream should prevent these, but the spread must not be the
+    // thing that resurrects them.
+    expect(applyRetryJitter(-5, 0.2, () => 1)).toBe(-5)
+    expect(applyRetryJitter(Number.NaN, 0.2, () => 1)).toBeNaN()
+  })
+})


### PR DESCRIPTION
#2282 **item 2**.

Retry backoff was `backoff[i]` / a fixed number / the 30s default, clamped, with **no randomisation**. So a provider going down for a minute failed N jobs at once, `backoff[0]` sent all N back at once, and they failed together again. The herd never breaks up, and every wave lands on the recovering dependency at full width.

The backoff was doing its job for a single job and nothing at all for a fleet.

## Additive, deliberately

Classic full jitter picks uniformly from `[0, delay]`. That retries **sooner** than asked, and `backoff` here is frequently a rate-limit accommodation ("wait 60s, the API said so") rather than a politeness hint. Coming back at 12s because a coin came up short would be a behaviour change with a real failure mode.

So the window opens *after* the configured delay and never before it:

| delay | ratio | window |
|---|---|---|
| 60s | 0.2 (default) | 60-72s |
| 40s | 0.5 | 40-60s |
| 0s | any | 0s, an explicit immediate retry stays immediate |

`STACKS_QUEUE_RETRY_JITTER` overrides the ratio; `0` disables it, which also gives ops a way back to deterministic timing.

## Tests

`applyRetryJitter` takes its randomness as an argument, so these assert behaviour rather than sampling it. The herd case walks a fixed sequence and checks that five jobs which all shared one delay come back at five *different* times, bounded by the window.

Also covered: never earlier than configured (the property that matters), whole seconds since `available_at` is a unix timestamp, and that a negative or NaN delay is not turned into a retry storm by the spread.

**Verified to fail against the previous code.**

## Verification

| | |
|---|---|
| queue suite | **312 pass / 1 fail** (baseline 305 / 1) |
| the 1 fail | `redis-contract.test.ts` against a local Redis reporting `MISCONF`; passes in CI |
| lint | unchanged, 18 errors / 42 warnings |
| typecheck | unchanged at 13, none in queue |

After this, #2282 has items **1** and **4** left. Item 1 asks to "record per-attempt or document the semantics", which is a decision rather than an implementation, and item 4 needs a fence-token design.