### PR TITLE
fix(auth): put back the module mocks that made Auth untestable

### DIFF
--- a/storage/framework/core/auth/tests/register.test.ts
+++ b/storage/framework/core/auth/tests/register.test.ts
@@ -27,12 +27,22 @@ import { HttpError } from '@stacksjs/error-handling'
 // package rely on (password-reset-revocation.test.ts queries the real
 // `db`; reset.ts hashes with the real `makeHash`) and put them back in
 // afterAll. The spread matters: mocking patches the live namespace in
-// place, so a bare namespace capture would "restore" the mock itself.
-// `@stacksjs/orm` / `../src/authentication` stay mocked — no other
-// test file here imports them, and capturing the real ones would boot
-// the full ORM/model graph this file exists to avoid.
+// place, so a bare namespace capture would "restore" the mock itself —
+// which also means the capture has to happen BEFORE the mock below.
+//
+// Every mock this file installs is captured, including
+// `../src/authentication` and `@stacksjs/orm`. An earlier version left
+// those two mocked on the way out, reasoning that no other file in the
+// directory imported them. That was wrong, and it did not fail loudly:
+// `Auth` stayed a plain object carrying nothing but the `createTokenForUser`
+// stub below, so every later file in a whole-directory run saw
+// `Auth.revokeToken` and friends as undefined, and the class behind the
+// framework's documented auth entry point could not be covered by a test
+// that runs in CI at all (stacksjs/stacks#2309).
 const realDatabase = { ...await import('@stacksjs/database') }
 const realSecurity = { ...await import('@stacksjs/security') }
+const realOrm = { ...await import('@stacksjs/orm') }
+const realAuthentication = { ...await import('../src/authentication') }
 // Read at module scope (top-level await is fine here, inside a `describe` it is
 // not). #2281's cases toggle `auth.registration` on the live config object,
 // which `duplicateEmailError` reads per call.
@@ -41,6 +51,8 @@ const realConfig = await import('@stacksjs/config')
 afterAll(() => {
   mock.module('@stacksjs/database', () => realDatabase)
   mock.module('@stacksjs/security', () => realSecurity)
+  mock.module('@stacksjs/orm', () => realOrm)
+  mock.module('../src/authentication', () => realAuthentication)
 })
 
 // ─── Shared recording state ─────────────────────────────────────────

