### PR TITLE
fix(auth): set the auth cookie on every path that starts a session

### DIFF
--- a/storage/framework/defaults/app/Actions/Auth/LoginAction.ts
+++ b/storage/framework/defaults/app/Actions/Auth/LoginAction.ts
@@ -1,5 +1,5 @@
 import { Action } from '@stacksjs/actions'
-import { Auth, createTwoFactorChallenge, getTwoFactorState } from '@stacksjs/auth'
+import { Auth, authCookie, createTwoFactorChallenge, getTwoFactorState } from '@stacksjs/auth'
 import { User } from '@stacksjs/orm'
 import { response } from '@stacksjs/router'
 import { schema } from '@stacksjs/validation'
@@ -66,6 +66,15 @@ export default new Action({
     // The legacy `token` field is kept for backward compatibility
     // with clients that haven't been updated yet — it shadows
     // `access_token` and will be removed in a future major.
+    //
+    // The same token also goes out as an httpOnly cookie, matching
+    // SocialCallbackAction. Without it, how a browser ends up signed in
+    // depended on which way it signed in: OAuth left a cookie, email+password
+    // left only JSON, and a server-rendered page cannot read JSON — it posts a
+    // form, follows a redirect, and comes back carrying nothing but cookies.
+    // So the first authenticated document render had no way to identify the
+    // user (#2306). The body is unchanged, so an API client that ignores the
+    // cookie behaves exactly as before.
     return response.json({
       access_token: result.token,
       refresh_token: result.refreshToken,
@@ -77,6 +86,6 @@ export default new Action({
         email: user?.email,
         name: user?.name,
       },
-    })
+    }, { headers: { 'Set-Cookie': authCookie(result.token) } })
   },
 })

--- a/storage/framework/defaults/app/Actions/Auth/RefreshTokenAction.ts
+++ b/storage/framework/defaults/app/Actions/Auth/RefreshTokenAction.ts
@@ -1,5 +1,5 @@
 import { Action } from '@stacksjs/actions'
-import { refreshToken } from '@stacksjs/auth'
+import { authCookie, refreshToken } from '@stacksjs/auth'
 import { response } from '@stacksjs/router'
 import { schema } from '@stacksjs/validation'
 
@@ -25,12 +25,16 @@ export default new Action({
         refreshExpiresInDays: 30, // 30 day refresh token
       })
 
+      // Rotation invalidates the token the cookie was carrying, so a cookie
+      // left untouched here would go stale at the exact moment the session was
+      // meant to be extended: the browser keeps presenting a revoked token
+      // while the JSON body holds a live one it cannot read (#2306).
       return response.json({
         access_token: result.plainTextToken,
         refresh_token: result.refreshToken,
         token_type: 'Bearer',
         expires_in: result.expiresIn,
-      })
+      }, { headers: { 'Set-Cookie': authCookie(result.plainTextToken) } })
     }
     catch (error: any) {
       return response.unauthorized(error.message || 'Invalid or expired refresh token')

--- a/storage/framework/defaults/app/Actions/Auth/RegisterAction.ts
+++ b/storage/framework/defaults/app/Actions/Auth/RegisterAction.ts
@@ -1,5 +1,5 @@
 import { Action } from '@stacksjs/actions'
-import { Auth, register } from '@stacksjs/auth'
+import { Auth, authCookie, register } from '@stacksjs/auth'
 import { dispatch } from '@stacksjs/events'
 import { response } from '@stacksjs/router'
 import { schema } from '@stacksjs/validation'
@@ -53,6 +53,10 @@ export default new Action({
       // were signed out an hour into their first session while every other
       // user refreshed normally (stacksjs/stacks#2212). The legacy `token`
       // alias stays for backward compatibility.
+      // Registering signs the account in, so it is a session-issuing path like
+      // the other three and carries the cookie for the same reason: the very
+      // next thing a server-rendered app does is redirect to an authenticated
+      // page (#2306).
       return response.json({
         access_token: result.token,
         refresh_token: result.refreshToken,
@@ -64,7 +68,7 @@ export default new Action({
           email: user?.email,
           name: user?.name,
         },
-      })
+      }, { headers: { 'Set-Cookie': authCookie(result.token) } })
     }
 
     return response.error('Registration failed')

--- a/storage/framework/defaults/app/Actions/Auth/VerifyTwoFactorLoginAction.ts
+++ b/storage/framework/defaults/app/Actions/Auth/VerifyTwoFactorLoginAction.ts
@@ -1,5 +1,5 @@
 import { Action } from '@stacksjs/actions'
-import { Auth, consumeTwoFactorChallenge, verifyTwoFactorLoginCode } from '@stacksjs/auth'
+import { Auth, authCookie, consumeTwoFactorChallenge, verifyTwoFactorLoginCode } from '@stacksjs/auth'
 import { response } from '@stacksjs/router'
 import { schema } from '@stacksjs/validation'
 
@@ -41,6 +41,10 @@ export default new Action({
 
     const user = result.user
 
+    // This is where a 2FA account's session actually begins — LoginAction
+    // deliberately mints nothing for these users until the code is verified —
+    // so the cookie belongs here too. Setting it only on LoginAction would
+    // have left every 2FA account exactly where it started (#2306).
     return response.json({
       access_token: result.token,
       refresh_token: result.refreshToken,
@@ -52,6 +56,6 @@ export default new Action({
         email: user?.email,
         name: user?.name,
       },
-    })
+    }, { headers: { 'Set-Cookie': authCookie(result.token) } })
   },
 })

