### PR TITLE
fix(upgrade): report when the vendored framework defaults fall behind

### DIFF
--- a/docs/guide/buddy/upgrade.md
+++ b/docs/guide/buddy/upgrade.md
@@ -32,7 +32,7 @@ buddy upgrade:<type> [options]
 | `-v, --version <version>` | Install a specific version (e.g., 0.70.23) |
 | `--canary` | Upgrade to the latest canary (bleeding-edge `main`) build |
 | `--stable` | Switch to the latest vetted stable release |
-| `--dry-run` | Preview which dependencies would change without writing or installing |
+| `--dry-run` | Preview which dependencies and managed project files would change, without writing or installing |
 | `-f, --force` | Force re-download, bypassing cache and version checks |
 | `--from <path>` | Sync from a local stacks checkout (e.g. ~/Code/stacks), skips GitHub |
 | `--no-postinstall` | Skip post-sync hooks (auto-imports, bun install, migrate) |
@@ -47,6 +47,34 @@ Run without a subcommand to upgrade the Stacks framework to the latest version:
 ```bash
 buddy upgrade
 ```
+
+### Why `bun install` is not enough
+
+A package-managed app keeps a copy of the framework scaffold in
+`storage/framework/defaults`, and that copy is the one that runs: the generated
+auto-import barrel reaches into it by relative path.
+
+`buddy upgrade` is the only thing that writes it. Bumping `stacks` in
+`package.json` and running `bun install`, which is the ordinary way to move a
+dependency, advances `node_modules/@stacksjs/defaults` and leaves the vendored
+tree exactly where it was. The app then runs framework code from whichever
+release it was last synced from, against a current install.
+
+Three things now report the gap:
+
+- `buddy dev` prints a one-line warning at startup when the two disagree.
+- `buddy doctor` has a **Framework defaults** check with the file counts.
+- `buddy upgrade --dry-run` previews the scaffold changes, not just the
+  dependency bumps.
+
+Each sync stamps `storage/framework/defaults/.stacks-sync.json` with the version
+it copied from, which is what those checks read. A tree synced before that stamp
+existed reports as unstamped until the next `buddy upgrade`.
+
+Note that the sync also removes files under `storage/framework/defaults` that
+the package no longer ships, so it is not purely additive. The tree is
+gitignored, so `git checkout` cannot undo it. Keep customizations in `app/`,
+which overrides the defaults and is never touched by the sync.
 
 ### Upgrade All
 

--- a/storage/framework/core/actions/src/index.ts
+++ b/storage/framework/core/actions/src/index.ts
@@ -27,6 +27,18 @@ export { formatProject, lintFix, lintProject } from './lint/lint'
 // and never exits, so the command owns rendering and the exit code.
 export { DEFAULT_STX_LINT_CONFIG, loadStxLintConfig, runStxLint } from './lint/stx-gate'
 export type { StxLintConfig, StxLintReport, StxLintResult } from './lint/stx-gate'
+// Provenance of the vendored framework defaults. Exported from
+// ./upgrade/package-project — the pure module — so importing this barrel never
+// pulls ./upgrade/index, which runs an upgrade on import.
+export {
+  DEFAULTS_SYNC_MARKER,
+  defaultsPackagePath,
+  inspectDefaultsProvenance,
+  installedDefaultsVersion,
+  measureDefaultsDrift,
+  summarizeStructureChanges,
+} from './upgrade/package-project'
+export type { DefaultsProvenance, DefaultsSkew, DefaultsSyncMarker, ProjectStructureChange } from './upgrade/package-project'
 export * from './setup'
 
 // makeFactory,

