### PR TITLE
ci: build the subpath-exporting packages before typechecking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,30 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Same reason the `test` job builds these, and the same two packages:
+      # a workspace package's ROOT export resolves from source when `dist` is
+      # missing, but a subpath pattern like `./composables/*` does not. `dist`
+      # is gitignored and nothing else here builds it, so every
+      # `@stacksjs/browser/composables/*` import is unresolvable and this job
+      # has been red on:
+      #
+      #   error TS2307: Cannot find module '@stacksjs/browser/composables/csrf'
+      #   error TS2307: Cannot find module '@stacksjs/browser/composables/useStorage'
+      #
+      # It stays green on developer machines because a stale `dist` is already
+      # sitting there.
+      #
+      # Dependency order matters: browser's built `composables/useStorage.js`
+      # imports `@stacksjs/composables/useStorage`, so composables has to exist
+      # first or the same error moves one level down.
+      - name: Build packages imported by subpath
+        run: |
+          for pkg in composables browser; do
+            echo "::group::build @stacksjs/$pkg"
+            (cd "storage/framework/core/$pkg" && bun run build)
+            echo "::endgroup::"
+          done
+
       - name: Typecheck
         run: bun run typecheck
 


### PR DESCRIPTION
`typecheck` has been red on `main` on exactly two errors:

```
error TS2307: Cannot find module '@stacksjs/browser/composables/csrf'
error TS2307: Cannot find module '@stacksjs/browser/composables/useStorage'
```

This is the same cause the **`test`** job already carries a build step for, and the same two packages: a workspace package's ROOT export resolves from source when `dist` is missing, but a subpath pattern like `./composables/*` does not. `dist` is gitignored and nothing in the `typecheck` job builds it, so every `@stacksjs/browser/composables/*` import is unresolvable. The `test` job got this step; `typecheck` never did.

### What newly exposed it

`tsconfig.defaults.json` is the second project in the `typecheck` script. It covers `storage/framework/defaults/functions/**`, and those files import the subpath directly - `functions/auth.ts`, `functions/cms/pages.ts`, `functions/realtime/websockets.ts` and nine others.

### Verification

Reproduced and fixed locally, running that project alone:

| state | `Cannot find module '@stacksjs/browser/composables/*'` |
|---|---|
| both `dist` directories deleted | **2** - exactly the errors CI reports, nothing else new |
| after this job's build loop | **0** |

The build loop regenerates `dist/composables/{csrf,useStorage}.{js,d.ts}`, which is what the subpath pattern needs.

### Why it looks green locally

Two things hide it:

1. A stale `dist` is usually already sitting in a developer's tree.
2. The `typecheck` script chains with `&&`, and the first project (`tsconfig.framework.json`) fails on unrelated pre-existing errors, so the defaults project never runs unless you invoke it directly.

### Not the cause

I previously attributed this job's failure to #2322 (the unpublished `craft-native` subpaths). That was wrong - #2322 describes a real problem, but it is not what `typecheck` reports today. Worth re-reading that issue against current CI output.
