### PR TITLE
fix(config): stop an app config restating what the library already defaults

### DIFF
--- a/config/query-builder.ts
+++ b/config/query-builder.ts
@@ -19,7 +19,6 @@ export default {
   dialect,
   database: databaseConfig,
   snapshotDir: 'storage/framework/database',
-  migrationDir: 'database/migrations',
   timestamps: {
     createdAt: 'created_at',
     updatedAt: 'updated_at',
@@ -70,4 +69,13 @@ export default {
     column: 'deleted_at',
     defaultFilter: true,
   },
-} satisfies QueryBuilderConfig
+  // `Partial`, not the bare config type. `QueryBuilderConfig` is the RESOLVED
+  // shape the library reads after merging its own defaults, so every field on
+  // it is required — and declaring an app config against it means any field
+  // upstream adds becomes a compile error here until someone restates a value
+  // the library already defaults. That is how `migrationDir` and `snapshotDir`
+  // ended up hard-coded in this file: not because the app wanted to override
+  // them, but to satisfy a type. `setConfig()` has always taken
+  // `Partial<QueryBuilderConfig>`, so this matches what the library actually
+  // accepts.
+} satisfies Partial<QueryBuilderConfig>


### PR DESCRIPTION
Chris on c7ededfc:

> should not be required. nothing in those configs should ever be required and always default to sensible defaults

Agreed, and that commit fixed the symptom. This is the cause.

## Why a field kept becoming required

`config/query-builder.ts` was declared `satisfies QueryBuilderConfig`. That is the **resolved** shape the library reads *after* merging its own defaults, so all twelve of its top-level fields are required:

```
REQUIRED  verbose, dialect, database, snapshotDir, migrationDir, timestamps,
          pagination, aliasing, relations, transactionDefaults, sql, features
optional  browser, debug, hooks, softDeletes, sqlite, vitess
```

So every field upstream adds becomes a compile error in this repo until somebody restates a value the library already supplies. That is the whole story of both `migrationDir` and `snapshotDir` landing in this file — not an override anyone wanted, just a type being satisfied. bun-query-builder 0.2.25 dropping the `?` from `migrationDir` (types.d.ts:233) is what triggered it this time.

`setConfig()` has **always** taken `Partial<QueryBuilderConfig>`, so the library already treats app input as partial. This declares the file the way the library actually consumes it.

## Verification

`buddy migrate:status` output is **byte-identical before and after** apart from its timestamp, so the corpus still resolves to `database/migrations`. It has three independent defaults for that value and the app was duplicating all of them:

- `defaultConfig.migrationDir = 'database/migrations'`
- `getSqlDirectory(workspaceRoot, migrationDir = 'database/migrations')`
- `const configured = migrationDir || 'database/migrations'`

Repo typecheck unchanged at 13. No lint findings in the file.

`snapshotDir` stays, because `storage/framework/database` is a genuine override rather than a restatement of the library's `.qb` default.

## The durable half

This makes *this* repo immune. Every other consumer still declares against the resolved type and will hit the same thing on the next added field. The package should export a user-facing partial config type; filing that upstream separately.