--- a/storage/framework/core/actions/src/upgrade/package-project.ts
+++ b/storage/framework/core/actions/src/upgrade/package-project.ts
@@ -1,5 +1,5 @@
-import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
-import { dirname, join, relative } from 'node:path'
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { dirname, join, relative, sep } from 'node:path'
 
 export interface ProjectStructureChange {
   path: string
@@ -8,6 +8,18 @@ export interface ProjectStructureChange {
 
 interface PackageProjectOptions {
   dryRun?: boolean
+  /**
+   * Treat same-size files as equal instead of reading both sides.
+   *
+   * A full content comparison of the defaults tree costs ~75ms warm and ~200ms
+   * cold, which is too much to spend on every `buddy dev`. Sizes alone still
+   * catch the drift that matters, because a tree that is releases behind
+   * differs in which files exist long before it differs only in bytes.
+   *
+   * Only meaningful together with `dryRun`: nothing should be copied on the
+   * strength of a size match.
+   */
+  shallow?: boolean
 }
 
 interface ProjectPackageJson {
@@ -25,9 +37,17 @@ const DEFAULTS_PACKAGE_IGNORES = new Set([
   'tests',
 ])
 
+/**
+ * Provenance stamp written next to the synced tree. The sync is the only thing
+ * that writes `storage/framework/defaults`, so this is the only record of which
+ * release the tree came from.
+ */
+export const DEFAULTS_SYNC_MARKER = '.stacks-sync.json'
+
 const LOCAL_DEFAULT_IGNORES = new Set([
   '.DS_Store',
   '.discovered-models.json',
+  DEFAULTS_SYNC_MARKER,
   'dist',
   'node_modules',
 ])
@@ -51,7 +71,7 @@ const SUPPORT_FILES: Array<{ source: string, target: string, executable?: boolea
   },
 ]
 
-function sameFile(left: string, right: string): boolean {
+function sameFile(left: string, right: string, shallow = false): boolean {
   if (!existsSync(left) || !existsSync(right))
     return false
 
@@ -59,6 +79,9 @@ function sameFile(left: string, right: string): boolean {
   const rightStat = statSync(right)
   if (leftStat.size !== rightStat.size)
     return false
+
+  if (shallow)
+    return true
 
   return readFileSync(left).equals(readFileSync(right))
 }
@@ -71,7 +94,7 @@ function copyFileIfChanged(
   options: PackageProjectOptions,
   executable = false,
 ): void {
-  if (sameFile(source, target)) {
+  if (sameFile(source, target, options.shallow)) {
     if (executable && !options.dryRun)
       chmodSync(target, 0o755)
     return
@@ -173,7 +196,161 @@ export function syncPackageProjectFiles(
       rmSync(target, { force: true })
   }
 
+  if (!options.dryRun)
+    stampDefaultsSync(targetDefaults, defaultsPackageRoot)
+
   return changes
+}
+
+/** Version field of a package manifest, or null when it cannot be read. */
+function packageVersion(packageRoot: string): string | null {
+  try {
+    const version = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))?.version
+    return typeof version === 'string' ? version : null
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * Record which release the tree was copied from.
+ *
+ * Without this the vendored tree carries no version of its own, so an app that
+ * moves `stacks` forward through `package.json` and `bun install` (which never
+ * runs the sync) has no way to notice that its framework defaults stayed put.
+ */
+function stampDefaultsSync(targetDefaults: string, defaultsPackageRoot: string): void {
+  const version = packageVersion(defaultsPackageRoot)
+  if (!version)
+    return
+
+  const marker: DefaultsSyncMarker = { version, syncedAt: new Date().toISOString() }
+  mkdirSync(targetDefaults, { recursive: true })
+  writeFileSync(join(targetDefaults, DEFAULTS_SYNC_MARKER), `${JSON.stringify(marker, null, 2)}\n`)
+}
+
+export interface DefaultsSyncMarker {
+  /** `@stacksjs/defaults` version the tree was copied from. */
+  version: string
+  /** ISO-8601 instant of the copy. */
+  syncedAt: string
+}
+
+/**
+ * - `not-applicable` — nothing to compare: no vendored tree, no installed
+ *   package, or a framework checkout where the tree is the source rather than a
+ *   copy of it.
+ * - `unstamped` — the tree predates provenance stamping, so only a file
+ *   comparison can say whether it is current.
+ */
+export type DefaultsProvenance = 'not-applicable' | 'current' | 'stale' | 'unstamped'
+
+export interface DefaultsSkew {
+  status: DefaultsProvenance
+  /** Version of the installed `@stacksjs/defaults`. */
+  installed: string | null
+  /** Version the vendored tree was last synced from. */
+  vendored: string | null
+  syncedAt: string | null
+}
+
+const NOT_APPLICABLE: DefaultsSkew = { status: 'not-applicable', installed: null, vendored: null, syncedAt: null }
+
+/** Where `syncPackageProjectFiles` reads from, given a project root. */
+export function defaultsPackagePath(projectRoot: string): string {
+  return join(projectRoot, 'node_modules/@stacksjs/defaults')
+}
+
+/** Version of the installed `@stacksjs/defaults`, or null when absent. */
+export function installedDefaultsVersion(projectRoot: string): string | null {
+  return packageVersion(defaultsPackagePath(projectRoot))
+}
+
+function isInside(child: string, parent: string): boolean {
+  const resolved = realpathSync(child)
+  return resolved === parent || resolved.startsWith(`${parent}${sep}`)
+}
+
+/**
+ * Compare the vendored framework defaults against the installed package.
+ *
+ * Cheap by construction: two manifest reads and one marker read. Callers that
+ * need a file-level answer (there is none when the tree is `unstamped`) run
+ * {@link measureDefaultsDrift}.
+ */
+export function inspectDefaultsProvenance(projectRoot: string): DefaultsSkew {
+  const targetDefaults = join(projectRoot, 'storage/framework/defaults')
+  const packageRoot = defaultsPackagePath(projectRoot)
+
+  if (!existsSync(targetDefaults) || !existsSync(join(packageRoot, 'package.json')))
+    return NOT_APPLICABLE
+
+  // A framework checkout carries the framework's own source, and there the
+  // vendored tree is what `@stacksjs/defaults` is built *from* rather than a
+  // copy of it. Comparing the two reports drift that means nothing.
+  if (existsSync(join(projectRoot, 'storage/framework/core/buddy/package.json')))
+    return NOT_APPLICABLE
+
+  // Same reasoning for a linked checkout: an installed package resolves inside
+  // node_modules, while a workspace or `bun link` reference resolves back out
+  // to source the developer is editing.
+  try {
+    if (!isInside(packageRoot, join(realpathSync(projectRoot), 'node_modules')))
+      return NOT_APPLICABLE
+  }
+  catch {
+    return NOT_APPLICABLE
+  }
+
+  const installed = packageVersion(packageRoot)
+  if (!installed)
+    return NOT_APPLICABLE
+
+  let marker: DefaultsSyncMarker | null = null
+  try {
+    const raw = JSON.parse(readFileSync(join(targetDefaults, DEFAULTS_SYNC_MARKER), 'utf8'))
+    if (typeof raw?.version === 'string')
+      marker = { version: raw.version, syncedAt: typeof raw.syncedAt === 'string' ? raw.syncedAt : '' }
+  }
+  catch {
+    // No marker, or an unreadable one. Either way the tree is unstamped.
+  }
+
+  if (!marker)
+    return { status: 'unstamped', installed, vendored: null, syncedAt: null }
+
+  return {
+    status: marker.version === installed ? 'current' : 'stale',
+    installed,
+    vendored: marker.version,
+    syncedAt: marker.syncedAt || null,
+  }
+}
+
+/**
+ * What a sync would change right now, without changing it.
+ *
+ * Returns null when there is no installed package to compare against. Pass
+ * `shallow` for a boot-time probe; leave it off for an exact answer.
+ */
+export function measureDefaultsDrift(
+  projectRoot: string,
+  options: { shallow?: boolean } = {},
+): ProjectStructureChange[] | null {
+  const packageRoot = defaultsPackagePath(projectRoot)
+  if (!existsSync(join(packageRoot, 'package.json')))
+    return null
+
+  return syncPackageProjectFiles(projectRoot, packageRoot, { dryRun: true, shallow: options.shallow })
+}
+
+/** `+added ~updated -removed`, the shape `buddy upgrade` already prints. */
+export function summarizeStructureChanges(changes: ProjectStructureChange[]): string {
+  const added = changes.filter(change => change.action === 'add').length
+  const updated = changes.filter(change => change.action === 'update').length
+  const removed = changes.filter(change => change.action === 'remove').length
+  return `+${added} ~${updated} -${removed}`
 }
 
 /**

--- a/storage/framework/core/actions/src/upgrade/package-project.ts
+++ b/storage/framework/core/actions/src/upgrade/package-project.ts
@@ -94,7 +94,9 @@ function copyFileIfChanged(
   options: PackageProjectOptions,
   executable = false,
 ): void {
-  if (sameFile(source, target, options.shallow)) {
+  // `shallow` is ignored unless nothing is being written, so a size match can
+  // never be the reason a stale file survives a real sync.
+  if (sameFile(source, target, options.shallow && options.dryRun)) {
     if (executable && !options.dryRun)
       chmodSync(target, 0o755)
     return
@@ -255,7 +257,9 @@ export interface DefaultsSkew {
   syncedAt: string | null
 }
 
-const NOT_APPLICABLE: DefaultsSkew = { status: 'not-applicable', installed: null, vendored: null, syncedAt: null }
+function notApplicable(): DefaultsSkew {
+  return { status: 'not-applicable', installed: null, vendored: null, syncedAt: null }
+}
 
 /** Where `syncPackageProjectFiles` reads from, given a project root. */
 export function defaultsPackagePath(projectRoot: string): string {
@@ -284,28 +288,28 @@ export function inspectDefaultsProvenance(projectRoot: string): DefaultsSkew {
   const packageRoot = defaultsPackagePath(projectRoot)
 
   if (!existsSync(targetDefaults) || !existsSync(join(packageRoot, 'package.json')))
-    return NOT_APPLICABLE
+    return notApplicable()
 
   // A framework checkout carries the framework's own source, and there the
   // vendored tree is what `@stacksjs/defaults` is built *from* rather than a
   // copy of it. Comparing the two reports drift that means nothing.
   if (existsSync(join(projectRoot, 'storage/framework/core/buddy/package.json')))
-    return NOT_APPLICABLE
+    return notApplicable()
 
   // Same reasoning for a linked checkout: an installed package resolves inside
   // node_modules, while a workspace or `bun link` reference resolves back out
   // to source the developer is editing.
   try {
     if (!isInside(packageRoot, join(realpathSync(projectRoot), 'node_modules')))
-      return NOT_APPLICABLE
+      return notApplicable()
   }
   catch {
-    return NOT_APPLICABLE
+    return notApplicable()
   }
 
   const installed = packageVersion(packageRoot)
   if (!installed)
-    return NOT_APPLICABLE
+    return notApplicable()
 
   let marker: DefaultsSyncMarker | null = null
   try {

--- a/storage/framework/core/actions/src/upgrade/packages.ts
+++ b/storage/framework/core/actions/src/upgrade/packages.ts
@@ -11,8 +11,11 @@ import process from 'node:process'
 import { runCommand } from '@stacksjs/cli'
 import {
   detectProjectAiProviders,
+  installedDefaultsVersion,
+  measureDefaultsDrift,
   migratePackageProjectManifest,
   migratePackageProjectTsconfig,
+  summarizeStructureChanges,
   syncPackageProjectFiles,
 } from './package-project'
 
@@ -232,6 +235,18 @@ export async function upgradeStacksPackages(projectRoot: string, options: Packag
     console.log(`  Project manifest migrations: ${projectManifestChanges.length}\n`)
 
   if (options.dryRun) {
+    // Manifest rewrites are the small half of an upgrade. The large half is the
+    // scaffold under storage/framework/defaults, and a preview that reports
+    // only the former reads as "this upgrade touches four files" when it is
+    // about to rewrite hundreds. The comparison is against the version
+    // installed right now, because the target is not on disk yet.
+    const pending = measureDefaultsDrift(projectRoot)
+    if (pending && pending.length > 0) {
+      const installed = installedDefaultsVersion(projectRoot)
+      console.log(`  Managed project files, against the installed @stacksjs/defaults${installed ? ` (${installed})` : ''}:`)
+      console.log(`    ${summarizeStructureChanges(pending)}   in storage/framework/defaults and project support files\n`)
+    }
+
     console.log('  --dry-run: no files were written and nothing was installed.\n')
     process.exit(0)
   }

--- a/storage/framework/core/actions/tests/upgrade-package-project.test.ts
+++ b/storage/framework/core/actions/tests/upgrade-package-project.test.ts
@@ -3,9 +3,14 @@ import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, wr
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  DEFAULTS_SYNC_MARKER,
   detectProjectAiProviders,
+  inspectDefaultsProvenance,
+  installedDefaultsVersion,
+  measureDefaultsDrift,
   migratePackageProjectManifest,
   migratePackageProjectTsconfig,
+  summarizeStructureChanges,
   syncPackageProjectFiles,
 } from '../src/upgrade/package-project'
 
@@ -27,7 +32,7 @@ function writeDefault(path: string, contents: string): void {
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'stacks-package-project-'))
   defaultsRoot = join(root, 'node_modules/@stacksjs/defaults')
-  writeDefault('package.json', '{"name":"@stacksjs/defaults"}')
+  writeDefault('package.json', '{"name":"@stacksjs/defaults","version":"0.70.362"}')
   writeDefault('ai/skills/stacks-buddy/SKILL.md', 'current skill')
   writeDefault('project/buddy', '#!/bin/sh\n')
   writeDefault('project/bootstrap', '#!/bin/sh\n')
@@ -92,6 +97,103 @@ describe('package project file sync', () => {
     expect(changes.length).toBeGreaterThan(0)
     expect(existsSync(join(root, 'storage/framework/defaults'))).toBe(false)
     expect(existsSync(join(root, 'buddy'))).toBe(false)
+  })
+})
+
+describe('framework defaults provenance', () => {
+  const markerPath = (): string => join(root, 'storage/framework/defaults', DEFAULTS_SYNC_MARKER)
+
+  it('stamps the tree with the version it was synced from', () => {
+    syncPackageProjectFiles(root, defaultsRoot)
+
+    const marker = JSON.parse(readFileSync(markerPath(), 'utf8'))
+    expect(marker.version).toBe('0.70.362')
+    expect(Number.isNaN(Date.parse(marker.syncedAt))).toBe(false)
+    expect(installedDefaultsVersion(root)).toBe('0.70.362')
+  })
+
+  it('leaves the stamp alone on a later sync, and never counts it as drift', () => {
+    syncPackageProjectFiles(root, defaultsRoot)
+    const changes = syncPackageProjectFiles(root, defaultsRoot)
+
+    expect(changes.filter(change => change.path.endsWith(DEFAULTS_SYNC_MARKER))).toEqual([])
+    expect(existsSync(markerPath())).toBe(true)
+    expect(measureDefaultsDrift(root)).toEqual([])
+  })
+
+  it('writes no stamp on a dry run', () => {
+    syncPackageProjectFiles(root, defaultsRoot, { dryRun: true })
+
+    expect(existsSync(markerPath())).toBe(false)
+  })
+
+  it('reports a synced tree as current', () => {
+    syncPackageProjectFiles(root, defaultsRoot)
+
+    expect(inspectDefaultsProvenance(root)).toMatchObject({
+      status: 'current',
+      installed: '0.70.362',
+      vendored: '0.70.362',
+    })
+  })
+
+  it('reports a tree left behind by a plain dependency bump as stale', () => {
+    syncPackageProjectFiles(root, defaultsRoot)
+
+    // What `bun install` does on its own: the package advances, and nothing
+    // touches storage/framework/defaults.
+    writeDefault('package.json', '{"name":"@stacksjs/defaults","version":"0.70.400"}')
+    writeDefault('ai/skills/stacks-buddy/SKILL.md', 'newer skill')
+
+    expect(inspectDefaultsProvenance(root)).toMatchObject({
+      status: 'stale',
+      installed: '0.70.400',
+      vendored: '0.70.362',
+    })
+    expect(summarizeStructureChanges(measureDefaultsDrift(root) ?? [])).toBe('+0 ~1 -0')
+  })
+
+  it('reports a tree written before stamping existed as unstamped', () => {
+    syncPackageProjectFiles(root, defaultsRoot)
+    rmSync(markerPath())
+
+    expect(inspectDefaultsProvenance(root)).toMatchObject({
+      status: 'unstamped',
+      installed: '0.70.362',
+      vendored: null,
+    })
+  })
+
+  it('has nothing to compare without an installed package', () => {
+    write('storage/framework/defaults/ai/skills/stacks-buddy/SKILL.md', 'old skill')
+    rmSync(defaultsRoot, { recursive: true, force: true })
+
+    expect(inspectDefaultsProvenance(root).status).toBe('not-applicable')
+    expect(measureDefaultsDrift(root)).toBeNull()
+  })
+
+  it('stays quiet in a framework checkout, where the tree is the source', () => {
+    syncPackageProjectFiles(root, defaultsRoot)
+    write('storage/framework/core/buddy/package.json', '{"name":"@stacksjs/buddy"}')
+    writeDefault('package.json', '{"name":"@stacksjs/defaults","version":"0.70.400"}')
+
+    expect(inspectDefaultsProvenance(root).status).toBe('not-applicable')
+  })
+
+  it('finds drift by size alone, for the boot-time probe', () => {
+    syncPackageProjectFiles(root, defaultsRoot)
+    writeDefault('ai/skills/stacks-buddy/SKILL.md', 'a skill of a different length entirely')
+
+    expect(summarizeStructureChanges(measureDefaultsDrift(root, { shallow: true }) ?? [])).toBe('+0 ~1 -0')
+  })
+
+  it('does not read contents when probing shallow', () => {
+    syncPackageProjectFiles(root, defaultsRoot)
+    // Same length, different bytes: a full comparison sees it, sizes do not.
+    writeDefault('ai/skills/stacks-buddy/SKILL.md', 'CURRENT SKILL')
+
+    expect(measureDefaultsDrift(root, { shallow: true })).toEqual([])
+    expect(summarizeStructureChanges(measureDefaultsDrift(root) ?? [])).toBe('+0 ~1 -0')
   })
 })
 

--- a/storage/framework/core/buddy/src/commands/dev.ts
+++ b/storage/framework/core/buddy/src/commands/dev.ts
@@ -70,6 +70,49 @@ async function actions(): Promise<typeof import('@stacksjs/actions')> {
   return _actions
 }
 
+/**
+ * Say so when the app is about to run framework defaults it did not install.
+ *
+ * `storage/framework/defaults` is the copy that executes: the generated
+ * auto-import barrel reaches into it by relative path. Only `buddy upgrade`
+ * writes it, so moving `stacks` forward the ordinary way (edit package.json,
+ * `bun install`) advances `node_modules/@stacksjs/defaults` and leaves the
+ * vendored tree exactly where it was. Nothing else compares the two, so the
+ * only symptom is a ReferenceError naming a framework-internal symbol from a
+ * bug that was fixed releases ago.
+ *
+ * Cheap on the common path: two manifest reads and a marker read. The file
+ * comparison only runs for a tree written before stamping existed, and it
+ * compares sizes rather than contents to stay off the boot budget.
+ */
+async function warnOnStaleFrameworkDefaults(): Promise<void> {
+  try {
+    const { inspectDefaultsProvenance, measureDefaultsDrift } = await actions()
+    const skew = inspectDefaultsProvenance(projectPath())
+
+    if (skew.status === 'not-applicable' || skew.status === 'current')
+      return
+
+    if (skew.status === 'stale') {
+      log.warn(`storage/framework/defaults is from ${skew.vendored}, but @stacksjs/defaults ${skew.installed} is installed.`)
+    }
+    else {
+      // Unstamped. Only a comparison can tell whether it is actually behind,
+      // and most trees are not, so stay silent unless one really differs.
+      const drift = measureDefaultsDrift(projectPath(), { shallow: true })
+      if (!drift || drift.length === 0)
+        return
+
+      log.warn(`storage/framework/defaults does not match the installed @stacksjs/defaults ${skew.installed}.`)
+    }
+
+    log.warn('The app runs the vendored copy. Run `buddy upgrade` to sync it, or `buddy doctor` for the file counts.')
+  }
+  catch {
+    // Provenance is a courtesy. It must never stop a dev server from starting.
+  }
+}
+
 export const interactiveDevChoices = [
   { value: 'all', title: 'All' },
   { value: 'frontend', title: 'Frontend' },
@@ -341,6 +384,8 @@ export function dev(buddy: CLI): void {
 
       const perf = Bun.nanoseconds()
       process.env.STACKS_DEV_ENTRY_PATH = resolveDevelopmentEntryPath({ site: options.site })
+
+      await warnOnStaleFrameworkDefaults()
 
       // log.info('Ensuring web server/s running...')
 

--- a/storage/framework/core/buddy/src/commands/doctor.ts
+++ b/storage/framework/core/buddy/src/commands/doctor.ts
@@ -109,6 +109,50 @@ export function doctor(buddy: CLI): void {
         })
       }
 
+      // Framework defaults that are older than the package they came from
+      //
+      // `storage/framework/defaults` is the copy that executes — the generated
+      // auto-import barrel reaches into it by relative path — and only
+      // `buddy upgrade` writes it. Bump `stacks` in package.json and
+      // `bun install`, which is how anyone moves a dependency, and the package
+      // advances while the vendored tree stays put. Nothing else compares them,
+      // so an app can run month-old framework code against a current install
+      // and the only symptom is a ReferenceError naming an internal symbol.
+      await probe(checks, 'Framework defaults', async () => {
+        const { inspectDefaultsProvenance, measureDefaultsDrift, summarizeStructureChanges } = await import('@stacksjs/actions')
+        const root = resolve(process.cwd())
+        const skew = inspectDefaultsProvenance(root)
+
+        if (skew.status === 'not-applicable')
+          return 'Not a package-managed project (nothing to compare)'
+
+        // Exact counts here. `doctor` is the command you run to get a number,
+        // and a full comparison of the tree costs well under a second.
+        const drift = measureDefaultsDrift(root) ?? []
+        const synced = skew.syncedAt ? `, synced ${skew.syncedAt.slice(0, 10)}` : ''
+
+        if (drift.length === 0)
+          return `Vendored tree matches @stacksjs/defaults ${skew.installed}${synced}`
+
+        const counts = summarizeStructureChanges(drift)
+        const fix = 'The app runs the vendored copy. Run `buddy upgrade` to sync it.'
+
+        // A recorded version that disagrees with the installed one is not open
+        // to interpretation: the app is running a release it did not install.
+        if (skew.status === 'stale') {
+          throw new Error(
+            `storage/framework/defaults is from ${skew.vendored} while @stacksjs/defaults ${skew.installed} is installed (${counts}). ${fix}`,
+          )
+        }
+
+        // Unstamped. The files differ, but a tree written before stamping
+        // existed cannot say whether that is age or a deliberate local edit,
+        // so report it without failing the run.
+        throw new ProbeWarning(
+          `storage/framework/defaults differs from the installed @stacksjs/defaults ${skew.installed} (${counts}), and carries no record of what it was synced from. ${fix}`,
+        )
+      }, 8000)
+
       // Check Bun version against the framework minimum
       const bunVersion = process.versions.bun
       if (bunVersion && isSupportedBunVersion(bunVersion)) {


### PR DESCRIPTION
Fixes the reporting half of #2302.

`storage/framework/defaults` is the copy that executes, and `buddy upgrade` is the only thing that writes it. Bumping `stacks` in `package.json` and running `bun install` advances `node_modules/@stacksjs/defaults` and leaves the vendored tree where it was. Nothing compared the two.

## What this adds

Each sync stamps `storage/framework/defaults/.stacks-sync.json` with the version it copied from. Three places read it:

| | before | after |
|---|---|---|
| `buddy dev` | silent | one-line warning when the tree and the package disagree |
| `buddy doctor` | no such check | **Framework defaults** check with exact `+add ~update -remove` counts |
| `buddy upgrade --dry-run` | manifest rewrites only | also previews the scaffold changes |

Reproducing the reporter's scenario (a 0.70.52 tree against a 0.70.362 install):

```
--- buddy dev ---
⚠ storage/framework/defaults is from 0.70.52, but @stacksjs/defaults 0.70.362 is installed.
⚠ The app runs the vendored copy. Run `buddy upgrade` to sync it, or `buddy doctor` for the file counts.

--- buddy doctor ---
✗ Framework defaults   storage/framework/defaults is from 0.70.52 while @stacksjs/defaults 0.70.362
                       is installed (+1 ~1 -1). The app runs the vendored copy. Run `buddy upgrade` to sync it.

--- after buddy upgrade ---
✓ Framework defaults   Vendored tree matches @stacksjs/defaults 0.70.362, synced 2026-08-11
```

## Notes

- **Severity split.** A recorded version that disagrees with the installed one fails `doctor`. A tree written before stamping existed (every app today) only warns, because age and a deliberate local edit are indistinguishable there. It resolves itself on the next `buddy upgrade`.
- **Quiet where it should be.** All three checks return `not-applicable` in a framework checkout and behind a `bun link`, where the tree is what the package is built *from*. Verified: `✓ Framework defaults  Not a package-managed project (nothing to compare) (0ms)` in this repo.
- **Boot cost.** The dev probe is two manifest reads plus a marker read (0.10ms measured). The file comparison only runs for an unstamped tree, and compares sizes rather than contents: a full comparison of 1673 files costs ~75ms warm and ~200ms cold, which is too much for every `buddy dev`. A tree that is releases behind differs in *which files exist* long before it differs only in bytes. `doctor` does the exact comparison, since that is the command you run to get a number.
- The whole dev check is wrapped in a try/catch. Provenance is a courtesy and must never stop a dev server from starting.

## Still open on #2302

Suggestion 4, having the generated auto-import barrel resolve `@stacksjs/defaults` instead of `../defaults/…`, is the architectural fix that would stop the vendored copy being load-bearing at all. Not attempted here.

## Verification

- 15 tests in `upgrade-package-project.test.ts` (9 new) covering stamp write, stamp survival across re-sync, dry-run writing nothing, and each provenance state.
- Full actions suite: 408 pass, 0 fail.
- `pickier` clean on all seven files. `bun run typecheck` unchanged (all remaining errors pre-existing, none in touched files).
- End-to-end simulation of the reporter's scenario, including that it clears after `buddy upgrade`.