### PR TITLE
fix(composables): stop useTimeAgo's getter test racing the clock

### DIFF
--- a/storage/framework/core/composables/tests/timing.test.ts
+++ b/storage/framework/core/composables/tests/timing.test.ts
@@ -822,7 +822,18 @@ describe('useTimeAgo', () => {
   })
 
   it('should accept a getter function', () => {
-    const result = useTimeAgo(() => Date.now() - 120 * 1000)
+    // The timestamp is captured here rather than computed inside the getter,
+    // and it deliberately is not a round two minutes.
+    //
+    // `update()` reads its own `Date.now()` BEFORE calling the getter, so a
+    // getter that computes `Date.now()` itself yields
+    // `diff = 120000 - (elapsed between the two reads)` - at most exactly two
+    // minutes, and under it the moment the clock ticks once. `formatTimeAgo`
+    // floors, so 119999ms is "1 minute ago". The test passed only while both
+    // reads landed in the same millisecond, which an idle laptop manages and a
+    // loaded CI runner does not.
+    const past = Date.now() - 125 * 1000
+    const result = useTimeAgo(() => past)
     expect(result.value).toBe('2 minutes ago')
   })
 


### PR DESCRIPTION
Surfaced on an unrelated PR's CI run, where this failed while `main` was green on the same test. It is not flaky in the "sometimes the machine is slow" sense - it could only ever pass by luck.

## Why

```ts
const result = useTimeAgo(() => Date.now() - 120 * 1000)
expect(result.value).toBe('2 minutes ago')
```

`update()` (`useTimeAgo.ts:89-94`) reads `now = Date.now()` **before** calling the getter:

```ts
const now = Date.now()          // T1
const target = getTimestamp()   // calls the getter, which reads Date.now() -> T2 >= T1
const diff = now - target       // 120000 - (T2 - T1)
```

So `diff` is at most exactly 120000, and less the moment the clock ticks once. `formatTimeAgo` floors, so 119999ms is `"1 minute ago"`. The assertion holds only while both reads land in the same millisecond - which an idle laptop manages (8/8 locally) and a loaded CI runner does not.

Deterministic, by burning one millisecond inside the getter:

```
getter computing Date.now() itself    -> 1 minute ago
getter returning a captured timestamp -> 2 minutes ago
```

## Fix

Capture the timestamp before the call, the way the two sibling tests in the same block already do - which is why only this one flaked - and move it off the bucket boundary to 125s. What the test exists to check, that a getter is accepted at all, is unchanged.

`timing.test.ts` 103 pass / 0 fail, pickier clean.