### PR TITLE
fix(env): ship runtime path dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -226,7 +226,7 @@
       "dependencies": {
         "@stacksjs/composables": "workspace:*",
         "@stacksjs/stx": "^0.2.176",
-        "bun-query-builder": "^0.2.29",
+        "bun-query-builder": "^0.2.30",
       },
       "devDependencies": {
         "@stacksjs/utils": "workspace:*",
@@ -481,7 +481,7 @@
       "version": "0.70.372",
       "dependencies": {
         "@stacksjs/ts-validation": "^0.5.4",
-        "bun-query-builder": "^0.2.29",
+        "bun-query-builder": "^0.2.30",
         "dynamodb-tooling": "^0.3.2",
       },
       "devDependencies": {
@@ -594,8 +594,10 @@
     "storage/framework/core/env": {
       "name": "@stacksjs/env",
       "version": "0.70.372",
-      "devDependencies": {
+      "dependencies": {
         "@stacksjs/path": "workspace:*",
+      },
+      "devDependencies": {
         "@stacksjs/validation": "workspace:*",
         "better-dx": "^0.2.17",
       },
@@ -782,7 +784,7 @@
       "version": "0.70.372",
       "dependencies": {
         "@stacksjs/ts-validation": "^0.5.4",
-        "bun-query-builder": "^0.2.29",
+        "bun-query-builder": "^0.2.30",
       },
       "devDependencies": {
         "@stacksjs/config": "workspace:*",
@@ -831,7 +833,7 @@
       "name": "@stacksjs/query-builder",
       "version": "0.70.372",
       "dependencies": {
-        "bun-query-builder": "^0.2.29",
+        "bun-query-builder": "^0.2.30",
       },
       "devDependencies": {
         "@stacksjs/database": "workspace:*",
@@ -1070,7 +1072,7 @@
         "@stacksjs/clapp": "^0.2.12",
         "@stacksjs/stx": "^0.2.176",
         "@stacksjs/ts-validation": "^0.5.4",
-        "bun-query-builder": "^0.2.29",
+        "bun-query-builder": "^0.2.30",
       },
       "devDependencies": {
         "@stacksjs/validation": "workspace:*",
@@ -1543,7 +1545,7 @@
 
     "bun-plugin-stx": ["bun-plugin-stx@0.2.179", "", { "dependencies": { "@stacksjs/stx": "^0.2.72", "stx-router": "^0.2.72" }, "bin": { "serve": "./dist/serve.js", "stx-serve": "./dist/serve.js" } }, "sha512-PeI823oH4e4cEAjbA5XWSP+9s9Fn0uee+a5LzOlleVNLfboTPDXL8Z5xv4hBGgaj5HQ9KOvq08KlCYe1rqUVrA=="],
 
-    "bun-query-builder": ["bun-query-builder@0.2.29", "", { "dependencies": { "@stacksjs/clapp": "^0.2.12", "@stacksjs/ts-faker": "^0.1.8", "@stacksjs/ts-validation": "^0.5.2", "dynamodb-tooling": "^0.3.5" }, "bin": { "query-builder": "./dist/bin/cli.js", "qbx": "./dist/bin/cli.js", "qb": "./dist/bin/cli.js" } }, "sha512-5jZyGXWb1ffVQQvN24052MeWUibb9q01dMgV//PuYliR7Js/v+ZPMGKCqQYToo+Ojwm6hqetvle4rldZvzGBtA=="],
+    "bun-query-builder": ["bun-query-builder@0.2.30", "", { "dependencies": { "@stacksjs/clapp": "^0.2.12", "@stacksjs/ts-faker": "^0.1.8", "@stacksjs/ts-validation": "^0.5.2", "dynamodb-tooling": "^0.3.5" }, "bin": { "query-builder": "./dist/bin/cli.js", "qbx": "./dist/bin/cli.js", "qb": "./dist/bin/cli.js" } }, "sha512-ng7dwgsa5vhfocCDfj15j93rEQvqT5XMuA3VmyuEvVwzIk8IsPbOFtUVPbf1eY1e9dpVeffpOGa09MxiVTLDpQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -1818,6 +1820,8 @@
     "better-dx/@stacksjs/bunpress": ["@stacksjs/bunpress@0.1.21", "", { "dependencies": { "@stacksjs/stx": "^0.2.82", "@stacksjs/ts-cloud": "^0.7.51", "@stacksjs/ts-md": "^0.1.1", "bunfig": "^0.15.6" }, "bin": { "bunpress": "./dist/bin/cli.js" } }, "sha512-F44YG7rylrrrDasCK0RLUvOCuMFzXiJPM+Y22FgLc1dq1nYlRmZ+wk/3IRndWVGIiCyy0FsWKDka7ktk345SAA=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "stacks/bun-query-builder": ["bun-query-builder@0.2.29", "", { "dependencies": { "@stacksjs/clapp": "^0.2.12", "@stacksjs/ts-faker": "^0.1.8", "@stacksjs/ts-validation": "^0.5.2", "dynamodb-tooling": "^0.3.5" }, "bin": { "query-builder": "./dist/bin/cli.js", "qbx": "./dist/bin/cli.js", "qb": "./dist/bin/cli.js" } }, "sha512-5jZyGXWb1ffVQQvN24052MeWUibb9q01dMgV//PuYliR7Js/v+ZPMGKCqQYToo+Ojwm6hqetvle4rldZvzGBtA=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
   }

--- a/storage/framework/core/env/package.json
+++ b/storage/framework/core/env/package.json
@@ -54,9 +54,11 @@
     "typecheck": "bun tsc --noEmit",
     "prepublishOnly": "bun run build"
   },
+  "dependencies": {
+    "@stacksjs/path": "workspace:*"
+  },
   "devDependencies": {
     "better-dx": "^0.2.17",
-    "@stacksjs/path": "workspace:*",
     "@stacksjs/validation": "workspace:*"
   }
 }


### PR DESCRIPTION
## What changed

Move `@stacksjs/path` from `devDependencies` to `dependencies` for `@stacksjs/env` and refresh the Bun lockfile.

## Why

The published `@stacksjs/env` main entry imports `@stacksjs/path` at runtime. Fresh consumers therefore fail with `Cannot find module @stacksjs/path` unless they happen to install it independently.

## Validation

- `bun install --frozen-lockfile`
- `bun test ./test ./tests` (224 passing)
- `bun run build`