### PR TITLE
fix(auth): stop confirming whether an email is registered, by default

### DIFF
--- a/storage/framework/core/auth/src/register.ts
+++ b/storage/framework/core/auth/src/register.ts
@@ -11,16 +11,26 @@ import { isUniqueViolation } from './rbac-store-bqb'
 /**
  * The error thrown when a registration collides with an existing email.
  *
- * By default it says so plainly (friendlier UX). With
- * `config.auth.registration.preventEnumeration` enabled it returns a generic
- * 422 that an attacker can't use to confirm an address is registered
- * (stacksjs/stacks#1985). Timing is already equalized (the bcrypt hash runs
- * before any existence check), so the response body was the last oracle.
+ * Generic by default: a 422 that does not say whether the address is
+ * registered. Timing was already equalized in #1985 (the bcrypt hash runs
+ * before any existence check), which left the response body as the last
+ * remaining oracle, and `409 Email already exists` states the answer outright.
+ *
+ * The default flipped in stacksjs/stacks#2281. #1985 shipped this seam behind
+ * an opt-in flag, which meant every scaffolded app served an account-existence
+ * oracle until someone went looking for a setting they had no reason to know
+ * about. A framework should not need to be configured into not leaking; the
+ * friendlier message is the thing worth opting IN to, because choosing it means
+ * accepting that anyone can enumerate your users.
+ *
+ * Set `config.auth.registration.preventEnumeration = false` to get
+ * `409 Email already exists` back. Only `false` does it: an unset flag now
+ * means protected.
  */
 function duplicateEmailError(): HttpError {
-  if ((config.auth as any)?.registration?.preventEnumeration)
-    return new HttpError(422, 'Registration could not be completed. Please check your details and try again.')
-  return new HttpError(409, 'Email already exists')
+  if ((config.auth as any)?.registration?.preventEnumeration === false)
+    return new HttpError(409, 'Email already exists')
+  return new HttpError(422, 'Registration could not be completed. Please check your details and try again.')
 }
 
 // RFC 5322-ish: a single @ with at least one dot in the domain. Tighter than

--- a/storage/framework/core/auth/tests/register.test.ts
+++ b/storage/framework/core/auth/tests/register.test.ts
@@ -33,6 +33,10 @@ import { HttpError } from '@stacksjs/error-handling'
 // the full ORM/model graph this file exists to avoid.
 const realDatabase = { ...await import('@stacksjs/database') }
 const realSecurity = { ...await import('@stacksjs/security') }
