### PR TITLE
feat(deploy): say when production data has no way back

### DIFF
--- a/storage/framework/core/buddy/src/commands/deploy.ts
+++ b/storage/framework/core/buddy/src/commands/deploy.ts
@@ -16,6 +16,7 @@ import { ExitCode } from '@stacksjs/types'
 import { getErrorCode, getErrorMessage } from '@stacksjs/utils'
 import { ensureAppKey, ensureDeployEnvIsSet, ensureEnvIsSet } from './setup'
 import { resultFailed } from '../result'
+import { findUnbackedManagedServices, unbackedDataMessage } from '../unbacked-data'
 
 // Use console.log for clean output without timestamps
 const log = {
@@ -1326,6 +1327,15 @@ async function deployToHetzner(tsCloudConfig: any, deployEnv: string, options: D
     log.error('Upgrade @stacksjs/ts-cloud (bun update @stacksjs/ts-cloud), or point TS_CLOUD_MODULE at a build that has it.')
     process.exit(ExitCode.FatalError)
   }
+
+  // Say it before the deploy, not after: this run is about to `migrate` against
+  // data that has no restore path, and a schema change is the likeliest way an
+  // app loses it. Not a refusal - the operator may know, and a deploy is the
+  // wrong place to argue - but it will not happen silently, which is how it
+  // went unnoticed in the app that opened stacksjs/stacks#2313.
+  const unbacked = findUnbackedManagedServices(tsCloudConfig)
+  if (unbacked.length > 0)
+    log.warn(`[deploy] ${unbackedDataMessage(unbacked)}`)
 
   try {
     await runHetznerDeploy({ tsCloudConfig, environment, verbose, docker: (options as any).docker === true, createCloudDriver, deployAllComputeSites, ensureManagementDashboard, resolveSiteKind, onlySite: (options as any).site || undefined, persistedAttachBox })

--- a/storage/framework/core/buddy/src/commands/doctor.ts
+++ b/storage/framework/core/buddy/src/commands/doctor.ts
@@ -453,6 +453,37 @@ export function doctor(buddy: CLI): void {
         })
       }
 
+      // Stateful services provisioned on the compute instance with nothing
+      // backing them up. A warning rather than a failure: the app runs, and
+      // whether that risk is acceptable is the operator's call. It is here
+      // because the alternative is finding out the way the report that opened
+      // stacksjs/stacks#2313 did, which is after the disk is gone.
+      await probe(checks, 'Database backups', async () => {
+        const fs = await import('node:fs')
+        const cloudConfig = resolve(process.cwd(), 'config/cloud.ts')
+        if (!fs.existsSync(cloudConfig))
+          return 'No config/cloud.ts (skipped)'
+
+        const { findUnbackedManagedServices, unbackedDataMessage } = await import('../unbacked-data')
+
+        let tsCloud: unknown
+        try {
+          tsCloud = (await import(cloudConfig)).tsCloud
+        }
+        catch {
+          // Evaluating config/cloud.ts can fail for reasons of its own (a
+          // missing env var, a bad import). Not this probe's business to
+          // report, and the deploy says it far more loudly.
+          throw new ProbeWarning('could not read config/cloud.ts (skipped)')
+        }
+
+        const unbacked = findUnbackedManagedServices(tsCloud)
+        if (unbacked.length === 0)
+          return 'No unbacked managed data services'
+
+        throw new ProbeWarning(unbackedDataMessage(unbacked))
+      })
+
       // .env decryption — verify enc: values can be decrypted with the
       // configured private key, if any are present. No-op when there
       // are no encrypted values or no key.

