### PR TITLE
refactor(dashboard): replace hand-rolled search timers with useDebounce

### DIFF
--- a/storage/framework/defaults/resources/components/Dashboard/GlobalSearch.stx
+++ b/storage/framework/defaults/resources/components/Dashboard/GlobalSearch.stx
@@ -10,7 +10,6 @@ const isOpen = state(false)
 const selectedIndex = state(0)
 const error = state('')
 const searchInput = useRef('globalSearchInput')
-let searchTimer: ReturnType<typeof setTimeout> | null = null
 let searchRequest: AbortController | null = null
 
 function flatResults(): SearchResultItem[] {
@@ -74,13 +73,9 @@ async function runSearch(value: string): Promise<void> {
   }
 }
 
-function scheduleSearch(value: string): void {
-  if (searchTimer) clearTimeout(searchTimer)
-  searchTimer = setTimeout(() => {
-    searchTimer = null
-    void runSearch(value)
-  }, 250)
-}
+const scheduleSearch = useDebounce((value: string) => {
+  void runSearch(value)
+}, 250)
 
 function moveUp(): void {
   const items = flatResults()
@@ -137,7 +132,6 @@ function handleGlobalKeydown(event: KeyboardEvent): void {
 useEventListener('keydown', handleGlobalKeydown)
 
 onDestroy(() => {
-  if (searchTimer) clearTimeout(searchTimer)
   searchRequest?.abort()
 })
 </script>

--- a/storage/framework/defaults/resources/components/Dashboard/Jobs/JobHistory.stx
+++ b/storage/framework/defaults/resources/components/Dashboard/Jobs/JobHistory.stx
@@ -13,7 +13,6 @@ const selectedStatus = state('all')
 const searchQuery = state('')
 const isLoading = state(true)
 const loadError = state('')
-let searchTimer: ReturnType<typeof setTimeout> | undefined
 
 function totalPages(): number {
   return Math.max(1, Math.ceil(total() / perPage()))
@@ -32,11 +31,7 @@ function reloadFilters(): void {
   void loadJobs()
 }
 
-function reloadSearch(): void {
-  if (searchTimer)
-    clearTimeout(searchTimer)
-  searchTimer = setTimeout(reloadFilters, 250)
-}
+const reloadSearch = useDebounce(reloadFilters, 250)
 
 async function loadJobs(): Promise<void> {
   isLoading.set(true)
@@ -92,11 +87,6 @@ async function handleRetry(id: string | CustomEvent<string>): Promise<void> {
 
 onMount(() => {
   void loadJobs()
-})
-
-onDestroy(() => {
-  if (searchTimer)
-    clearTimeout(searchTimer)
 })
 </script>
 

--- a/storage/framework/defaults/resources/components/Dashboard/Models/ModelRecordsDashboard.stx
+++ b/storage/framework/defaults/resources/components/Dashboard/Models/ModelRecordsDashboard.stx
@@ -230,26 +230,17 @@ function toggleSort(column: ColumnMeta) {
   void load()
 }
 
-// Debounced so a query is not fired per keystroke. The timer id is module
-// scope rather than signal state: it is bookkeeping, not something the
-// template renders.
-let searchTimer: ReturnType<typeof setTimeout> | undefined
-
-function onSearchInput() {
-  clearTimeout(searchTimer)
-  searchTimer = setTimeout(() => {
-    page.set(1)
-    void load()
-  }, 250)
-}
+// Debounced so a query is not fired per keystroke. Search and the per-column
+// filters deliberately share one debounce, the way they shared one timer id
+// before: typing in either should schedule a single reload, not two.
+const onSearchInput = useDebounce(() => {
+  page.set(1)
+  void load()
+}, 250)
 
 function onFilterInput(column: string, event: Event) {
   filters.set({ ...filters(), [column]: (event.target as HTMLInputElement).value })
-  clearTimeout(searchTimer)
-  searchTimer = setTimeout(() => {
-    page.set(1)
-    void load()
-  }, 250)
+  onSearchInput()
 }
 
 function clearFilters() {

--- a/tests/unit/dashboard-native-bindings.test.ts
+++ b/tests/unit/dashboard-native-bindings.test.ts
@@ -800,9 +800,13 @@ describe('dashboard native STX bindings', () => {
     expect(requestDetails).toContain('<Modal')
     expect(requestDetails).toContain('Recorded')
 
+    // Search stays debounced, but the timer belongs to useDebounce rather than
+    // the component. The composable registers its own onDestroy, so a
+    // hand-rolled timer id plus teardown here is the thing to guard against
+    // now, not the thing to require (#2290).
     const jobs = componentSource('Jobs/JobHistory.stx')
-    expect(jobs).toContain('setTimeout(reloadFilters, 250)')
-    expect(jobs).toContain('onDestroy(')
+    expect(jobs).toContain('useDebounce(reloadFilters, 250)')
+    expect(jobs).not.toMatch(/setTimeout|clearTimeout/)
 
     const queries = componentSource('Queries/QueryDashboard.stx')
     expect(queries).toContain('const itemsPerPage = state(50)')


### PR DESCRIPTION
Six of the seventeen "an stx primitive already covers this" findings from #2290. The tooltip half stays parked on stacksjs/stx#1922.

All six are the same shape: a module-scope `searchTimer`, a `clearTimeout` + `setTimeout` pair per call site, and an `onDestroy` to clear it. `useDebounce(fn, delay)` registers its own `onDestroy`, so the variable and the teardown both go with it.

```diff
-let searchTimer: ReturnType<typeof setTimeout> | undefined
-
-function reloadSearch(): void {
-  if (searchTimer)
-    clearTimeout(searchTimer)
-  searchTimer = setTimeout(reloadFilters, 250)
-}
+const reloadSearch = useDebounce(reloadFilters, 250)
...
-onDestroy(() => {
-  if (searchTimer)
-    clearTimeout(searchTimer)
-})
```

37 lines out, 12 in, across `GlobalSearch.stx`, `Jobs/JobHistory.stx`, and `Models/ModelRecordsDashboard.stx`. No `searchTimer` left in the tree.

In `ModelRecordsDashboard` the search input and per-column filters now share one debounced function. That is what sharing a single `searchTimer` id already did: typing in either schedules one reload, not two.

## Why only six of seventeen

Worked all seventeen. The other eleven should not be migrated, for three different reasons.

**Three are false positives.** All three `click-outside` findings are `document.addEventListener('click', …)` used for event **delegation** — reacting to clicks that land *inside* `[data-stx-qty-dec]`, `[data-stx-add-to-cart]`, `[data-stx-gallery-thumb]`. `useClickOutside(ref, fn)` fires on clicks *outside* a target. Opposite semantics; migrating would break all three. Each already carries a comment explaining why delegation was chosen (SPA fragment swaps re-injecting scoped scripts, multiple galleries on one page, duplicate-listener guards).

**Two are correct as written.** Both `fetch` findings thread an `AbortController` *into* a typed project helper — `fetchGlobalSearch(value, signal)`, `fetchNotificationDeliveryHistory({ …, signal })` — with a last-write-wins guard (`if (searchRequest === request)`). `useFetch(url)` takes a URL, so adopting it means inlining the endpoint and query construction and dropping the typed helper. Not a drop-in.

**Six are blocked upstream** by the same class of bug as the tooltip runtime, reported on stacksjs/stx#1922:

| composable | in browser bundle | in `STX_RUNTIME_GLOBALS` | |
|---|---|---|---|
| `useDebounce` / `useThrottle` | yes | yes | usable — what this PR uses |
| `useFetch` | yes | yes | usable |
| `useClickOutside` | yes | yes | usable |
| `useSearchParams` | **no** | yes | declared, never shipped to the client |
| `useClipboard` | yes | **no** | shipped, never declared |
| `useShare` / `useAsyncData` | no | no | neither |

So the 3 `search-params` and 3 `clipboard` findings recommend primitives that would throw a ReferenceError if adopted verbatim.

## Verification

- `stx typecheck` error counts identical before and after on all three files (4, 3, 8 — all pre-existing module-resolution and inference errors, none on changed lines). Verified by running against the stashed tree.
- `pickier` clean.
- `stx codemod` no longer reports any `debounce` finding; the count drops 6 → 0.

## One correction to #2290's tally

There are no `env` findings. The three counted earlier were the dotenv loader's own `[env] loaded 32/45 variables` log lines matching the grep, not codemod output. The seventeen are exactly: debounce 6, clipboard 3, search-params 3, click-outside 3, fetch 2.