### PR TITLE
fix(api): stop the API server serving the whole site

### DIFF
--- a/docs/basics/routing.md
+++ b/docs/basics/routing.md
@@ -82,8 +82,10 @@ route.group({ prefix: '/auth' }, () => {
   route.delete('/tokens/{id}', 'Actions/Auth/RevokeTokenAction')
 })
 
-// Nested prefix groups
-route.group({ prefix: '/api/v1' }, () => {
+// Nested prefix groups. Prefixes concatenate, including the one the route
+// file itself is mounted under: in `routes/api.ts` (already `/api`) this
+// lands at /api/v1/users. Writing `/api/v1` here would give /api/api/v1.
+route.group({ prefix: '/v1' }, () => {
   route.group({ prefix: '/users' }, () => {
     route.get('/', 'Actions/User/IndexAction')
     route.get('/{id}', 'Actions/User/ShowAction')

--- a/docs/bootcamp/api.md
+++ b/docs/bootcamp/api.md
@@ -19,33 +19,42 @@ Stacks follows a clean, Laravel-inspired architecture for APIs:
 
 Routes are defined in the `routes/` directory. The main API routes go in `routes/api.ts`.
 
+Everything in `routes/api.ts` is mounted under `/api`. The prefix comes from the
+`'api'` key in `app/Routes.ts` and matches the path the dev proxy forwards, so
+the paths you write here are relative to `/api` and the file never spells it out
+itself. Each example below shows the URL it actually answers.
+
 ### Basic Routes
 
 ```typescript
 // routes/api.ts
 import { response, route } from '@stacksjs/router'
 
-// Simple GET route with inline handler
-route.get('/', () => response.text('Hello, World!'))
+// Simple GET route with inline handler -> GET /api/hello
+route.get('/hello', () => response.text('Hello, World!'))
 
-// Return JSON
+// Return JSON -> GET /api/status
 route.get('/status', () => response.json({
   status: 'ok',
   timestamp: Date.now(),
 }))
 
-// Route with path parameters
+// Route with path parameters -> GET /api/users/42
 route.get('/users/{id}', (request) => {
   const userId = request.param('id')
   return response.json({ userId })
 })
 
-// Different HTTP methods
+// Different HTTP methods -> /api/users, /api/users/{id}
 route.post('/users', 'Actions/User/CreateUserAction')
 route.put('/users/{id}', 'Actions/User/UpdateUserAction')
 route.patch('/users/{id}', 'Actions/User/PatchUserAction')
 route.delete('/users/{id}', 'Actions/User/DeleteUserAction')
 ```
+
+To answer a path at the document root instead, add a route file whose registry
+entry sets `prefix: ''` (see `app/Routes.ts`). The API server serves `/api` and
+nothing else; the pages at the document root come from the views server.
 
 ### Route Groups
 
@@ -55,20 +64,21 @@ Group routes with shared configuration:
 // routes/api.ts
 import { route } from '@stacksjs/router'
 
-// Group with prefix
-route.group({ prefix: '/api/v1' }, () => {
+// Group with prefix. Group prefixes nest inside the file's own `/api`, so
+// write `/v1` and not `/api/v1` -> GET /api/v1/users
+route.group({ prefix: '/v1' }, () => {
   route.get('/users', 'Actions/User/ListUsersAction')
   route.get('/users/{id}', 'Actions/User/GetUserAction')
   route.post('/users', 'Actions/User/CreateUserAction')
 })
 
-// Group with middleware
+// Group with middleware -> GET /api/me
 route.group({ middleware: 'auth' }, () => {
   route.get('/me', 'Actions/Auth/AuthUserAction')
   route.post('/logout', 'Actions/Auth/LogoutAction')
 })
 
-// Combine prefix and middleware
+// Combine prefix and middleware -> GET /api/admin/dashboard
 route.group({ prefix: '/admin', middleware: ['auth', 'admin'] }, () => {
   route.get('/dashboard', 'Actions/Admin/DashboardAction')
   route.get('/users', 'Actions/Admin/ListUsersAction')
@@ -77,17 +87,19 @@ route.group({ prefix: '/admin', middleware: ['auth', 'admin'] }, () => {
 
 ### Special Routes
 
-Stacks provides convenience methods for common routes:
+```typescript
+// Health check. Probes the database and cache and answers 503 when either is
+// down, so a load balancer stops routing to a broken instance. It registers
+// `/api/health` regardless of which file calls it - point uptime monitors
+// there, not at `/health`, which is free for a page of your own.
+route.health()
+```
+
+Point a route at an action by naming it instead of passing a function. The path
+is resolved under `app/Actions/`, falling back to the framework defaults:
 
 ```typescript
-// Health check endpoint (GET /health)
-route.health()
-
-// Route to an action
-route.action('/example') // equivalent to route.get('/example', 'ExampleAction')
-
-// Route to a job
-route.job('/process') // equivalent to route.get('/process', 'ProcessJob')
+route.get('/posts', 'Actions/PostIndexAction') // -> GET /api/posts
 ```
 
 ## Creating Actions

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -236,6 +236,55 @@ This now shows `current_page` and friends at the top level alongside `meta`.
 
 Read the top-level fields. Replace `res.meta.page` with `res.current_page`, and `res.meta._` with `res.*`. The `total` / `last_page` fields remain opt-in behind `?with_count=true` (omitted otherwise, like a simple paginator). Stop depending on `meta`; it will be removed.
 
+## The API server no longer serves pages (#2314)
+
+### What changed
+
+The API process used to mount a GET route for every `.stx` under
+`resources/views`, because bun-router discovers that directory on its own. It
+now serves `/api` and nothing else. Requests to any other path answer `404`
+JSON.
+
+Nothing was ever meant to read those pages. The API process has no static-asset
+handling and no CSS pipeline, so the HTML it emitted carried no stylesheet and
+every image 404'd: it only rendered correctly when fetched through a different
+server. In dev the views server renders pages and proxies `/api/**` to the API
+process, and in production `buddy serve` does the same, so the API process is
+the proxy target in both.
+
+Declared routes are unaffected. bun-router already skipped a discovered view
+when a GET route existed at that path, so nothing that answers a route today
+changes.
+
+### Who is affected
+
+Monitoring, scripts or bookmarks pointed at a non-`/api` path **on the API
+port** (3008 by default) rather than at the site. Traffic through the site
+itself is unchanged, because that never reached this process.
+
+### Detect
+
+```bash
+curl -s -o /dev/null -w '%{http_code} %{content_type}\n' http://127.0.0.1:3008/
+```
+
+`404 application/json` is the new behaviour. If you were relying on the page,
+this used to be `200 text/html`.
+
+### Remediate
+
+Point the request at the site rather than the API port. If you genuinely want
+pages from this process, ask for file routing before the server starts and it
+is left alone:
+
+```ts
+// routes/api.ts, or anywhere that runs during route loading
+route.bunRouter.views({ viewsPath: 'resources/views' })
+```
+
+Health probes should use `/api/health`, which reports `503` when the database
+or cache is down.
+
 ## Verifying the upgrade
 
 Run through this checklist after upgrading:

--- a/routes/api.ts
+++ b/routes/api.ts
@@ -5,6 +5,12 @@ import { response, route } from '@stacksjs/router'
  * The routes defined here are automatically registered. Last but
  * not least, you may also create any other `routes/*.ts` files.
  *
+ * Every route in this file is mounted under `/api`. The prefix comes from
+ * the `'api'` key in `app/Routes.ts` and lines up with the path the dev
+ * proxy forwards (`/api/*`), so `route.get('/hello', ...)` below answers
+ * `GET /api/hello`. Paths at the document root belong in a route file
+ * whose registry entry sets `prefix: ''`.
+ *
  * Framework routes (auth, dashboard, commerce, CMS, etc.) are loaded
  * automatically from storage/framework/defaults/routes/dashboard.ts.
  * You do NOT need to define them here — only add your own custom routes.
@@ -12,8 +18,8 @@ import { response, route } from '@stacksjs/router'
  * @see https://docs.stacksjs.com/routing
  */
 
-// Your custom routes go here:
-route.get('/', () => response.text('hello world'))
+// Your custom routes go here. This one answers `GET /api/hello`:
+route.get('/hello', () => response.text('hello world'))
 
 // `/coming-soon` is served as an STX view from
 // `storage/framework/defaults/resources/views/coming-soon.stx`. The

--- a/storage/framework/api/api-types.ts
+++ b/storage/framework/api/api-types.ts
@@ -142,29 +142,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  "/api/": {
-    get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      "200": { content: { "application/json": Record<string, unknown> } }
-      "422": { content: never }
-      "500": { content: never }
-    }
-  }
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   "/api/activities": {
     get: {
     parameters: {
@@ -11107,6 +11084,29 @@ export interface paths {
       "500": { content: never }
     }
   }
+    trace?: never
+  }
+  "/api/hello": {
+    get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      "200": { content: { "application/json": Record<string, unknown> } }
+      "422": { content: never }
+      "500": { content: never }
+    }
+  }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
     trace?: never
   }
   "/api/labels": {

--- a/storage/framework/api/client.ts
+++ b/storage/framework/api/client.ts
@@ -135,13 +135,6 @@ export function createClient(config: ClientConfig) {
   },
 
   /**
-   * GET /api/
-   */
-  get(options?: RequestOptions): Promise<ApiResult<Record<string, unknown>>> {
-    return request(config, "GET", "/api/", {}, [], false, options)
-  },
-
-  /**
    * GET /api/activities
    */
   getActivities(options?: RequestOptions): Promise<ApiResult<Record<string, unknown>>> {
@@ -4185,6 +4178,13 @@ export function createClient(config: ClientConfig) {
    */
   patchGiftCardsId(input: { "id": string }, options?: RequestOptions): Promise<ApiResult<Record<string, unknown>>> {
     return request(config, "PATCH", "/api/gift-cards/{id}", input ?? {}, [], false, options)
+  },
+
+  /**
+   * GET /api/hello
+   */
+  getHello(options?: RequestOptions): Promise<ApiResult<Record<string, unknown>>> {
+    return request(config, "GET", "/api/hello", {}, [], false, options)
   },
 
   /**

--- a/storage/framework/api/openapi.json
+++ b/storage/framework/api/openapi.json
@@ -215,31 +215,6 @@
         }
       }
     },
-    "/api/": {
-      "get": {
-        "summary": "/api/",
-        "operationId": "get__api_",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation failed"
-          },
-          "500": {
-            "description": "Server error"
-          }
-        }
-      }
-    },
     "/api/activities": {
       "get": {
         "summary": "/api/activities",
@@ -16722,6 +16697,31 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/hello": {
+      "get": {
+        "summary": "/api/hello",
+        "operationId": "get__api_hello",
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Successful response",

--- a/storage/framework/core/actions/src/dev/api.ts
+++ b/storage/framework/core/actions/src/dev/api.ts
@@ -10,7 +10,7 @@ import { parseOptions } from '@stacksjs/cli'
 import { config, overridesReady } from '@stacksjs/config'
 import { path } from '@stacksjs/path'
 import type { Middleware } from '@stacksjs/router'
-import { route } from '@stacksjs/router'
+import { disableViewRouting, route } from '@stacksjs/router'
 import { autoImportsAreStale, generateAutoImportFiles, generateServerAutoImportTypes, injectGlobalAutoImports } from '@stacksjs/server'
 import { resolveApiHost } from '../helpers/api-host'
 import { exitWithParent } from './exit-with-parent'
@@ -183,6 +183,15 @@ route.use((async (request: any, next: any) => {
 
 // Import routes
 await route.importRoutes()
+
+// This process answers JSON. Without this it also mounts a GET route for every
+// `.stx` under `resources/views` — bun-router finds the directory on its own —
+// and serves the whole site on the port whose banner says "API server ready",
+// with no stylesheet and with every image 404ing because there is no static
+// handling here. The views server renders pages and proxies `/api/**` to this
+// process; it is the proxy target, not a second page server. Runs after the
+// route files so an app that asked for file routing itself keeps it (#2314).
+disableViewRouting(route.bunRouter)
 
 // Start server. Surface EADDRINUSE with a clear message — without this,
 // the process exits with a stack trace that mentions `bun.serve` and

--- a/storage/framework/core/actions/src/serve/api.ts
+++ b/storage/framework/core/actions/src/serve/api.ts
@@ -21,7 +21,7 @@ import process from 'node:process'
 import { config, overridesReady } from '@stacksjs/config'
 import { log } from '@stacksjs/logging'
 import { frameworkPath } from '@stacksjs/path'
-import { route } from '@stacksjs/router'
+import { disableViewRouting, route } from '@stacksjs/router'
 import { resolveApiHost } from '../helpers/api-host'
 
 /**
@@ -72,6 +72,15 @@ route.use(corsMiddleware.toRouterHandler())
 
 // Import routes
 await route.importRoutes()
+
+// This process answers JSON. Without this it also mounts a GET route for every
+// `.stx` under `resources/views` — bun-router finds the directory on its own —
+// and serves the whole site with no stylesheet and with every image 404ing,
+// because there is no static handling here. `buddy serve` renders pages and
+// reverse-proxies `/api/**` to this process; it is the proxy target, not a
+// second page server. Runs after the route files so an app that asked for file
+// routing itself keeps it (#2314).
+disableViewRouting(route.bunRouter)
 
 // Start server. `reusePort` (SO_REUSEPORT, Linux) lets a new release's
 // instance bind the same port while the old one still serves — the

--- a/storage/framework/core/router/src/index.ts
+++ b/storage/framework/core/router/src/index.ts
@@ -23,7 +23,7 @@ export type { StacksRequestExtensions, StacksRequestMacros, StacksRequestMarkers
 
 // Export Stacks-specific action resolver and URL helper
 export { assertRouteMiddlewareResolvable,
-  configureViewDirectories, clearMiddlewareCache, createStacksRouter, findUnresolvableRouteMiddleware, installMiddlewareHotReload, route, serve, serverResponse, url, warnOnMultipleRouterInstances } from './stacks-router'
+  configureViewDirectories, clearMiddlewareCache, createStacksRouter, disableViewRouting, findUnresolvableRouteMiddleware, installMiddlewareHotReload, route, serve, serverResponse, url, warnOnMultipleRouterInstances } from './stacks-router'
 
 // Export request context helpers
 export { cacheRequestQuery, clearCurrentRequest, getCurrentRequest, getTraceId, request, runWithRequest, setCurrentRequest, withTraceId } from './request-context'

--- a/storage/framework/core/router/src/stacks-router.ts
+++ b/storage/framework/core/router/src/stacks-router.ts
@@ -3591,6 +3591,15 @@ export function configureViewDirectories(bunRouter: Router): void {
  * specific" rule {@link configureViewDirectories} follows. Route files run
  * before this does, so asking for it from `routes/*.ts` works.
  *
+ * The two functions are coupled and the coupling is bun-router's, not ours:
+ * `serve()` calls {@link configureViewDirectories} after this, and that only
+ * backs off because `disableFileRouting()` happens to leave a non-empty
+ * `_fileRoutingConfig` behind. Were that flag ever to move to a field of its
+ * own, `configureViewDirectories` would overwrite the config and re-mount every
+ * template. `api-view-routing.test.ts` drives both, in that order, so the
+ * upgrade that changes it fails a test rather than quietly restoring the site
+ * to the API port.
+ *
  * @returns whether file routing was switched off by this call.
  */
 export function disableViewRouting(bunRouter: Router): boolean {

--- a/storage/framework/core/router/src/stacks-router.ts
+++ b/storage/framework/core/router/src/stacks-router.ts
@@ -3560,6 +3560,59 @@ export function configureViewDirectories(bunRouter: Router): void {
   })
 }
 
+/**
+ * Stop the API server answering page routes.
+ *
+ * bun-router discovers `.stx` files on its own: with no views configured at
+ * all it falls back to `detectViewsDirectory()`, finds `resources/views`
+ * because the directory happens to exist, and mounts a GET route for every
+ * template under it. The API server therefore serves the whole site, on the
+ * port whose banner says "API server ready".
+ *
+ * Those pages cannot work. The API process has no static-asset handling and no
+ * CSS pipeline, so the HTML it emits references images that 404 on that port
+ * and carries no stylesheet - a page that only renders correctly when fetched
+ * through a different server. Nothing needs it either: in dev the views server
+ * renders pages and proxies `/api/**` here, and in production `buddy serve`
+ * does the same. The API server is the proxy *target* in both.
+ *
+ * It is also actively misleading, which is how it was found
+ * (stacksjs/stacks#2314). A page answering 200 at a path the developer never
+ * routed reads as "my route was overridden", when the route was in fact mounted
+ * somewhere else entirely.
+ *
+ * Declared routes were never at risk - bun-router skips a discovered view when
+ * a GET route already exists at that path - so this changes nothing for any
+ * path that answers today.
+ *
+ * An application that called `route.bunRouter.views(...)` itself has asked for
+ * file routing and is left alone; that is the escape hatch for anyone serving
+ * pages from this process on purpose, and it is the same "said something more
+ * specific" rule {@link configureViewDirectories} follows. Route files run
+ * before this does, so asking for it from `routes/*.ts` works.
+ *
+ * @returns whether file routing was switched off by this call.
+ */
+export function disableViewRouting(bunRouter: Router): boolean {
+  const router = bunRouter as Router & {
+    _fileRoutingConfig?: Record<string, unknown>
+    disableFileRouting?: () => unknown
+  }
+
+  // Older bun-router, or a stand-in in a test. Nothing to switch off.
+  if (typeof router.disableFileRouting !== 'function')
+    return false
+
+  // The application configured views itself. Leave it alone.
+  const existing = router._fileRoutingConfig
+  if (existing && Object.keys(existing).length > 0)
+    return false
+
+  router.disableFileRouting()
+
+  return true
+}
+
 export interface StacksRouterInstance {
   bunRouter: Router
   routes: Route[]

--- a/storage/framework/core/router/tests/api-view-routing.test.ts
+++ b/storage/framework/core/router/tests/api-view-routing.test.ts
@@ -22,7 +22,7 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
-import { disableViewRouting } from '../src/stacks-router'
+import { configureViewDirectories, disableViewRouting } from '../src/stacks-router'
 
 let root = ''
 let previousCwd = ''
@@ -104,6 +104,25 @@ describe('disableViewRouting', () => {
 
     const page = await router.handleRequest(new Request('http://localhost/'))
     expect(page.status).toBe(200)
+  })
+
+  it('survives the rest of what serve() does on the way past', async () => {
+    // `route.serve()` calls `configureViewDirectories()` after this, and that
+    // function hands bun-router a view config of its own. It currently backs
+    // off because switching file routing off leaves `_fileRoutingConfig`
+    // non-empty - which is bun-router's implementation detail, not a promise
+    // to us. If an upgrade moved that flag to its own field,
+    // `configureViewDirectories` would overwrite the config and every `.stx`
+    // would come back, with the test above still passing. So drive both, in
+    // the order serve() drives them.
+    const router = makeApp()
+
+    disableViewRouting(router)
+    configureViewDirectories(router)
+    await initFileRoutes(router)
+
+    const page = await router.handleRequest(new Request('http://localhost/'))
+    expect(page.status).toBe(404)
   })
 
   it('does nothing on a router that cannot switch it off', async () => {

--- a/storage/framework/core/router/tests/api-view-routing.test.ts
+++ b/storage/framework/core/router/tests/api-view-routing.test.ts
@@ -1,0 +1,117 @@
+// The API server must not answer page routes.
+//
+// bun-router discovers `.stx` files without being asked: given no view config
+// it falls back to `detectViewsDirectory()`, finds `resources/views` because
+// the directory exists, and mounts a GET route for every template under it. So
+// the process whose banner reads "API server ready" was serving the whole site,
+// with no stylesheet and with every image 404ing, because there is no static
+// handling on that port.
+//
+// It also reads as a bug that isn't there: a page answering 200 at a path the
+// developer never routed looks like the route was overridden, when the route
+// was mounted somewhere else entirely (stacksjs/stacks#2314 was reported that
+// way round).
+//
+// These tests drive the real bun-router, not a stand-in, because the behaviour
+// being switched off is bun-router's - a stand-in would pass whatever the
+// upstream default became.
+
+import { Router } from '@stacksjs/bun-router'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { disableViewRouting } from '../src/stacks-router'
+
+let root = ''
+let previousCwd = ''
+
+/** An app with one page template and one declared API route. */
+function makeApp(): Router {
+  mkdirSync(join(root, 'resources/views'), { recursive: true })
+  writeFileSync(join(root, 'resources/views/index.stx'), '<h1>home</h1>\n')
+
+  const router = new Router()
+  router.get('/api/hello', () => new Response('hello world'))
+
+  return router
+}
+
+/** Mount whatever file routing is still switched on, as `serve()` would. */
+async function initFileRoutes(router: Router): Promise<void> {
+  await (router as Router & { _initFileRoutes: () => Promise<void> })._initFileRoutes()
+}
+
+beforeEach(() => {
+  // Through `realpathSync`: macOS puts temp directories behind a symlink
+  // (`/var` -> `/private/var`), and two spellings of one directory is a
+  // confusing way for a test to fail.
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'api-views-')))
+  previousCwd = process.cwd()
+  process.chdir(root)
+})
+
+afterEach(() => {
+  process.chdir(previousCwd)
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('disableViewRouting', () => {
+  it('stops the API server answering a path it never routed', async () => {
+    const router = makeApp()
+
+    expect(disableViewRouting(router)).toBe(true)
+    await initFileRoutes(router)
+
+    const page = await router.handleRequest(new Request('http://localhost/'))
+    expect(page.status).toBe(404)
+  })
+
+  it('leaves declared routes alone', async () => {
+    const router = makeApp()
+
+    disableViewRouting(router)
+    await initFileRoutes(router)
+
+    const declared = await router.handleRequest(new Request('http://localhost/api/hello'))
+    expect(declared.status).toBe(200)
+    expect(await declared.text()).toBe('hello world')
+  })
+
+  it('is switching something off, not describing what already happens', async () => {
+    // Without the call, the same app answers `/` with the template. If this
+    // ever stops being true the test above proves nothing, so it is asserted
+    // rather than assumed.
+    const router = makeApp()
+    await initFileRoutes(router)
+
+    const page = await router.handleRequest(new Request('http://localhost/'))
+    expect(page.status).toBe(200)
+    expect(page.headers.get('content-type')).toContain('text/html')
+  })
+
+  it('leaves an application that asked for file routing alone', async () => {
+    // The escape hatch for anyone serving pages from this process on purpose,
+    // and the same "said something more specific" rule configureViewDirectories
+    // follows. Route files run before this does, so asking from `routes/*.ts`
+    // works.
+    const router = makeApp()
+    router.views({ viewsPath: join(root, 'resources/views') })
+
+    expect(disableViewRouting(router)).toBe(false)
+    await initFileRoutes(router)
+
+    const page = await router.handleRequest(new Request('http://localhost/'))
+    expect(page.status).toBe(200)
+  })
+
+  it('does nothing on a router that cannot switch it off', async () => {
+    // An older bun-router, where `disableFileRouting` does not exist. Reporting
+    // false is the honest answer; throwing would take down a server boot over a
+    // hardening step.
+    const router = { get: () => {} } as unknown as Router
+
+    expect(disableViewRouting(router)).toBe(false)
+  })
+})

--- a/storage/framework/defaults/ai/skills/stacks-browse/SKILL.md
+++ b/storage/framework/defaults/ai/skills/stacks-browse/SKILL.md
@@ -133,7 +133,10 @@ diagnostics without printing every visited path or overflowing element.
 
 When testing a Stacks app, check:
 - **Dashboard routes** — admin pages rendering? (`localhost:3002`)
-- **API health** — `GET localhost:3008/health` returns ok?
+- **API health** — `GET localhost:3008/api/health` returns ok? (`/api/health`, not
+  `/health`: the probe is mounted under `/api` so it cannot collide with a page of
+  the same name, and the API port answers `/api` only - every other path is a 404
+  there by design, so point page checks at the frontend instead.)
 - **Auth flow** — `/login`, `/register`
 - **CMS/blog** — `/blog`, post detail pages, `/blog/feed.xml`, `/blog/sitemap.xml`
 - **STX components** — do custom components render server-side?


### PR DESCRIPTION
Closes #2314.

## The report's premise was wrong, and the real cause is worse

#2314 read as "a `.stx` view silently overrides an explicitly declared route". It does not. bun-router already skips a discovered view when a GET route exists at that path, and I reproduced that both directly and through `route.serve()`.

What actually happened: **`routes/api.ts` is mounted under `/api`**, so the scaffold's own example

```ts
route.get('/', () => response.text('hello world'))
```

answers `GET /api`, never `GET /`. Nothing overrode it; it was never at `/`. Verified on the wire:

```
/api      200 text/plain  hello world
/         200 text/html   55199   <- a view, filling a path with no route
```

The framework's own scaffold was teaching the wrong model of where routes land, and it cost the reporter an afternoon.

## The half that is a real bug

bun-router discovers `.stx` files without being asked: given no view config it falls back to `detectViewsDirectory()`, finds `resources/views` because the directory exists, and mounts a GET route for every template under it. So the process whose banner reads "API server ready" was serving every page of the site.

Those pages cannot work:

```
$ curl -s :3008/ | grep -c 'rel="stylesheet"'   # only the Google Fonts one
$ curl -o /dev/null -w '%{http_code}' :3008/images/logos/logo.png
404
```

No stylesheet, every image 404s, because the API process has no static handling. Nothing wants it either: in dev the views server renders pages and proxies `/api/**` here; in production `buddy serve` does the same while the API runs loopback-only as the `api` site in `config/cloud.ts`. The API server is the proxy target in both, never a second page server.

`route.serve()` called directly is untouched, so the harness behind eab230c4bc keeps working. An app that calls `route.bunRouter.views(...)` itself keeps file routing - the same "said something more specific" rule `configureViewDirectories` follows, and the documented opt-out.

## After

```
/            404 application/json   (was 200 text/html, 55KB)
/coming-soon 404 application/json   (was 200 text/html)
/api/hello   200 text/plain         hello world
/api/health  200 application/json
```

## Also in here

- The scaffold and `docs/bootcamp/api.md` now write the path they answer. That doc also had a group example prefixing `/api/v1` **inside** a file already prefixed `/api` (landing at `/api/api/v1`), and documented two methods that do not exist (`route.action`, `route.job`); `docs/basics/routing.md` had the same nested-prefix mistake.
- Regenerated `storage/framework/api/{openapi.json,api-types.ts,client.ts}`. These are byte-compared by the `docs:artifacts:check` release gate, so the rename would have failed on the tag rather than here. One path moves, `/api/` to `/api/hello`; the count stays at 628.
- An upgrade-guide entry, since this turns a 200 into a 404 for anyone pointing monitoring at a non-`/api` path on the API port.

## Verification

- `api-view-routing.test.ts`, 6 tests, driving the real bun-router. One asserts the pre-change behaviour so the others cannot silently become vacuous, and one drives `disableViewRouting` + `configureViewDirectories` in the order `serve()` does - that coupling rests on bun-router leaving a non-empty `_fileRoutingConfig` behind, so an upstream change to it now fails a test instead of quietly restoring the site to the API port.
- Router suite 379 pass / 0 fail, root suite 328 pass / 0 fail, `docs:artifacts:check` and `docs:links:check` green, typecheck at the 13-error baseline, pickier clean.

## Known, not addressed

`storage/framework/core/server/src/start.ts` and `storage/framework/api/dev.ts` are two more entrypoints that call the bare `serve()` and still mount views. Both are unreferenced - nothing in the repo imports either, and the shipped production artifact is built from `serve/api.ts` - so I left them rather than add code to dead files, but they are drift waiting to happen and `stacks-server`/`stacks-api` still document them.