--- a/storage/framework/core/auth/tests/revoke-token-cascade.test.ts
+++ b/storage/framework/core/auth/tests/revoke-token-cascade.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Signing out must take the refresh token with it (stacksjs/stacks#2306).
+ *
+ * The cascade used to live inline in `logout()`, which only ran for a request
+ * carrying an Authorization header. Every other revoke path - `logoutCookie()`
+ * above all, and "sign out everywhere" - revoked the access token and left the
+ * paired refresh token alive, so a refresh that leaked before the sign-out
+ * could still be exchanged for a fresh access token afterwards. Signing out is
+ * the one action a person takes *because* they think something is wrong, and it
+ * was the action that did not close the hole.
+ *
+ * #2308 moved the cascade into `Auth.revokeToken()` so every caller gets it.
+ * These tests pin that: each of the three revoke entry points, checked against
+ * the `oauth_refresh_tokens` row rather than against how the cascade is
+ * written.
+ *
+ * They could not run when they were written. `Auth` resolved to a plain object
+ * with no static methods in a whole-directory run, because `register.test.ts`
+ * left `../src/authentication` mocked on the way out and `mock.module` is
+ * process-wide (stacksjs/stacks#2309). The file was dropped rather than land
+ * red; this is it restored, with that mock now captured and put back.
+ *
+ * They boot the real query builder against a throwaway SQLite file, following
+ * `password-reset-revocation.test.ts` - the schema comes from the migrator, not
+ * from a fourth hand-written copy of it.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+
+const DB_PATH = join(tmpdir(), `stacks-2306-cascade-${process.pid}.sqlite`)
+process.env.DB_CONNECTION = 'sqlite'
+process.env.DB_DATABASE_PATH = DB_PATH
+process.env.APP_ENV = 'testing'
+
+const { acquireDbConfigLock, db, ensureDatabaseConfigLoaded, initializeDbConfig } = await import('@stacksjs/database')
+const { ensureFrameworkAuthTables } = await import('./helpers/auth-schema')
+const { createToken } = await import('../src/tokens')
+const { Auth } = await import('../src/authentication')
+
+const USER_ID = 4242
+const OTHER_USER_ID = 4343
+
+/**
+ * Re-pin the lazy `db` proxy to THIS file's SQLite path. Two forces move the
+ * shared singleton: `@stacksjs/database` kicks off a background config reload
+ * at module load, and bun runs a whole directory in one process, so a sibling
+ * file's hooks can win the connection between our tests. Draining the one-shot
+ * reload first means it cannot fire again after we force.
+ */
+async function forceConfig(): Promise<void> {
+  await ensureDatabaseConfigLoaded()
+  initializeDbConfig({
+    app: { env: 'testing' },
+    database: {
+      default: 'sqlite',
+      connections: { sqlite: { database: DB_PATH, prefix: '' } },
+    },
+  })
+}
+
+/** Is the refresh token paired with this access token still usable? */
+async function refreshTokenLiveFor(accessTokenId: number): Promise<boolean> {
+  const rows = await db.unsafe(
+    `SELECT revoked FROM oauth_refresh_tokens WHERE access_token_id = ? LIMIT 1`,
+    [accessTokenId],
+  ).execute()
+
+  const row = (rows as any[])[0]
+  expect(row).toBeDefined()
+
+  return !row.revoked
+}
+
+async function accessTokenLive(accessTokenId: number): Promise<boolean> {
+  const rows = await db.unsafe(
+    `SELECT revoked FROM oauth_access_tokens WHERE id = ? LIMIT 1`,
+    [accessTokenId],
+  ).execute()
+
+  return !(rows as any[])[0]?.revoked
+}
+
+let releaseDbConfigLock: () => void
+
+beforeAll(async () => {
+  // Holds `initializeDbConfig`'s process-wide config mutex for this file's
+  // lifetime (stacksjs/stacks#1862) - released in afterAll.
+  releaseDbConfigLock = await acquireDbConfigLock()
+  await forceConfig()
+
+  // Seeds the personal access client `createToken()` requires, too.
+  await ensureFrameworkAuthTables()
+})
+
+beforeEach(async () => {
+  await forceConfig()
+})
+
+afterAll(() => {
+  if (existsSync(DB_PATH))
+    unlinkSync(DB_PATH)
+  releaseDbConfigLock?.()
+})
+
+describe('revoking an access token revokes the refresh token paired with it (#2306)', () => {
+  test('revokeToken() cascades, so a leaked refresh cannot outlive the sign-out', async () => {
+    const session = await createToken(USER_ID, 'cascade-bearer', ['*'], { withRefreshToken: true })
+    const id = Number(session.accessToken.id)
+
+    expect(await refreshTokenLiveFor(id)).toBe(true)
+
+    await Auth.revokeToken(session.plainTextToken)
+
+    expect(await accessTokenLive(id)).toBe(false)
+    expect(await refreshTokenLiveFor(id)).toBe(false)
+  })
+
+  test('revokeTokenById() cascades, which is the cookie sign-out path', async () => {
+    // `logoutCookie()` has no plain token to hash - it holds the row id. This
+    // is the path that was leaving refresh tokens alive.
+    const session = await createToken(USER_ID, 'cascade-by-id', ['*'], { withRefreshToken: true })
+    const id = Number(session.accessToken.id)
+
+    await Auth.revokeTokenById(id)
+
+    expect(await accessTokenLive(id)).toBe(false)
+    expect(await refreshTokenLiveFor(id)).toBe(false)
+  })
+
+  test('revokeAllTokens() cascades across every session, and stops at the user', async () => {
+    const first = await createToken(USER_ID, 'cascade-all-1', ['*'], { withRefreshToken: true })
+    const second = await createToken(USER_ID, 'cascade-all-2', ['*'], { withRefreshToken: true })
+    const stranger = await createToken(OTHER_USER_ID, 'cascade-other', ['*'], { withRefreshToken: true })
+
+    await Auth.revokeAllTokens(USER_ID)
+
+    for (const session of [first, second]) {
+      const id = Number(session.accessToken.id)
+      expect(await accessTokenLive(id)).toBe(false)
+      expect(await refreshTokenLiveFor(id)).toBe(false)
+    }
+
+    // "Sign out everywhere" means everywhere for one account, not everyone.
+    const strangerId = Number(stranger.accessToken.id)
+    expect(await accessTokenLive(strangerId)).toBe(true)
+    expect(await refreshTokenLiveFor(strangerId)).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #2309.

## Cause

`register.test.ts` stubs four modules with `mock.module`, which is process-wide and which bun does not restore between files. It restored two and left `@stacksjs/orm` and `../src/authentication` mocked on the way out, on the reasoning - written into the file - that no other test in the directory imported either.

The issue text ruled this out ("the only mocked module in that directory is `@stacksjs/email`"). That was wrong; the mock is at `register.test.ts:143`. The probe says so exactly:

```
PROBE keys: [ "createTokenForUser" ]
```

`Auth` was this file's stub object, verbatim, for every file that ran afterwards.

## Why it matters

```
bun test ./storage/framework/core/auth/tests/<one file>   # function function
bun test ./storage/framework/core/auth/tests/             # object undefined
```

`Auth` is the documented, Laravel-shaped entry point - `Auth.attempt`, `Auth.user`, `Auth.logout`, `Auth.revokeToken` - and CI runs the directory, so none of it could be covered by a test that runs in CI. It failed in the direction that hides: a test calling `Auth.anything()` gets `undefined is not a function`, which reads as a broken test rather than a poisoned namespace, and every existing test in the directory reaches auth behaviour through the standalone functions in `tokens.ts`, so nothing tripped over it.

## Fix

Capture both before installing the mock and restore them in `afterAll`, exactly as the other two already were. The comment's objection - that capturing them boots the ORM/model graph this file exists to avoid - does not hold: standalone `register.test.ts` goes 310ms to 316ms.

## Restores the test #2308 could not land

`revoke-token-cascade.test.ts` pins that all three revoke entry points take the paired refresh token with them, so a refresh that leaked before a sign-out cannot be exchanged afterwards. `revokeTokenById()` is the cookie path, and it is the one that was leaving them alive. It also pins that "sign out everywhere" stops at the account.

Re-verified by removing the three `revokeRefreshTokensFor` calls: 3/3 fail without them, 3/3 pass with them, this time in a whole-directory run. It boots the real query builder against a throwaway SQLite file and takes its schema from the migrator, following `password-reset-revocation.test.ts` rather than adding a fourth hand-written copy of the DDL.

## Verification

`core/auth` 303 pass / 0 fail (was 300, plus these 3), root suite 328 pass / 0 fail, typecheck at the 13-error baseline, pickier clean.