--- a/storage/framework/core/buddy/src/unbacked-data.ts
+++ b/storage/framework/core/buddy/src/unbacked-data.ts
@@ -1,0 +1,117 @@
+/**
+ * Which stateful services this project runs on its own compute instance with
+ * nothing backing them up.
+ *
+ * `managedServices: { postgres: true }` is one boolean, and it decides that the
+ * only copy of the application's data lives on the same disk as the web
+ * process. Nothing in the framework then takes a dump, a snapshot, or anything
+ * offsite, and nothing says so - which is how it goes unnoticed
+ * (stacksjs/stacks#2313).
+ *
+ * The asymmetry that makes it worth saying out loud: `buddy deploy` runs
+ * `migrate` on every deploy. The framework is willing to run a schema change
+ * against production data it has no way to restore.
+ *
+ * ## Why this reports rather than fixes
+ *
+ * ts-cloud already carries a full backup subsystem - destinations, policies,
+ * retention, recovery points, verification, restore planning - but its logical
+ * database source runs `pg_dumpall` through `runtime.exec()` against a **data
+ * container**, and throws `Data container <name> was not found` for anything
+ * else. `managedServices` installs the engine from pantry as a boot-time
+ * systemd service, so there is no container and none of that machinery can
+ * reach it.
+ *
+ * Writing the dump here instead would mean hand-rolling the admin connection,
+ * and that is the part which is not obvious: pantry's postgres grants `trust`
+ * on the local unix socket but requires md5 over TCP loopback, where the
+ * `postgres` superuser has no password - so an on-box admin command must omit
+ * `-h` entirely and let the client find the socket. ts-cloud knows this and
+ * encodes it in `pgAdminCommand()`, which is declared in its types but exported
+ * from none of its entry points. A second copy of that rule in this repo would
+ * be wrong the first time upstream changed it.
+ *
+ * So the dump belongs upstream, next to the code that installed the engine, and
+ * this file's job is to make sure nobody finds out the way bughq did.
+ */
+
+/** A stateful service running on the instance with no backup path. */
+export interface UnbackedService {
+  /** The `managedServices` key, e.g. `postgres`. */
+  name: string
+  /** What is lost with the disk, in one clause. */
+  holds: string
+}
+
+/**
+ * Services whose contents cannot be rebuilt from anything else on the box.
+ *
+ * Caches and derived indexes are deliberately absent: losing redis, memcached
+ * or a meilisearch index costs a rebuild, not the data itself, and warning
+ * about them would train people to ignore the warning that matters.
+ */
+const STATEFUL_SERVICES: Record<string, string> = {
+  postgres: 'the application database',
+  mysql: 'the application database',
+  mariadb: 'the application database',
+  vitess: 'the application database',
+}
+
+/** Is this `managedServices` entry actually switched on? */
+function isEnabled(value: unknown): boolean {
+  if (value === true)
+    return true
+
+  if (!value || typeof value !== 'object')
+    return false
+
+  // An object is a configuration, so it is on unless it says otherwise.
+  return (value as { enabled?: boolean }).enabled !== false
+}
+
+/**
+ * Read the `managedServices` block of a ts-cloud config and return the stateful
+ * services it provisions on the instance.
+ *
+ * Every one of them is unbacked today, so presence in this list is the whole
+ * finding. When a `backups` surface exists, this is where it gets consulted.
+ */
+export function findUnbackedManagedServices(tsCloudConfig: unknown): UnbackedService[] {
+  const managed = (tsCloudConfig as any)?.infrastructure?.compute?.managedServices
+
+  if (!managed || typeof managed !== 'object')
+    return []
+
+  const out: UnbackedService[] = []
+
+  for (const [name, holds] of Object.entries(STATEFUL_SERVICES)) {
+    if (isEnabled(managed[name]))
+      out.push({ name, holds })
+  }
+
+  return out
+}
+
+/**
+ * The sentence `doctor` and `deploy` both say. One wording, so the two cannot
+ * drift into describing the situation differently.
+ */
+export function unbackedDataMessage(services: UnbackedService[]): string {
+  const first = services[0]
+
+  // Both callers check the list first, but a message helper that crashes on an
+  // empty list is a warning path that can take down the command it was meant to
+  // warn during.
+  if (!first)
+    return 'No unbacked managed data services.'
+
+  const names = services.map(s => s.name).join(', ')
+  const one = services.length === 1
+  const subject = one ? `${names} is` : `${names} are`
+  const holds = first.holds.charAt(0).toUpperCase() + first.holds.slice(1)
+
+  return `${subject} provisioned on the compute instance and nothing backs ${one ? 'it' : 'them'} up: `
+    + `no dump, no snapshot, nothing offsite, and no restore path. ${holds} shares a disk with the web process, `
+    + 'and `buddy deploy` runs `migrate` against it on every deploy. Until a backup surface lands (stacksjs/stacks#2313), '
+    + 'take your own dump on a schedule and copy it off the box.'
+}