--- a/tests/unit/auth-session-cookie-contract.test.ts
+++ b/tests/unit/auth-session-cookie-contract.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Every action that starts a browser session must set the auth cookie, and
+ * every action that ends one must clear it.
+ *
+ * The bug this pins (#2306): `SocialCallbackAction` set the cookie and nothing
+ * else did, so how a browser ended up signed in depended on which way it signed
+ * in. OAuth left a cookie; email+password left only JSON, which a
+ * server-rendered page cannot read — it posts a form, follows a redirect, and
+ * comes back carrying nothing but cookies. The first authenticated document
+ * render therefore had no way to identify the user.
+ *
+ * This is a contract over the shipped defaults rather than an HTTP test because
+ * there is no harness that invokes an Action and inspects its response headers.
+ * It asserts the requirement (this path handles the session cookie) rather than
+ * how it is written, so it survives refactors while still failing if a new
+ * sign-in path is added without one.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const ACTIONS = 'storage/framework/defaults/app/Actions/Auth'
+
+function action(name: string): string {
+  return readFileSync(resolve(`${ACTIONS}/${name}.ts`), 'utf8')
+}
+
+/** Actions that hand a browser a live session and must therefore set it. */
+const SESSION_ISSUING = [
+  'LoginAction',
+  'VerifyTwoFactorLoginAction',
+  'RegisterAction',
+  'SocialCallbackAction',
+]
+
+describe('auth session cookie contract (#2306)', () => {
+  test.each(SESSION_ISSUING)('%s sets the auth cookie', (name) => {
+    expect(action(name)).toMatch(/authCookie\(/)
+  })
+
+  test('the 2FA path is covered, not just the password path', () => {
+    // LoginAction deliberately mints no token for a 2FA account — it returns a
+    // challenge — so covering only LoginAction would leave every 2FA user
+    // exactly where they started.
+    const login = action('LoginAction')
+    expect(login).toContain('requires_two_factor: true')
+    expect(action('VerifyTwoFactorLoginAction')).toMatch(/authCookie\(/)
+  })
+
+  test('rotation re-sets the cookie so it cannot go stale', () => {
+    // Refreshing invalidates the token the cookie was carrying. Leaving it
+    // untouched would expire the browser's session at the exact moment it was
+    // meant to be extended.
+    expect(action('RefreshTokenAction')).toMatch(/authCookie\(/)
+  })
+
+  test.each(['LogoutAction', 'LogoutAllAction'])('%s clears the auth cookie', (name) => {
+    expect(action(name)).toMatch(/clearAuthCookie\(/)
+  })
+
+  test('minting an API token does not start a browser session', () => {
+    // CreateTokenAction issues a personal access token the caller will send as
+    // a bearer header. A cookie there would sign the browser in as a side
+    // effect of asking for an API credential.
+    expect(action('CreateTokenAction')).not.toMatch(/authCookie\(/)
+  })
+
+  test('the JSON body still carries the token for API clients', () => {
+    // The cookie is additive. A client that ignores Set-Cookie must behave
+    // exactly as it did before, so the OAuth2 payload stays intact.
+    for (const name of ['LoginAction', 'VerifyTwoFactorLoginAction', 'RegisterAction']) {
+      const source = action(name)
+      expect(source).toContain('access_token:')
+      expect(source).toContain('refresh_token:')
+      expect(source).toContain("token_type: 'Bearer'")
+    }
+  })
+})


### PR DESCRIPTION
Steps 2 and 3 of #2306, on top of #2308. Combined because they are the same decision applied to the same set of actions.

## The decision

**Always set, no config flag.** Nothing in a config should have to be switched on before server-rendered auth works; `SocialCallbackAction` already sets it unconditionally, so a flag would make the framework's own sign-in paths differently-configurable, which is the inconsistency being fixed. The JSON body is untouched, so an API client that ignores `Set-Cookie` behaves exactly as before.

## Four session-issuing paths, not one

The report named `LoginAction`. Auditing everything that calls `loginUsingId` or mints a session turned up three more:

| action | before | after |
|---|---|---|
| `LoginAction` | none | sets |
| `VerifyTwoFactorLoginAction` | none | sets |
| `RegisterAction` | none | sets |
| `SocialCallbackAction` | sets | unchanged |
| `RefreshTokenAction` | none | re-sets on rotation |
| `CreateTokenAction` | none | **deliberately still none** |

**`VerifyTwoFactorLoginAction` matters most of the three.** `LoginAction` deliberately mints no token for a 2FA account — it returns a challenge, and the session actually begins on verification. Setting the cookie only on `LoginAction` would have left every 2FA account exactly where it started.

**`RegisterAction`** mints a session and returns the same OAuth2 payload; registering signs the account in, and the next thing a server-rendered app does is redirect to an authenticated page.

**`RefreshTokenAction`** re-sets it because rotation invalidates the token the cookie was carrying. Left alone, the cookie goes stale at the exact moment the session was meant to be extended: the browser keeps presenting a revoked token while the JSON body holds a live one it cannot read.

**`CreateTokenAction` is excluded on purpose.** It issues a personal access token the caller will send as a bearer header. A cookie there would sign the browser in as a side effect of asking for an API credential.

## Verified on the wire

`response.json(data, { headers })` reaches the response with the body intact:

```
status: 200
content-type: application/json
set-cookie: auth-token=abc; Path=/; Max-Age=3600; HttpOnly; SameSite=Lax
body: {"access_token":"abc","token":"abc"}
```

(No `Secure` there only because the probe ran against a loopback `APP_URL` — that is `shouldSecureAuthCookie`'s documented behaviour, and an HTTPS app URL always gets it.)

## Test

New `tests/unit/auth-session-cookie-contract.test.ts`, in the `*-contract.test.ts` style this repo already uses for the shipped defaults, since there is no harness that invokes an Action and inspects response headers.

It asserts the *requirement* — this path handles the session cookie — rather than how it is written, so it survives refactors while still failing if a new sign-in path is added without one. That distinction is deliberate: #2305 had to undo a test that pinned an exact implementation string and blocked a legitimate refactor.

**Fails 5 of 10 without this change**, passes 10/10 with it.

Root suite 328 pass / 0 fail. `typecheck` 13 (baseline). `pickier` clean.

## On the HttpOnly point from the issue

Still true and still intended: this **replaces** a client-side mirror rather than complementing it, because a page script cannot read an httpOnly cookie. An app currently writing its own JS-readable cookie should drop that mirror and read the framework's, pointing `config.auth.cookie.name` at its existing name if it wants to keep it. That is also why this lands after #2308 rather than before — otherwise it would mint cookies the framework could not clear.