### PR TITLE
test: unbreak the CI test job (three independent failures)

### DIFF
--- a/storage/framework/core/orm/tests/type-compile-check.test.ts
+++ b/storage/framework/core/orm/tests/type-compile-check.test.ts
@@ -391,7 +391,9 @@ describe('Action class uses smart InferRequest for model-aware handlers', () => 
     // across lines, so allow whitespace between `handle: (` and the
     // typed `request:` parameter.
     // `handle: { bivarianceHack: (request: InferRequest<…>) => … }['bivarianceHack']`
-    expect(content).toMatch(/bivarianceHack:\s*\(\s*request: InferRequest<TModel/)
+    // The request type is now gated on TPayload for non-router callers, so
+    // allow the conditional between `request:` and `InferRequest<TModel`.
+    expect(content).toMatch(/bivarianceHack:\s*\(\s*request:[^)]*?InferRequest<TModel/)
   })
 
   test('model property is stored as string for runtime', () => {

--- a/storage/framework/core/orm/tests/type-narrowing.test.ts
+++ b/storage/framework/core/orm/tests/type-narrowing.test.ts
@@ -197,7 +197,11 @@ describe('Action class InferRequest type resolution', () => {
     // `handle` is declared through a bivariance hack —
     // `handle: { bivarianceHack: (request: InferRequest<…>) => … }['bivarianceHack']`
     // — so match the request type it carries rather than a bare `handle: (`.
-    expect(content).toMatch(/bivarianceHack:\s*\(\s*request: InferRequest<TModel/)
+    // The request type is now gated on TPayload, so that non-router callers
+    // (event listeners) can be typed with the payload they actually pass:
+    // `request: [TPayload] extends [never] ? InferRequest<…> : TPayload`.
+    // Anything between `request:` and `InferRequest<TModel` is that gate.
+    expect(content).toMatch(/bivarianceHack:\s*\(\s*request:[^)]*?InferRequest<TModel/)
   })
 
   test('falls back to bare RequestInstance when model is a string', () => {

--- a/storage/framework/core/sites/bunfig.toml
+++ b/storage/framework/core/sites/bunfig.toml
@@ -1,0 +1,9 @@
+# Preload the package test harness so the env pin (sqlite + temp DB file)
+# lands before any test file's imports evaluate.
+#
+# This only applies when `bun test` runs from THIS directory. CI runs
+# `bun test ./storage/framework/core/sites/tests` from the repo root, where
+# bunfig is read from the root and this preload never fires - see
+# tests/setup.ts for why the harness works either way.
+[test]
+preload = ["./tests/setup.ts"]

--- a/storage/framework/core/sites/tests/provision.test.ts
+++ b/storage/framework/core/sites/tests/provision.test.ts
@@ -7,22 +7,17 @@
  * overwrite a page somebody has edited since.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { beforeEach, describe, expect, it } from 'bun:test'
 import { db } from '@stacksjs/database'
 import { provisionSite } from '../src/provision'
+import { refreshDatabase } from './setup'
 
 const SUBDOMAIN = 'provision-test'
 
-async function cleanup(): Promise<void> {
-  const sites = await db.selectFrom('sites').select(['id']).where('subdomain', '=', SUBDOMAIN).execute()
-  for (const site of sites as Array<{ id: number }>) {
-    await db.deleteFrom('pages').where('site_id', '=', site.id).execute()
-    await db.deleteFrom('sites').where('id', '=', site.id).execute()
-  }
-}
-
-beforeEach(cleanup)
-afterEach(cleanup)
+// `refreshDatabase` also re-pins the database config, which the old
+// subdomain-scoped cleanup did not: `bun test` runs the directory in one
+// process, so a sibling file can otherwise win the connection between tests.
+beforeEach(refreshDatabase)
 
 const pages = [
   { title: 'Home', slug: '/', blocks: [{ type: 'rich-text', props: { html: '<p>Welcome.</p>' } }] },

--- a/storage/framework/core/sites/tests/setup.ts
+++ b/storage/framework/core/sites/tests/setup.ts
@@ -1,0 +1,187 @@
+/**
+ * Sites package test harness.
+ *
+ * `provision.test.ts` drives `provisionSite`, which writes real rows through
+ * the `db` proxy. It shipped with no database setup at all, so it only ever
+ * passed on a machine that happened to have a `sites` table in whatever
+ * database the ambient env pointed at. CI has neither, and the suite has
+ * failed there since the test landed:
+ *
+ *   SQLiteError: no such table: sites
+ *
+ * Strategy mirrors `core/cms/src/tests/setup.ts`: pin env to a throwaway
+ * SQLite file BEFORE any framework module loads, then create the tables this
+ * package's code path touches.
+ *
+ * Two invocations have to work, and only one of them gets the env pin early:
+ *
+ *   - From this directory (`bun test`), `bunfig.toml`'s `[test] preload` runs
+ *     this module first, so the pin lands before anything else resolves.
+ *   - From the repo root (`bun test ./storage/framework/core/sites/tests`,
+ *     which is what CI does), bunfig is read from the ROOT, so the preload
+ *     never fires and this module is evaluated as an ordinary import - after
+ *     the test file has already imported `@stacksjs/database`.
+ *
+ * The second case works because `forceConfig()` calls `initializeDbConfig`
+ * explicitly rather than relying on the env alone: the `db` proxy is lazy, so
+ * re-pinning the config before the first query still steers it. That is also
+ * why `refreshDatabase` re-pins on every test rather than once at load.
+ *
+ * The DDL is kept in step with `database/migrations/` by hand, the same way
+ * the CMS harness is - this runs without the migration pipeline. `sites`
+ * follows `1785502251848-create-sites-table.sql`; the page tables follow the
+ * CMS harness, because `provisionSite` seeds pages through
+ * `@stacksjs/cms`'s `createPageDocument`.
+ */
+
+import { existsSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+
+const DB_PATH = join(tmpdir(), `stacks-sites-${process.pid}.sqlite`)
+process.env.DB_CONNECTION = 'sqlite'
+process.env.DB_DATABASE_PATH = DB_PATH
+process.env.APP_ENV = 'testing'
+
+// Dynamic import AFTER the env pin so the lazy `db` proxy and the config
+// loader can't capture a different connection first.
+const { acquireDbConfigLock, db, ensureDatabaseConfigLoaded, initializeDbConfig } = await import('@stacksjs/database')
+
+// Holds `initializeDbConfig`'s process-wide config mutex (stacksjs/stacks#1862)
+// for this module's lifetime. Released on process exit alongside the file
+// cleanup below - this is a shared fixture, not a test file, so it has no
+// `afterAll` boundary of its own.
+const releaseDbConfigLock = await acquireDbConfigLock()
+
+/**
+ * Drain the one-shot async config reload, then force our temp SQLite config
+ * so a late-resolving override can't re-point the shared `db` proxy mid-test.
+ */
+async function forceConfig(): Promise<void> {
+  await ensureDatabaseConfigLoaded()
+  initializeDbConfig({
+    app: { env: 'testing' },
+    database: {
+      default: 'sqlite',
+      connections: { sqlite: { database: DB_PATH, prefix: '' } },
+    },
+  })
+}
+
+// A recycled pid would otherwise leak a previous run's schema and rows.
+for (const suffix of ['', '-wal', '-shm']) {
+  if (existsSync(`${DB_PATH}${suffix}`))
+    unlinkSync(`${DB_PATH}${suffix}`)
+}
+
+await forceConfig()
+
+// No REFERENCES clauses: `teams` does not exist in this harness, and the
+// tenancy behaviour under test does not depend on FK enforcement.
+await db.unsafe(`
+  CREATE TABLE IF NOT EXISTS sites (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    uuid VARCHAR(255),
+    name VARCHAR(255) NOT NULL,
+    subdomain VARCHAR(255) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'active',
+    settings TEXT,
+    timezone VARCHAR(64) DEFAULT 'America/New_York',
+    team_id INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
+  )
+`).execute()
+
+await db.unsafe(`
+  CREATE UNIQUE INDEX IF NOT EXISTS sites_subdomain_unique ON sites (subdomain)
+`).execute()
+
+await db.unsafe(`
+  CREATE TABLE IF NOT EXISTS pages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    uuid VARCHAR(255),
+    site_id INTEGER,
+    author_id INTEGER,
+    parent_id INTEGER,
+    title VARCHAR(255) NOT NULL,
+    slug VARCHAR(255),
+    path VARCHAR(2048),
+    template VARCHAR(255) NOT NULL DEFAULT 'default',
+    blocks TEXT,
+    meta_description VARCHAR(320),
+    status VARCHAR(32) NOT NULL DEFAULT 'draft',
+    scheduled_at TIMESTAMP,
+    views INTEGER NOT NULL DEFAULT 0,
+    conversions INTEGER NOT NULL DEFAULT 0,
+    published_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
+  )
+`).execute()
+
+await db.unsafe(`
+  CREATE UNIQUE INDEX IF NOT EXISTS pages_site_path_unique ON pages (site_id, path)
+`).execute()
+
+// `createPageDocument` reaches `storeRevision` and `recordSlugChangeRedirects`
+// through `@stacksjs/cms`'s page-document module, so both tables have to exist
+// even when a given call writes neither.
+await db.unsafe(`
+  CREATE TABLE IF NOT EXISTS page_revisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL,
+    author_id INTEGER,
+    revision INTEGER NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    blocks TEXT,
+    meta_description VARCHAR(320),
+    note VARCHAR(500),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
+  )
+`).execute()
+
+await db.unsafe(`
+  CREATE TABLE IF NOT EXISTS redirects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    site_id INTEGER NOT NULL,
+    from_path VARCHAR(2048) NOT NULL,
+    to_path VARCHAR(2048) NOT NULL,
+    status_code INTEGER NOT NULL DEFAULT 301,
+    source VARCHAR(32) NOT NULL DEFAULT 'manual',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
+  )
+`).execute()
+
+const tableNames = ['pages', 'page_revisions', 'redirects', 'sites']
+
+/**
+ * Wipe between tests. DELETE (not DROP) keeps the schema warm, and re-pinning
+ * the config per test is deliberate: `bun test` runs a whole directory in one
+ * process and every file here claims the same process-wide database globals.
+ */
+export async function refreshDatabase(): Promise<void> {
+  await forceConfig()
+  for (const table of tableNames) {
+    await db.unsafe(`DELETE FROM ${table}`).execute()
+  }
+}
+
+// Cleanup on process exit, NOT in an `afterAll`: registered during module
+// evaluation, an `afterAll` attaches to the FIRST importing file's scope and
+// would unlink the shared database while later files still hold connections.
+process.on('exit', () => {
+  for (const suffix of ['', '-wal', '-shm']) {
+    try {
+      if (existsSync(`${DB_PATH}${suffix}`))
+        unlinkSync(`${DB_PATH}${suffix}`)
+    }
+    catch {
+      // Best effort - pid-named file in tmpdir, the OS reclaims it.
+    }
+  }
+  releaseDbConfigLock()
+})

--- a/tests/unit/dashboard-commerce-route-contract.test.ts
+++ b/tests/unit/dashboard-commerce-route-contract.test.ts
@@ -11,7 +11,9 @@ describe('dashboard commerce route contract', () => {
     const detail = source('storage/framework/defaults/app/Actions/Dashboard/Commerce/CommerceProductDetailAction.ts')
 
     expect(detail).toContain('!Number.isSafeInteger(id) || id <= 0')
-    expect(detail).toContain("response.notFound({ error: 'Product not found' })")
+    // `response.notFound(message?)` takes the message itself, so the object form
+    // this used to pin serialized a `{ error }` wrapper the helper never unwraps.
+    expect(detail).toContain("response.notFound('Product not found')")
   })
 
   test('product mutations use local-friendly guarded dashboard routes', () => {

--- a/tests/unit/dashboard-operational-error-contract.test.ts
+++ b/tests/unit/dashboard-operational-error-contract.test.ts
@@ -15,7 +15,7 @@ describe('dashboard operational error contract', () => {
     expect(helper).toContain('console.error(`[dashboard/api] ${action} failed:`, error)')
     expect(helper).toContain('return response.json({ message }, status)')
     expect(helper).toContain('return message')
-    expect(helper).toContain('status = 503')
+    expect(helper).toContain('status: ResponseStatus = 503')
   })
 
   test('does not expose caught storage errors from operational read APIs', () => {


### PR DESCRIPTION
`main`'s `test` job has three independent failure groups. This fixes all three.

### 1. Root suite: two dashboard contract tests (2 tests)

`9ce75aeb56` ("third pass on the scaffold") changed both sources these tests pin, and neither assertion followed. The sources are the correct side of both:

- **`dashboard-response.ts`** now annotates its default as `status: ResponseStatus = 503`, so the bare `status = 503` substring no longer appears. Same default, same behaviour.
- **`CommerceProductDetailAction.ts`** now calls `response.notFound('Product not found')`. The helper documents itself as `notFound(message?)`, so the object form the test pinned was handing it an `{ error }` wrapper nothing unwraps. The test was holding the wrong shape in place.

### 2. Core / sites: `provisionSite` had no database (5 tests)

`provision.test.ts` drives `provisionSite`, which writes real rows, and shipped with **no database setup at all**. It only ever passed on a machine that happened to have a `sites` table in whatever database the ambient env pointed at. CI has neither, so it has failed there since it landed in `8f5b1c8402`:

```
SQLiteError: no such table: sites
```

Adds `tests/setup.ts` following the pattern `core/cms/src/tests/setup.ts` already establishes: a throwaway SQLite pinned before the framework loads, plus DDL for the tables this package's path touches (`sites` per `1785502251848-create-sites-table.sql`, and the page tables, since `provisionSite` seeds through `@stacksjs/cms`). The old subdomain-scoped `cleanup()` becomes `refreshDatabase`, which also re-pins the config per test, because the directory runs in one process and every file claims the same process-wide database globals (#1862).

One wrinkle worth recording: the `bunfig.toml` preload only fires for `bun test` run from the package directory. CI runs `bun test ./storage/framework/core/sites/tests` from the repo root, where bunfig is read from the root. The harness is written to work either way and is verified under both invocations.

### 3. Core / orm: the action-type regexes (2 tests)

Both pin the `handle` signature in `actions/src/action.ts` by regex. It gained a `TPayload` gate so non-router callers (event listeners, which `app/Events.ts` maps straight onto an action) can be typed with the payload they actually pass, and `request: InferRequest<TModel` stopped matching. Loosened to allow the conditional, bounded so it cannot run past the parameter list.

Mutation-checked: replacing the request type with `any` still fails exactly these two tests.

### Verification

- Root suite: **330 pass, 0 fail**.
- Core sweep, using the same loop as `ci.yml`: `orm` and `sites` clean. The three that still fail locally (`browser-extension`, `cache`, `queue`) need the Redis/DynamoDB services CI provides and are green there.

`typecheck` remains red on this PR for an unrelated reason that predates it: #2322, the unpublished `craft-native/mobile` and `/android` subpaths. That one needs craft published and is not fixable here.
