### PR TITLE
fix(server): boot the framework defaults the app actually installed

### DIFF
--- a/docs/guide/buddy/upgrade.md
+++ b/docs/guide/buddy/upgrade.md
@@ -48,28 +48,37 @@ Run without a subcommand to upgrade the Stacks framework to the latest version:
 buddy upgrade
 ```
 
-### Why `bun install` is not enough
+### Why `bun install` is not the whole upgrade
 
 A package-managed app keeps a copy of the framework scaffold in
-`storage/framework/defaults`, and that copy is the one that runs: the generated
-auto-import barrel reaches into it by relative path.
+`storage/framework/defaults`, and `buddy upgrade` is the only thing that writes
+it. Bumping `stacks` in `package.json` and running `bun install`, which is the
+ordinary way to move a dependency, advances `node_modules/@stacksjs/defaults`
+and leaves the vendored tree exactly where it was.
 
-`buddy upgrade` is the only thing that writes it. Bumping `stacks` in
-`package.json` and running `bun install`, which is the ordinary way to move a
-dependency, advances `node_modules/@stacksjs/defaults` and leaves the vendored
-tree exactly where it was. The app then runs framework code from whichever
-release it was last synced from, against a current install.
+Every sync stamps `storage/framework/defaults/.stacks-sync.json` with the
+version it copied from. Two things read that stamp.
 
-Three things now report the gap:
+**Boot prefers whichever copy the app actually declared.** A vendored tree
+stamped from an older release than the installed package is a cache of a
+release you have already moved past, so framework defaults resolve from
+`@stacksjs/defaults` instead. A `bun install` bump therefore runs the code you
+installed, not last month's. Nothing else changes order: a tree that matches, a
+tree with no stamp, a framework checkout, and a `bun link` all keep resolving to
+the vendored copy exactly as before.
+
+**Three commands report the gap**, because a tree on disk that is not what runs
+is still confusing to debug against:
 
 - `buddy dev` prints a one-line warning at startup when the two disagree.
 - `buddy doctor` has a **Framework defaults** check with the file counts.
 - `buddy upgrade --dry-run` previews the scaffold changes, not just the
   dependency bumps.
 
-Each sync stamps `storage/framework/defaults/.stacks-sync.json` with the version
-it copied from, which is what those checks read. A tree synced before that stamp
-existed reports as unstamped until the next `buddy upgrade`.
+Running `buddy upgrade` clears all of it. Until then an unstamped tree, which is
+any tree synced before stamping existed, still wins at boot: with no recorded
+version there is nothing to compare, so the checks report the difference without
+changing what resolves.
 
 Note that the sync also removes files under `storage/framework/defaults` that
 the package no longer ships, so it is not purely additive. The tree is

--- a/storage/framework/core/actions/src/index.ts
+++ b/storage/framework/core/actions/src/index.ts
@@ -27,18 +27,13 @@ export { formatProject, lintFix, lintProject } from './lint/lint'
 // and never exits, so the command owns rendering and the exit code.
 export { DEFAULT_STX_LINT_CONFIG, loadStxLintConfig, runStxLint } from './lint/stx-gate'
 export type { StxLintConfig, StxLintReport, StxLintResult } from './lint/stx-gate'
-// Provenance of the vendored framework defaults. Exported from
-// ./upgrade/package-project — the pure module — so importing this barrel never
-// pulls ./upgrade/index, which runs an upgrade on import.
-export {
-  DEFAULTS_SYNC_MARKER,
-  defaultsPackagePath,
-  inspectDefaultsProvenance,
-  installedDefaultsVersion,
-  measureDefaultsDrift,
-  summarizeStructureChanges,
-} from './upgrade/package-project'
-export type { DefaultsProvenance, DefaultsSkew, DefaultsSyncMarker, ProjectStructureChange } from './upgrade/package-project'
+// File-level drift between the vendored framework defaults and the installed
+// package. Exported from ./upgrade/package-project — the pure module — so
+// importing this barrel never pulls ./upgrade/index, which runs an upgrade on
+// import. The cheap version-level check lives in @stacksjs/path, because the
+// boot path consults it and cannot depend on this package.
+export { measureDefaultsDrift, summarizeStructureChanges } from './upgrade/package-project'
+export type { ProjectStructureChange } from './upgrade/package-project'
 export * from './setup'
 
 // makeFactory,

--- a/storage/framework/core/actions/src/upgrade/package-project.ts
+++ b/storage/framework/core/actions/src/upgrade/package-project.ts
@@ -1,5 +1,7 @@
-import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs'
-import { dirname, join, relative, sep } from 'node:path'
+import type { DefaultsSyncMarker } from '@stacksjs/path'
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { DEFAULTS_SYNC_MARKER, defaultsPackagePath } from '@stacksjs/path'
 
 export interface ProjectStructureChange {
   path: string
@@ -36,13 +38,6 @@ const DEFAULTS_PACKAGE_IGNORES = new Set([
   'project',
   'tests',
 ])
-
-/**
- * Provenance stamp written next to the synced tree. The sync is the only thing
- * that writes `storage/framework/defaults`, so this is the only record of which
- * release the tree came from.
- */
-export const DEFAULTS_SYNC_MARKER = '.stacks-sync.json'
 
 const LOCAL_DEFAULT_IGNORES = new Set([
   '.DS_Store',
@@ -204,17 +199,6 @@ export function syncPackageProjectFiles(
   return changes
 }
 
-/** Version field of a package manifest, or null when it cannot be read. */
-function packageVersion(packageRoot: string): string | null {
-  try {
-    const version = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))?.version
-    return typeof version === 'string' ? version : null
-  }
-  catch {
-    return null
-  }
-}
-
 /**
  * Record which release the tree was copied from.
  *
@@ -223,7 +207,7 @@ function packageVersion(packageRoot: string): string | null {
  * runs the sync) has no way to notice that its framework defaults stayed put.
  */
 function stampDefaultsSync(targetDefaults: string, defaultsPackageRoot: string): void {
-  const version = packageVersion(defaultsPackageRoot)
+  const version = manifestVersion(defaultsPackageRoot)
   if (!version)
     return
 
@@ -232,103 +216,14 @@ function stampDefaultsSync(targetDefaults: string, defaultsPackageRoot: string):
   writeFileSync(join(targetDefaults, DEFAULTS_SYNC_MARKER), `${JSON.stringify(marker, null, 2)}\n`)
 }
 
-export interface DefaultsSyncMarker {
-  /** `@stacksjs/defaults` version the tree was copied from. */
-  version: string
-  /** ISO-8601 instant of the copy. */
-  syncedAt: string
-}
-
-/**
- * - `not-applicable` — nothing to compare: no vendored tree, no installed
- *   package, or a framework checkout where the tree is the source rather than a
- *   copy of it.
- * - `unstamped` — the tree predates provenance stamping, so only a file
- *   comparison can say whether it is current.
- */
-export type DefaultsProvenance = 'not-applicable' | 'current' | 'stale' | 'unstamped'
-
-export interface DefaultsSkew {
-  status: DefaultsProvenance
-  /** Version of the installed `@stacksjs/defaults`. */
-  installed: string | null
-  /** Version the vendored tree was last synced from. */
-  vendored: string | null
-  syncedAt: string | null
-}
-
-function notApplicable(): DefaultsSkew {
-  return { status: 'not-applicable', installed: null, vendored: null, syncedAt: null }
-}
-
-/** Where `syncPackageProjectFiles` reads from, given a project root. */
-export function defaultsPackagePath(projectRoot: string): string {
-  return join(projectRoot, 'node_modules/@stacksjs/defaults')
-}
-
-/** Version of the installed `@stacksjs/defaults`, or null when absent. */
-export function installedDefaultsVersion(projectRoot: string): string | null {
-  return packageVersion(defaultsPackagePath(projectRoot))
-}
-
-function isInside(child: string, parent: string): boolean {
-  const resolved = realpathSync(child)
-  return resolved === parent || resolved.startsWith(`${parent}${sep}`)
-}
-
-/**
- * Compare the vendored framework defaults against the installed package.
- *
- * Cheap by construction: two manifest reads and one marker read. Callers that
- * need a file-level answer (there is none when the tree is `unstamped`) run
- * {@link measureDefaultsDrift}.
- */
-export function inspectDefaultsProvenance(projectRoot: string): DefaultsSkew {
-  const targetDefaults = join(projectRoot, 'storage/framework/defaults')
-  const packageRoot = defaultsPackagePath(projectRoot)
-
-  if (!existsSync(targetDefaults) || !existsSync(join(packageRoot, 'package.json')))
-    return notApplicable()
-
-  // A framework checkout carries the framework's own source, and there the
-  // vendored tree is what `@stacksjs/defaults` is built *from* rather than a
-  // copy of it. Comparing the two reports drift that means nothing.
-  if (existsSync(join(projectRoot, 'storage/framework/core/buddy/package.json')))
-    return notApplicable()
-
-  // Same reasoning for a linked checkout: an installed package resolves inside
-  // node_modules, while a workspace or `bun link` reference resolves back out
-  // to source the developer is editing.
+/** Version field of a package manifest, or null when it cannot be read. */
+function manifestVersion(packageRoot: string): string | null {
   try {
-    if (!isInside(packageRoot, join(realpathSync(projectRoot), 'node_modules')))
-      return notApplicable()
+    const version = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))?.version
+    return typeof version === 'string' ? version : null
   }
   catch {
-    return notApplicable()
-  }
-
-  const installed = packageVersion(packageRoot)
-  if (!installed)
-    return notApplicable()
-
-  let marker: DefaultsSyncMarker | null = null
-  try {
-    const raw = JSON.parse(readFileSync(join(targetDefaults, DEFAULTS_SYNC_MARKER), 'utf8'))
-    if (typeof raw?.version === 'string')
-      marker = { version: raw.version, syncedAt: typeof raw.syncedAt === 'string' ? raw.syncedAt : '' }
-  }
-  catch {
-    // No marker, or an unreadable one. Either way the tree is unstamped.
-  }
-
-  if (!marker)
-    return { status: 'unstamped', installed, vendored: null, syncedAt: null }
-
-  return {
-    status: marker.version === installed ? 'current' : 'stale',
-    installed,
-    vendored: marker.version,
-    syncedAt: marker.syncedAt || null,
+    return null
   }
 }
 

--- a/storage/framework/core/actions/src/upgrade/packages.ts
+++ b/storage/framework/core/actions/src/upgrade/packages.ts
@@ -9,9 +9,9 @@ import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from '
 import { join, relative } from 'node:path'
 import process from 'node:process'
 import { runCommand } from '@stacksjs/cli'
+import { installedDefaultsVersion } from '@stacksjs/path'
 import {
   detectProjectAiProviders,
-  installedDefaultsVersion,
   measureDefaultsDrift,
   migratePackageProjectManifest,
   migratePackageProjectTsconfig,

--- a/storage/framework/core/actions/tests/upgrade-package-project.test.ts
+++ b/storage/framework/core/actions/tests/upgrade-package-project.test.ts
@@ -2,11 +2,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { DEFAULTS_SYNC_MARKER, installedDefaultsVersion } from '@stacksjs/path'
 import {
-  DEFAULTS_SYNC_MARKER,
   detectProjectAiProviders,
-  inspectDefaultsProvenance,
-  installedDefaultsVersion,
   measureDefaultsDrift,
   migratePackageProjectManifest,
   migratePackageProjectTsconfig,
@@ -127,17 +125,7 @@ describe('framework defaults provenance', () => {
     expect(existsSync(markerPath())).toBe(false)
   })
 
-  it('reports a synced tree as current', () => {
-    syncPackageProjectFiles(root, defaultsRoot)
-
-    expect(inspectDefaultsProvenance(root)).toMatchObject({
-      status: 'current',
-      installed: '0.70.362',
-      vendored: '0.70.362',
-    })
-  })
-
-  it('reports a tree left behind by a plain dependency bump as stale', () => {
+  it('measures what a plain dependency bump left behind', () => {
     syncPackageProjectFiles(root, defaultsRoot)
 
     // What `bun install` does on its own: the package advances, and nothing
@@ -145,39 +133,15 @@ describe('framework defaults provenance', () => {
     writeDefault('package.json', '{"name":"@stacksjs/defaults","version":"0.70.400"}')
     writeDefault('ai/skills/stacks-buddy/SKILL.md', 'newer skill')
 
-    expect(inspectDefaultsProvenance(root)).toMatchObject({
-      status: 'stale',
-      installed: '0.70.400',
-      vendored: '0.70.362',
-    })
+    expect(installedDefaultsVersion(root)).toBe('0.70.400')
     expect(summarizeStructureChanges(measureDefaultsDrift(root) ?? [])).toBe('+0 ~1 -0')
   })
 
-  it('reports a tree written before stamping existed as unstamped', () => {
-    syncPackageProjectFiles(root, defaultsRoot)
-    rmSync(markerPath())
-
-    expect(inspectDefaultsProvenance(root)).toMatchObject({
-      status: 'unstamped',
-      installed: '0.70.362',
-      vendored: null,
-    })
-  })
-
-  it('has nothing to compare without an installed package', () => {
+  it('has nothing to measure without an installed package', () => {
     write('storage/framework/defaults/ai/skills/stacks-buddy/SKILL.md', 'old skill')
     rmSync(defaultsRoot, { recursive: true, force: true })
 
-    expect(inspectDefaultsProvenance(root).status).toBe('not-applicable')
     expect(measureDefaultsDrift(root)).toBeNull()
-  })
-
-  it('stays quiet in a framework checkout, where the tree is the source', () => {
-    syncPackageProjectFiles(root, defaultsRoot)
-    write('storage/framework/core/buddy/package.json', '{"name":"@stacksjs/buddy"}')
-    writeDefault('package.json', '{"name":"@stacksjs/defaults","version":"0.70.400"}')
-
-    expect(inspectDefaultsProvenance(root).status).toBe('not-applicable')
   })
 
   it('finds drift by size alone, for the boot-time probe', () => {

--- a/storage/framework/core/buddy/src/commands/dev.ts
+++ b/storage/framework/core/buddy/src/commands/dev.ts
@@ -8,7 +8,7 @@ import { homedir } from 'node:os'
 import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Action } from '@stacksjs/enums'
-import { libsPath, projectPath, stxPath } from '@stacksjs/path'
+import { inspectDefaultsProvenance, libsPath, projectPath, stxPath } from '@stacksjs/path'
 import { ExitCode } from '@stacksjs/types'
 import { version } from '../../package.json'
 import { resultFailed } from '../result'
@@ -71,15 +71,17 @@ async function actions(): Promise<typeof import('@stacksjs/actions')> {
 }
 
 /**
- * Say so when the app is about to run framework defaults it did not install.
+ * Say so when the vendored framework defaults and the installed package
+ * disagree about which release the app is running.
  *
- * `storage/framework/defaults` is the copy that executes: the generated
- * auto-import barrel reaches into it by relative path. Only `buddy upgrade`
- * writes it, so moving `stacks` forward the ordinary way (edit package.json,
- * `bun install`) advances `node_modules/@stacksjs/defaults` and leaves the
- * vendored tree exactly where it was. Nothing else compares the two, so the
- * only symptom is a ReferenceError naming a framework-internal symbol from a
- * bug that was fixed releases ago.
+ * Only `buddy upgrade` writes `storage/framework/defaults`, so moving `stacks`
+ * forward the ordinary way (edit package.json, `bun install`) advances
+ * `node_modules/@stacksjs/defaults` and leaves the vendored tree where it was.
+ *
+ * A tree with a recorded version is no longer load-bearing in that state:
+ * `frameworkDefaultsDir` resolves to the package instead, so the warning is
+ * telling you where the code came from rather than reporting a fault. A tree
+ * with no stamp still wins, so there the warning is a real one.
  *
  * Cheap on the common path: two manifest reads and a marker read. The file
  * comparison only runs for a tree written before stamping existed, and it
@@ -87,25 +89,25 @@ async function actions(): Promise<typeof import('@stacksjs/actions')> {
  */
 async function warnOnStaleFrameworkDefaults(): Promise<void> {
   try {
-    const { inspectDefaultsProvenance, measureDefaultsDrift } = await actions()
     const skew = inspectDefaultsProvenance(projectPath())
-
     if (skew.status === 'not-applicable' || skew.status === 'current')
       return
 
     if (skew.status === 'stale') {
       log.warn(`storage/framework/defaults is from ${skew.vendored}, but @stacksjs/defaults ${skew.installed} is installed.`)
-    }
-    else {
-      // Unstamped. Only a comparison can tell whether it is actually behind,
-      // and most trees are not, so stay silent unless one really differs.
-      const drift = measureDefaultsDrift(projectPath(), { shallow: true })
-      if (!drift || drift.length === 0)
-        return
-
-      log.warn(`storage/framework/defaults does not match the installed @stacksjs/defaults ${skew.installed}.`)
+      log.warn('Booting the installed package instead. Run `buddy upgrade` to bring the tree up to date.')
+      return
     }
 
+    // Unstamped, so the tree carries no version to compare and resolution stays
+    // on it. Only a file comparison can say whether it is actually behind, and
+    // most are not, so stay silent unless one really differs.
+    const { measureDefaultsDrift } = await actions()
+    const drift = measureDefaultsDrift(projectPath(), { shallow: true })
+    if (!drift || drift.length === 0)
+      return
+
+    log.warn(`storage/framework/defaults does not match the installed @stacksjs/defaults ${skew.installed}.`)
     log.warn('The app runs the vendored copy. Run `buddy upgrade` to sync it, or `buddy doctor` for the file counts.')
   }
   catch {

--- a/storage/framework/core/buddy/src/commands/doctor.ts
+++ b/storage/framework/core/buddy/src/commands/doctor.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 import { bold, dim, green, intro, log, onUnknownSubcommand, red, yellow } from "@stacksjs/cli"
 import { feature } from '@stacksjs/config'
+import { inspectDefaultsProvenance } from '@stacksjs/path'
 import { storage } from '@stacksjs/storage'
 import { isSupportedBunVersion, isVersionGreaterThanOrEqual, minimumBunVersion } from '@stacksjs/utils'
 import { FEATURE_NAMES, featurePathsPresent } from './features'
@@ -119,7 +120,7 @@ export function doctor(buddy: CLI): void {
       // so an app can run month-old framework code against a current install
       // and the only symptom is a ReferenceError naming an internal symbol.
       await probe(checks, 'Framework defaults', async () => {
-        const { inspectDefaultsProvenance, measureDefaultsDrift, summarizeStructureChanges } = await import('@stacksjs/actions')
+        const { measureDefaultsDrift, summarizeStructureChanges } = await import('@stacksjs/actions')
         const root = resolve(process.cwd())
         const skew = inspectDefaultsProvenance(root)
 
@@ -135,21 +136,24 @@ export function doctor(buddy: CLI): void {
           return `Vendored tree matches @stacksjs/defaults ${skew.installed}${synced}`
 
         const counts = summarizeStructureChanges(drift)
-        const fix = 'The app runs the vendored copy. Run `buddy upgrade` to sync it.'
 
-        // A recorded version that disagrees with the installed one is not open
-        // to interpretation: the app is running a release it did not install.
+        // A recorded version that disagrees with the installed one takes the
+        // tree out of the resolution path, so the app is running what it
+        // installed. Still a warning: the tree on disk is not what executes,
+        // which is confusing to read and to debug against.
         if (skew.status === 'stale') {
-          throw new Error(
-            `storage/framework/defaults is from ${skew.vendored} while @stacksjs/defaults ${skew.installed} is installed (${counts}). ${fix}`,
+          throw new ProbeWarning(
+            `storage/framework/defaults is from ${skew.vendored} while @stacksjs/defaults ${skew.installed} is installed (${counts}). `
+            + 'Boot resolves the package, so the tree on disk is not what runs. Run `buddy upgrade` to sync it.',
           )
         }
 
-        // Unstamped. The files differ, but a tree written before stamping
-        // existed cannot say whether that is age or a deliberate local edit,
-        // so report it without failing the run.
+        // Unstamped, so the tree still wins and the app really is running it.
+        // A file comparison cannot say whether that is age or a deliberate
+        // local edit, so report it without failing the run.
         throw new ProbeWarning(
-          `storage/framework/defaults differs from the installed @stacksjs/defaults ${skew.installed} (${counts}), and carries no record of what it was synced from. ${fix}`,
+          `storage/framework/defaults differs from the installed @stacksjs/defaults ${skew.installed} (${counts}), and carries no record of what it was synced from. `
+          + 'The app runs the vendored copy. Run `buddy upgrade` to sync it.',
         )
       }, 8000)
 

--- a/storage/framework/core/path/src/index.ts
+++ b/storage/framework/core/path/src/index.ts
@@ -3,8 +3,10 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  readFileSync,
   readdirSync,
   readlinkSync,
+  realpathSync,
   renameSync,
   rmSync,
   unlinkSync,
@@ -1119,6 +1121,128 @@ export function publicPath(path?: string): string {
 }
 
 /**
+ * Provenance stamp written next to the synced tree. `buddy upgrade` is the only
+ * thing that writes `storage/framework/defaults`, so this is the only record of
+ * which release the tree came from.
+ */
+export const DEFAULTS_SYNC_MARKER = '.stacks-sync.json'
+
+export interface DefaultsSyncMarker {
+  /** `@stacksjs/defaults` version the tree was copied from. */
+  version: string
+  /** ISO-8601 instant of the copy. */
+  syncedAt: string
+}
+
+/**
+ * - `not-applicable` — nothing to compare: no vendored tree, no installed
+ *   package, or a framework checkout where the tree is the source rather than a
+ *   copy of it.
+ * - `unstamped` — the tree predates provenance stamping, so only a file
+ *   comparison can say whether it is current.
+ */
+export type DefaultsProvenance = 'not-applicable' | 'current' | 'stale' | 'unstamped'
+
+export interface DefaultsSkew {
+  status: DefaultsProvenance
+  /** Version of the installed `@stacksjs/defaults`. */
+  installed: string | null
+  /** Version the vendored tree was last synced from. */
+  vendored: string | null
+  syncedAt: string | null
+}
+
+function notApplicable(): DefaultsSkew {
+  return { status: 'not-applicable', installed: null, vendored: null, syncedAt: null }
+}
+
+/** Where `buddy upgrade` reads the managed scaffold from. */
+export function defaultsPackagePath(projectRoot: string = projectPath()): string {
+  return join(projectRoot, 'node_modules/@stacksjs/defaults')
+}
+
+/** Version field of a package manifest, or null when it cannot be read. */
+function manifestVersion(packageRoot: string): string | null {
+  try {
+    const version = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))?.version
+    return typeof version === 'string' ? version : null
+  }
+  catch {
+    return null
+  }
+}
+
+/** Version of the installed `@stacksjs/defaults`, or null when absent. */
+export function installedDefaultsVersion(projectRoot: string = projectPath()): string | null {
+  return manifestVersion(defaultsPackagePath(projectRoot))
+}
+
+function isInside(child: string, parent: string): boolean {
+  const resolved = realpathSync(child)
+  return resolved === parent || resolved.startsWith(`${parent}${sep}`)
+}
+
+/**
+ * Compare the vendored framework defaults against the installed package.
+ *
+ * `storage/framework/defaults` is the copy that executes, and `buddy upgrade`
+ * is the only thing that writes it. Bump `stacks` in package.json and run
+ * `bun install`, which is how anyone moves a dependency, and the package
+ * advances while the vendored tree stays put.
+ *
+ * Cheap by construction: two manifest reads and one marker read, so callers on
+ * a boot path can consult it freely.
+ */
+export function inspectDefaultsProvenance(projectRoot: string = projectPath()): DefaultsSkew {
+  const targetDefaults = join(projectRoot, 'storage/framework/defaults')
+  const packageRoot = defaultsPackagePath(projectRoot)
+
+  if (!existsSync(targetDefaults) || !existsSync(join(packageRoot, 'package.json')))
+    return notApplicable()
+
+  // A framework checkout carries the framework's own source, and there the
+  // vendored tree is what `@stacksjs/defaults` is built *from* rather than a
+  // copy of it. Comparing the two reports drift that means nothing.
+  if (existsSync(join(projectRoot, 'storage/framework/core/buddy/package.json')))
+    return notApplicable()
+
+  // Same reasoning for a linked checkout: an installed package resolves inside
+  // node_modules, while a workspace or `bun link` reference resolves back out
+  // to source the developer is editing.
+  try {
+    if (!isInside(packageRoot, join(realpathSync(projectRoot), 'node_modules')))
+      return notApplicable()
+  }
+  catch {
+    return notApplicable()
+  }
+
+  const installed = manifestVersion(packageRoot)
+  if (!installed)
+    return notApplicable()
+
+  let marker: DefaultsSyncMarker | null = null
+  try {
+    const raw = JSON.parse(readFileSync(join(targetDefaults, DEFAULTS_SYNC_MARKER), 'utf8'))
+    if (typeof raw?.version === 'string')
+      marker = { version: raw.version, syncedAt: typeof raw.syncedAt === 'string' ? raw.syncedAt : '' }
+  }
+  catch {
+    // No marker, or an unreadable one. Either way the tree is unstamped.
+  }
+
+  if (!marker)
+    return { status: 'unstamped', installed, vendored: null, syncedAt: null }
+
+  return {
+    status: marker.version === installed ? 'current' : 'stale',
+    installed,
+    vendored: marker.version,
+    syncedAt: marker.syncedAt || null,
+  }
+}
+
+/**
  * Returns the path to the `push` directory within the `notifications` directory.
  *
  * @param path - The relative path to the file or directory within the push directory.
@@ -1778,6 +1902,9 @@ export interface Path {
   findProjectPath: (project: string) => Promise<string>
   coreStoragePath: (path?: string) => string
   publicPath: (path?: string) => string
+  defaultsPackagePath: (projectRoot?: string) => string
+  installedDefaultsVersion: (projectRoot?: string) => string | null
+  inspectDefaultsProvenance: (projectRoot?: string) => DefaultsSkew
   pushPath: (path?: string) => string
   queryBuilderPath: (path?: string) => string
   queuePath: (path?: string) => string
@@ -1924,6 +2051,9 @@ export const path: Path = {
   findProjectPath,
   coreStoragePath,
   publicPath,
+  defaultsPackagePath,
+  installedDefaultsVersion,
+  inspectDefaultsProvenance,
   pushPath,
   queryBuilderPath,
   queuePath,

--- a/storage/framework/core/path/tests/defaults-provenance.test.ts
+++ b/storage/framework/core/path/tests/defaults-provenance.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Which release the vendored framework defaults came from.
+ *
+ * `storage/framework/defaults` is the copy the generated auto-import barrel
+ * reaches into, and `buddy upgrade` is the only thing that writes it. Bumping
+ * `stacks` in package.json and running `bun install`, which is how anyone moves
+ * a dependency, advances `node_modules/@stacksjs/defaults` and leaves the
+ * vendored tree exactly where it was.
+ *
+ * These pin the four states, because `frameworkDefaultsDir` changes which copy
+ * boot resolves based on them. Getting `not-applicable` wrong in particular
+ * would make framework development resolve to the last build output instead of
+ * live source.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DEFAULTS_SYNC_MARKER, defaultsPackagePath, inspectDefaultsProvenance, installedDefaultsVersion } from '../src/index'
+
+let root: string
+
+function write(relativePath: string, contents: string): void {
+  const full = join(root, relativePath)
+  mkdirSync(join(full, '..'), { recursive: true })
+  writeFileSync(full, contents)
+}
+
+/** An app that installed the package and has a vendored tree stamped from it. */
+function scaffold(options: { installed: string, stamped?: string }): void {
+  write('node_modules/@stacksjs/defaults/package.json', JSON.stringify({ name: '@stacksjs/defaults', version: options.installed }))
+  write('storage/framework/defaults/functions/billing.ts', 'export function useBillable() {}\n')
+
+  if (options.stamped) {
+    write(
+      `storage/framework/defaults/${DEFAULTS_SYNC_MARKER}`,
+      JSON.stringify({ version: options.stamped, syncedAt: '2026-08-11T00:00:00.000Z' }),
+    )
+  }
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'stacks-defaults-provenance-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('framework defaults provenance', () => {
+  it('reports a tree stamped from the installed version as current', () => {
+    scaffold({ installed: '0.70.362', stamped: '0.70.362' })
+
+    expect(inspectDefaultsProvenance(root)).toEqual({
+      status: 'current',
+      installed: '0.70.362',
+      vendored: '0.70.362',
+      syncedAt: '2026-08-11T00:00:00.000Z',
+    })
+  })
+
+  it('reports a tree left behind by a plain dependency bump as stale', () => {
+    scaffold({ installed: '0.70.362', stamped: '0.70.52' })
+
+    expect(inspectDefaultsProvenance(root)).toMatchObject({
+      status: 'stale',
+      installed: '0.70.362',
+      vendored: '0.70.52',
+    })
+  })
+
+  it('reports a tree written before stamping existed as unstamped', () => {
+    scaffold({ installed: '0.70.362' })
+
+    expect(inspectDefaultsProvenance(root)).toMatchObject({
+      status: 'unstamped',
+      installed: '0.70.362',
+      vendored: null,
+    })
+  })
+
+  it('treats an unreadable marker as unstamped rather than throwing', () => {
+    scaffold({ installed: '0.70.362' })
+    write(`storage/framework/defaults/${DEFAULTS_SYNC_MARKER}`, 'not json at all')
+
+    expect(inspectDefaultsProvenance(root).status).toBe('unstamped')
+  })
+
+  it('has nothing to compare without an installed package', () => {
+    write('storage/framework/defaults/functions/billing.ts', 'export function useBillable() {}\n')
+
+    expect(inspectDefaultsProvenance(root).status).toBe('not-applicable')
+    expect(installedDefaultsVersion(root)).toBeNull()
+  })
+
+  it('has nothing to compare without a vendored tree', () => {
+    write('node_modules/@stacksjs/defaults/package.json', '{"name":"@stacksjs/defaults","version":"0.70.362"}')
+
+    expect(inspectDefaultsProvenance(root).status).toBe('not-applicable')
+  })
+
+  it('stays quiet in a framework checkout, where the tree is the source', () => {
+    // The package there is a publish wrapper built *from* the vendored tree, so
+    // any difference between them is a stale build, not a stale app. Preferring
+    // the package would make every edit under defaults/ invisible until rebuild.
+    scaffold({ installed: '0.70.400', stamped: '0.70.52' })
+    write('storage/framework/core/buddy/package.json', '{"name":"@stacksjs/buddy"}')
+
+    expect(inspectDefaultsProvenance(root).status).toBe('not-applicable')
+  })
+
+  it('stays quiet behind a link that resolves out of node_modules', () => {
+    scaffold({ installed: '0.70.400', stamped: '0.70.52' })
+
+    const elsewhere = mkdtempSync(join(tmpdir(), 'stacks-linked-defaults-'))
+    writeFileSync(join(elsewhere, 'package.json'), '{"name":"@stacksjs/defaults","version":"0.70.400"}')
+    rmSync(defaultsPackagePath(root), { recursive: true, force: true })
+    require('node:fs').symlinkSync(elsewhere, defaultsPackagePath(root))
+
+    expect(inspectDefaultsProvenance(root).status).toBe('not-applicable')
+    rmSync(elsewhere, { recursive: true, force: true })
+  })
+
+  it('reads the installed version straight off the package', () => {
+    scaffold({ installed: '0.70.362', stamped: '0.70.362' })
+
+    expect(installedDefaultsVersion(root)).toBe('0.70.362')
+    expect(defaultsPackagePath(root)).toBe(join(root, 'node_modules/@stacksjs/defaults'))
+  })
+})

--- a/storage/framework/core/server/src/imports.ts
+++ b/storage/framework/core/server/src/imports.ts
@@ -62,23 +62,65 @@ function configEnabled(configRelPaths: string[]): boolean {
  * the workspace package, which holds only build files — no `functions/`, no
  * `app/` — so the lookup misses and the vendored branch wins, which is what we
  * want when developing the framework itself.
+ *
+ * The one exception to vendored-first is a tree the installed package has
+ * already moved past. `buddy upgrade` is the only thing that writes
+ * `storage/framework/defaults`, so bumping `stacks` in package.json and running
+ * `bun install` leaves a copy of an older release sitting in front of the one
+ * the app actually declared. That copy is a cache, not source, and preferring
+ * it means booting code from a release nobody asked for. Only a recorded
+ * version that disagrees with the installed one flips the order: an unstamped
+ * tree, a framework checkout, and a linked checkout all keep resolving exactly
+ * as before. See `inspectDefaultsProvenance`.
  */
 export function frameworkDefaultsDir(sub: string): string | undefined {
   const vendored = path.storagePath(`framework/defaults/${sub}`)
-  if (existsSync(vendored))
-    return vendored
 
+  return resolveDefaultsDir(
+    existsSync(vendored) ? vendored : undefined,
+    packagedDefaultsDir(sub),
+    vendoredDefaultsAreStale(),
+  )
+}
+
+/**
+ * The precedence rule on its own, so it can be pinned without a project on
+ * disk. Vendored wins unless it is a copy of a release the app has already
+ * moved past, and a missing side never beats a present one.
+ */
+export function resolveDefaultsDir(
+  vendored: string | undefined,
+  packaged: string | undefined,
+  vendoredIsStale: boolean,
+): string | undefined {
+  if (packaged && vendoredIsStale)
+    return packaged
+
+  return vendored ?? packaged
+}
+
+function packagedDefaultsDir(sub: string): string | undefined {
   try {
     const packageRoot = dirname(fileURLToPath(import.meta.resolve('@stacksjs/defaults/package.json')))
     const packaged = `${packageRoot}/${sub}`
-    if (existsSync(packaged))
-      return packaged
+    return existsSync(packaged) ? packaged : undefined
   }
   catch {
     // @stacksjs/defaults is not installed — there is no fallback to offer.
+    return undefined
   }
+}
 
-  return undefined
+/**
+ * Memoised: `frameworkDefaultsDir` is called once per scanned directory on the
+ * boot path, and the answer cannot change without a restart.
+ */
+let defaultsAreStale: boolean | undefined
+function vendoredDefaultsAreStale(): boolean {
+  if (defaultsAreStale === undefined)
+    defaultsAreStale = path.inspectDefaultsProvenance().status === 'stale'
+
+  return defaultsAreStale
 }
 
 /** Drop the directories that do not exist, so a scan is never handed one. */

--- a/storage/framework/core/server/tests/auto-import-dirs.test.ts
+++ b/storage/framework/core/server/tests/auto-import-dirs.test.ts
@@ -16,7 +16,7 @@
 import { existsSync } from 'node:fs'
 import { describe, expect, it } from 'bun:test'
 import { path } from '@stacksjs/path'
-import { autoImportSourceDirs, frameworkDefaultsDir } from '../src/imports'
+import { autoImportSourceDirs, frameworkDefaultsDir, resolveDefaultsDir } from '../src/imports'
 
 describe('framework-default scan directories', () => {
   it('never reports a directory that does not exist', () => {
@@ -52,6 +52,39 @@ describe('framework-default scan directories', () => {
 
   it('returns undefined for a subdirectory that exists in neither place', () => {
     expect(frameworkDefaultsDir('definitely-not-a-real-defaults-subdir')).toBeUndefined()
+  })
+
+  describe('precedence', () => {
+    const vendored = '/app/storage/framework/defaults/functions'
+    const packaged = '/app/node_modules/@stacksjs/defaults/functions'
+
+    it('prefers the vendored copy while it is not known to be behind', () => {
+      // Covers current, unstamped, a framework checkout, and a linked checkout.
+      // All four report something other than `stale`, and all four must resolve
+      // exactly as they did before provenance existed.
+      expect(resolveDefaultsDir(vendored, packaged, false)).toBe(vendored)
+    })
+
+    it('prefers the package once the vendored copy is a release behind', () => {
+      // `buddy upgrade` is the only writer of the vendored tree, so a plain
+      // `bun install` bump leaves a copy of an older release in front of the one
+      // the app declared. That copy is a cache, not source.
+      expect(resolveDefaultsDir(vendored, packaged, true)).toBe(packaged)
+    })
+
+    it('never prefers a package directory that is not there', () => {
+      // The publish wrapper ships a subset. A subdir it does not carry must fall
+      // back to the vendored copy rather than resolving to nothing.
+      expect(resolveDefaultsDir(vendored, undefined, true)).toBe(vendored)
+    })
+
+    it('falls back to the package when there is no vendored copy at all', () => {
+      expect(resolveDefaultsDir(undefined, packaged, false)).toBe(packaged)
+    })
+
+    it('returns undefined when neither side has the directory', () => {
+      expect(resolveDefaultsDir(undefined, undefined, true)).toBeUndefined()
+    })
   })
 
   it('still reports the user-space directories', () => {


### PR DESCRIPTION
Suggestion 4 from #2302, the one #2303 left open: stop the vendored copy being load-bearing when it is out of date.

## The change

`frameworkDefaultsDir` (`storage/framework/core/server/src/imports.ts`) resolved the vendored tree first and the installed package only as a fallback. A vendored tree whose sync stamp disagrees with the installed package is a cache of a release the app has already moved past, so boot now resolves the package instead.

| provenance | resolves to | |
|---|---|---|
| `not-applicable` | vendored | unchanged |
| `current` | vendored | unchanged |
| `unstamped` | vendored | unchanged |
| **`stale`** | **package** | the only change |

Verified against the reporter's exact setup:

```
stale (bun install bump)       status=stale          -> PACKAGE
current (after buddy upgrade)  status=current        -> vendored
framework checkout             status=not-applicable -> vendored
```

## Why the stamp is the trigger, and not just "package-first"

Flipping the order outright looked like the obvious fix. It breaks framework development. `core/defaults/build.ts` copies **every** entry of `storage/framework/defaults` into the publish wrapper, so a built monorepo has `node_modules/@stacksjs/defaults/functions/` too, and package-first would resolve to the last build output. Every edit under `defaults/` would be invisible until you rebuilt the wrapper.

Provenance already reports `not-applicable` in a framework checkout (it looks for `storage/framework/core/buddy/package.json`), so that case is excluded by construction rather than by luck. Same for a `bun link`, where the package resolves back out of `node_modules`.

## Where the code lives now

The version-level check moves from `@stacksjs/actions` to `@stacksjs/path`, because the boot path cannot depend on `actions`. `path` is a genuine leaf (zero `@stacksjs/*` dependencies, single `src/index.ts`, already uses `node:fs`), and `server`, `actions`, and `buddy` all already declare it. File-level drift (`measureDefaultsDrift`, `summarizeStructureChanges`) stays in `actions`, next to the sync that produces it.

The precedence rule itself is extracted as `resolveDefaultsDir(vendored, packaged, stale)` so it can be pinned without a project on disk.

## Message corrections

Both #2303 messages claimed "the app runs the vendored copy". For a stamped-stale tree that is now false, so:

- `buddy doctor` drops the stale case from **fail** to **warn**, and says boot resolves the package so the tree on disk is not what runs.
- `buddy dev` says it is booting the installed package instead.

The unstamped case keeps the original wording, because there the tree really does still win.

## Verification

- 9 new provenance tests in `@stacksjs/path`, 5 new precedence tests in `@stacksjs/server`, drift tests kept in `actions`.
- Suites: path 93, actions 405, server 84 — all pass. buddy 352 pass / 3 fail, identical to `main` without this diff (`postal-mime` missing, plus a within-suite `make:mail` ordering artifact).
- `pickier` clean on all 11 files. `bun run typecheck` still 17 errors, none in touched files.
- `buddy doctor` in this repo still reports `✓ Framework defaults  Not a package-managed project (nothing to compare) (0ms)`.

## Noted, not fixed

`@stacksjs/path` is declared in `devDependencies` of `@stacksjs/actions` while 20+ files in its `src/` import it at runtime. Pre-existing and untouched here; moving it wants a `bun install --lockfile-only` of its own.