--- a/storage/framework/core/buddy/tests/unbacked-data.test.ts
+++ b/storage/framework/core/buddy/tests/unbacked-data.test.ts
@@ -1,0 +1,88 @@
+/**
+ * `managedServices: { postgres: true }` puts the only copy of an app's data on
+ * the same disk as the web process, and nothing backs it up
+ * (stacksjs/stacks#2313). These pin what gets reported, and - just as
+ * importantly - what does not: a warning that fires for a redis cache is a
+ * warning people learn to scroll past, and the one it is hiding is the one
+ * about the database.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { findUnbackedManagedServices, unbackedDataMessage } from '../src/unbacked-data'
+
+function config(managedServices: unknown): unknown {
+  return { infrastructure: { compute: { managedServices } } }
+}
+
+describe('findUnbackedManagedServices', () => {
+  it('reports the boolean form from the docs', () => {
+    const found = findUnbackedManagedServices(config({ postgres: true }))
+
+    expect(found.map(s => s.name)).toEqual(['postgres'])
+  })
+
+  it('reports a configured service, since a configuration means it is on', () => {
+    // The shape apps actually ship: an object of settings, no `enabled` key.
+    const found = findUnbackedManagedServices(config({
+      vitess: { mode: 'cluster', cell: 'zone1', vtgatePort: 15306 },
+    }))
+
+    expect(found.map(s => s.name)).toEqual(['vitess'])
+  })
+
+  it('says nothing about caches and derived indexes', () => {
+    // Losing these costs a rebuild, not the data. Warning about them is how a
+    // warning stops being read.
+    const found = findUnbackedManagedServices(config({
+      redis: true,
+      memcached: true,
+      meilisearch: { masterKey: 'x' },
+    }))
+
+    expect(found).toEqual([])
+  })
+
+  it('reports every stateful engine, not just the first', () => {
+    const found = findUnbackedManagedServices(config({ postgres: true, mysql: true, redis: true }))
+
+    expect(found.map(s => s.name).sort()).toEqual(['mysql', 'postgres'])
+  })
+
+  it('honours an explicit opt-out', () => {
+    expect(findUnbackedManagedServices(config({ postgres: { enabled: false } }))).toEqual([])
+    expect(findUnbackedManagedServices(config({ postgres: false }))).toEqual([])
+  })
+
+  it('says nothing about a database this project did not provision', () => {
+    // An app pointed at RDS, Neon or a managed Postgres has backups from its
+    // provider and never wrote `managedServices` at all.
+    expect(findUnbackedManagedServices(config(undefined))).toEqual([])
+    expect(findUnbackedManagedServices({ infrastructure: { compute: {} } })).toEqual([])
+    expect(findUnbackedManagedServices({})).toEqual([])
+    expect(findUnbackedManagedServices(undefined)).toEqual([])
+  })
+})
+
+describe('unbackedDataMessage', () => {
+  it('names the service and what is about to run against it', () => {
+    const message = unbackedDataMessage(findUnbackedManagedServices(config({ postgres: true })))
+
+    expect(message).toContain('postgres is provisioned on the compute instance')
+    expect(message).toContain('no dump, no snapshot, nothing offsite, and no restore path')
+    // The asymmetry that makes this worth interrupting a deploy for.
+    expect(message).toContain('`migrate`')
+  })
+
+  it('does not crash the command it was meant to warn during', () => {
+    // Both callers check the list first, so this is unreachable today. It is
+    // pinned anyway: a warning helper that throws takes down a deploy.
+    expect(() => unbackedDataMessage([])).not.toThrow()
+  })
+
+  it('reads correctly for more than one service', () => {
+    const message = unbackedDataMessage(findUnbackedManagedServices(config({ postgres: true, mysql: true })))
+
+    expect(message).toContain('are provisioned')
+    expect(message).toContain('backs them up')
+  })
+})


### PR DESCRIPTION
Refs #2313. This is the half that does not have to wait for upstream; see below for why the other half does.

## What lands

`buddy doctor` grows a `Database backups` probe, and `buddy deploy` warns before it starts:

```
⚠ Database backups  postgres is provisioned on the compute instance and nothing backs it up:
                    no dump, no snapshot, nothing offsite, and no restore path. The application
                    database shares a disk with the web process, and `buddy deploy` runs
                    `migrate` against it on every deploy. Until a backup surface lands
                    (stacksjs/stacks#2313), take your own dump on a schedule and copy it off
                    the box.
```

Both go through one `findUnbackedManagedServices()` so they cannot drift into describing the situation differently. A warning, not a refusal: whether the risk is acceptable is the operator's call, and a deploy is the wrong place to argue about it.

Caches and derived indexes are deliberately not reported. Losing redis, memcached or a meilisearch index costs a rebuild rather than the data, and warning about them is how a warning stops being read - taking the one about the database with it.

## Correcting the issue's evidence

The issue greps `@stacksjs/cloud` and finds no backup mechanism. The code is in `@stacksjs/ts-cloud`, and it is there - a whole subsystem: destinations, policies, retention, recovery points, jobs, verification, restore planning, `pg_dumpall`, `mysqldump`.

**None of it can reach `managedServices`.** The logical database source runs the dump through container exec:

```js
async exportLogicalBackup(id) {
  const name = runtimeId(id), inspect = await this.runtime.inspect(name)
  if (!inspect) throw new Error(`Data container ${name} was not found.`)
  ...
  dump = await this.runtime.exec(name, ['sh', '-c', '... exec pg_dumpall ...'])
```

`managedServices` installs the engine from pantry as a boot-time systemd service - ts-cloud's own `db-provision` docs say so. No container, so that path throws for every Stacks deploy. So the issue's conclusion is right even though its evidence pointed at the wrong package, and the gap is sharper than "nobody wrote a backup": the backup subsystem exists and the provisioning path it was written for is not the one Stacks uses.

## Why the dump itself is not in this PR

It would mean hand-rolling the admin connection here, and that is the part that is not obvious. From ts-cloud's own `db-provision.d.ts`:

> The pantry postgres pg_hba grants `trust` on the local unix socket but requires md5 password auth over TCP loopback - and the `postgres` superuser has no password - so against the co-located engine admin clients MUST use the socket: omit `-h` entirely.

It encodes that in `pgAdminCommand(database, 'pg_dump')`, alongside `isLocalDatabase()` and `buildDatabaseSetupScript()`. All three are declared in the shipped types and exported from **none** of the entry points:

```
pgAdminCommand undefined
isLocalDatabase undefined
buildDatabaseSetupScript undefined
```

(`@stacksjs/ts-cloud`, `/drivers`, and a direct subpath import all fail.) A second copy of that pg_hba rule in this repo would be wrong the first time upstream changed it, which is the definition of the workaround we do not ship.

## The split I would suggest

- **ts-cloud** exports the dump/restore primitives for services it provisions, or better, owns `beforeMigrations` for them - it installed the engine and is the only layer that knows how to talk to it.
- **Stacks** owns the `backups` config surface the issue sketches, the pre-migration hook, and this warning, which then becomes conditional instead of unconditional.

The seam on this side already exists: `runsMigrations(site)` in `deploy.ts` identifies the site that runs `migrate`, and `applyPersistentStatePaths` already rewrites sites to add shared paths, which is where a dump target outside the release tree would go.

## Verification

`unbacked-data.test.ts`, 9 tests: the boolean form from the docs, the configured-object form apps actually ship, multiple engines, the explicit opt-out, an app on a managed database that never wrote `managedServices`, that caches are not reported, and that the message helper cannot throw and take the deploy with it. Confirmed against this repo's real `config/cloud.ts` via `buddy doctor` (it reports `vitess`).

buddy suite 383 pass / 0 fail, root suite 328 pass / 0 fail, typecheck at the 13-error baseline, pickier clean.