+// Read at module scope (top-level await is fine here, inside a `describe` it is
+// not). #2281's cases toggle `auth.registration` on the live config object,
+// which `duplicateEmailError` reads per call.
+const realConfig = await import('@stacksjs/config')
 
 afterAll(() => {
   mock.module('@stacksjs/database', () => realDatabase)
@@ -171,15 +175,64 @@ describe('register() input validation (unchanged 422 guards)', () => {
 })
 
 describe('register() timing-oracle hardening (#1953)', () => {
-  test('duplicate email → 409, and bcrypt ran BEFORE the existence check', async () => {
+  test('duplicate email is rejected, and bcrypt ran BEFORE the existence check', async () => {
     scenario.existingRow = { id: 1, email: 'taken@example.com' }
 
     await expect(register({ email: 'taken@example.com', password: 'long-enough-pw', name: 'X' } as any))
-      .rejects.toMatchObject({ status: 409, message: 'Email already exists' })
+      .rejects.toMatchObject({ status: 422 })
 
     // The regression: pre-fix this was ['select'] with no 'hash' —
     // registered emails returned in ~1ms while fresh ones paid bcrypt.
     expect(ops).toEqual(['hash', 'select'])
+  })
+})
+
+// stacksjs/stacks#2281 — #1985 built the generic-response seam but left it
+// opt-in, so every scaffolded app served `409 Email already exists`: an
+// account-existence oracle for anyone who wanted to enumerate users. Timing
+// was equalized above; the response body was the last channel open.
+describe('register() does not confirm whether an address is registered (#2281)', () => {
+  const authConfig = realConfig.config.auth as any
+  const original = authConfig?.registration
+
+  afterAll(() => {
+    if (authConfig)
+      authConfig.registration = original
+  })
+
+  test('an unset flag means protected, not exposed', async () => {
+    if (authConfig)
+      delete authConfig.registration
+    scenario.existingRow = { id: 1, email: 'taken@example.com' }
+
+    // The decisive assertion: the message must not distinguish this from any
+    // other rejection. `409 Email already exists` is the answer to "does this
+    // account exist", handed over on request.
+    await expect(register({ email: 'taken@example.com', password: 'long-enough-pw', name: 'X' } as any))
+      .rejects.toMatchObject({ status: 422 })
+
+    await expect(register({ email: 'taken@example.com', password: 'long-enough-pw', name: 'X' } as any))
+      .rejects.not.toMatchObject({ message: 'Email already exists' })
+  })
+
+  test('explicitly disabling it brings the specific 409 back', async () => {
+    if (authConfig)
+      authConfig.registration = { preventEnumeration: false }
+    scenario.existingRow = { id: 1, email: 'taken@example.com' }
+
+    await expect(register({ email: 'taken@example.com', password: 'long-enough-pw', name: 'X' } as any))
+      .rejects.toMatchObject({ status: 409, message: 'Email already exists' })
+  })
+
+  test('only an explicit false disables it — a truthy or absent value stays protected', async () => {
+    for (const registration of [undefined, {}, { preventEnumeration: true }]) {
+      if (authConfig)
+        authConfig.registration = registration as any
+      scenario.existingRow = { id: 1, email: 'taken@example.com' }
+
+      await expect(register({ email: 'taken@example.com', password: 'long-enough-pw', name: 'X' } as any))
+        .rejects.toMatchObject({ status: 422 })
+    }
   })
 })
 
@@ -214,11 +267,15 @@ describe('register() transactional create (#1953)', () => {
     ['MySQL errno 1062', { errno: 1062 }],
     ['Postgres 23505', { code: '23505' }],
   ] as const) {
-    test(`lost race — insert throws ${label} → mapped to 409`, async () => {
+    // Routed through the same `duplicateEmailError` as the pre-check path, so
+    // the two are indistinguishable from outside. If the race path answered
+    // 409 while the pre-check answered 422, losing the race would itself be
+    // the oracle (stacksjs/stacks#2281).
+    test(`lost race — insert throws ${label} → mapped to a duplicate rejection`, async () => {
       scenario.insertError = err
 
       await expect(register({ email: 'racer@example.com', password: 'long-enough-pw', name: 'X' } as any))
-        .rejects.toMatchObject({ status: 409, message: 'Email already exists' })
+        .rejects.toMatchObject({ status: 422 })
     })
   }
 

--- a/storage/framework/core/types/src/auth.ts
+++ b/storage/framework/core/types/src/auth.ts
@@ -215,13 +215,20 @@ export interface AuthOptions {
    */
   registration?: {
     /**
-     * When true, a duplicate-email registration returns a generic error
-     * instead of "Email already exists", so the endpoint no longer confirms
-     * whether an address is registered. Off by default (the specific message
-     * is friendlier). Reduces the disclosure; a fully non-enumerable flow
-     * (always respond success + notify the existing account out-of-band) is
-     * a larger, separate opt-in.
-     * @default false
+     * Whether a duplicate-email registration returns a generic error instead
+     * of "Email already exists".
+     *
+     * **On by default** (stacksjs/stacks#2281). Set it to `false` to get the
+     * specific 409 back, accepting that the endpoint then confirms whether any
+     * given address is registered. Only an explicit `false` disables it; unset
+     * means protected.
+     *
+     * This closes the response-body oracle. Timing was equalized separately in
+     * #1985. A fully non-enumerable flow — always respond success and notify
+     * the existing account out-of-band — is a larger, separate opt-in, still
+     * open as the second half of #2281.
+     *
+     * @default true
      */
     preventEnumeration?: boolean
   }


### PR DESCRIPTION
#2281.

#1985 built the generic-response seam and left it **opt-in**, so every scaffolded app answered a duplicate registration with `409 Email already exists` — an account-existence oracle for anyone who cared to enumerate users. Timing was equalized in #1985; the response body was the last channel still open, and it states the answer outright.

## The call I made

Flipped to on. A framework should not need to be *configured into* not leaking, and the friendlier specific message is the thing worth opting **in** to, because choosing it means accepting that anyone can enumerate your users.

Only an explicit `config.auth.registration.preventEnumeration = false` restores the 409. Unset means protected.

**This is breaking** for anyone matching on the 409 status or its message. The escape hatch is one config line, and it is documented on the type.

## The race path matters too

`register()` rejects duplicates from two places: the in-transaction pre-check, and the unique-violation catch when it loses a race. Both route through the same `duplicateEmailError`, so they are indistinguishable from outside. Had the race path kept answering 409 while the pre-check answered 422, **losing the race would itself have been the oracle** — a slower but perfectly usable one.

## Verification

| | |
|---|---|
| auth suite | **289 pass / 0 fail** (was 286; three cases added) |
| mock.module leakage | none — full-package run, not just the one file |

New cases: an unset flag means protected, an explicit `false` brings the 409 back, and a truthy-or-absent value stays protected.

## Still open

The second half of #2281: whether the uniform response should be the #1953-proposed 2xx "verification email sent" shape rather than a 422. That is a larger API change and wants its own decision — flagging rather than bundling.