### PR TITLE
feat(logging): a transport seam, so the log stream can go elsewhere

### DIFF
--- a/config/logging.ts
+++ b/config/logging.ts
@@ -28,4 +28,29 @@ export default {
    * @default 'storage/logs/deployments.log'
    */
   deploymentsPath: storagePath('logs/deployments.log'),
+
+  /**
+   * **Transports**
+   *
+   * Extra destinations for every log record, on top of the console and the log
+   * file. Each one receives the record before formatting, so `args` still holds
+   * the real `Error` and the real context object.
+   *
+   * `log()` must return immediately. A transport doing network I/O should
+   * buffer there and deliver on its own timer, then drain in `flush()`, which
+   * the framework calls on `beforeExit`.
+   *
+   * @example
+   * transports: [
+   *   {
+   *     name: 'my-log-service',
+   *     level: 'info',
+   *     log: record => buffer.push(record),
+   *     flush: () => deliver(buffer.splice(0)),
+   *   },
+   * ],
+   *
+   * @default []
+   */
+  transports: [],
 } satisfies LoggingConfig

--- a/storage/framework/core/logging/src/index.ts
+++ b/storage/framework/core/logging/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint no-console: 0 */
+import type { LogContext, LogLevel, LogRecord, LogTransport } from '@stacksjs/types'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import process from 'node:process'
 import { Logger } from '@stacksjs/clarity'
@@ -38,15 +39,132 @@ function registerFlushOnExit(): void {
   })
 }
 
-// Request context propagation for structured logging
-export interface LogContext {
-  requestId?: string
-  userId?: string | number
-  [key: string]: unknown
+// --- Transports -------------------------------------------------------------
+//
+// Everything the framework logs also goes to any registered transport, so a
+// log service, an OTel exporter, or a test sink can see the stream without the
+// application rewriting a single call site.
+//
+// Transports receive the record BEFORE formatting collapses it: `args` still
+// holds the real `Error` and the real context object. That is the whole point
+// of the seam. A formatter would only ever see the string.
+
+const _transports: LogTransport[] = []
+
+/** Transports that have thrown. Reported once each, then left alone. */
+const _brokenTransports = new Set<string>()
+
+/**
+ * Severity ranking for a transport's own `level` filter.
+ *
+ * `success` ranks with `info` deliberately: it is an outcome, not a severity,
+ * and a transport asking for `warning` and above does not want it.
+ */
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  success: 1,
+  warning: 2,
+  error: 3,
 }
 
-/** Valid log levels — mirrors `@stacksjs/clarity`'s `LogLevel`. */
-export type LogLevel = 'debug' | 'info' | 'success' | 'warning' | 'error'
+function addTransport(candidate: unknown): (() => void) | null {
+  const t = candidate as LogTransport | undefined
+  if (!t || typeof t !== 'object' || typeof t.log !== 'function') {
+    process.stderr.write('[logging] Ignoring a transport without a log() function.\n')
+    return null
+  }
+  if (typeof t.name !== 'string' || !t.name) {
+    process.stderr.write('[logging] Ignoring a transport without a name.\n')
+    return null
+  }
+
+  _transports.push(t)
+  return () => {
+    const at = _transports.indexOf(t)
+    if (at !== -1) _transports.splice(at, 1)
+  }
+}
+
+/**
+ * Attach a transport at runtime, and get back a function that detaches it.
+ *
+ * The alternative to declaring one in `config/logging.ts`, for a package that
+ * has to attach without the application editing its config. Registering also
+ * initializes the logger, so a transport attached at boot starts receiving
+ * `debug` records immediately rather than waiting for the first console-visible
+ * line to build the config.
+ */
+export function registerTransport(transport: LogTransport): () => void {
+  const detach = addTransport(transport)
+  if (!detach) return () => {}
+  void initLogger()
+  return detach
+}
+
+/** The transports currently attached. A copy, so callers cannot mutate the list. */
+export function transports(): readonly LogTransport[] {
+  return [..._transports]
+}
+
+/**
+ * Hand one record to every transport that wants it.
+ *
+ * Synchronous and total: a transport that throws is contained and reported
+ * once, because the logger is frequently the thing reporting a failure and it
+ * must not become a second one. Cheap when nothing is attached, which is the
+ * common case and the reason for the length check at every call site.
+ */
+function dispatch(level: LogLevel, message: string, args: unknown[]): void {
+  if (_transports.length === 0) return
+
+  let record: LogRecord
+  try {
+    record = {
+      level,
+      message,
+      args,
+      context: getLogContext(),
+      timestamp: new Date().toISOString(),
+    }
+  }
+  catch {
+    // Building the record must never take a log call down with it.
+    return
+  }
+
+  for (const transport of _transports) {
+    if (transport.level && LEVEL_RANK[level] < LEVEL_RANK[transport.level])
+      continue
+    try {
+      transport.log(record)
+    }
+    catch (err) {
+      if (!_brokenTransports.has(transport.name)) {
+        _brokenTransports.add(transport.name)
+        const reason = err instanceof Error ? err.message : String(err)
+        process.stderr.write(`[logging] Transport "${transport.name}" threw: ${reason}. Further throws from it are silent.\n`)
+      }
+    }
+  }
+}
+
+/** Drain every transport that buffers. Never rejects; see {@link LogTransport.flush}. */
+async function flushTransports(): Promise<void> {
+  const pending = _transports
+    .filter(t => typeof t.flush === 'function')
+    .map(t => t.flush!().catch(() => {}))
+  if (pending.length > 0)
+    await Promise.allSettled(pending)
+}
+
+// Request context propagation for structured logging, and the transport
+// contract. Both are declared in `@stacksjs/types` so `config/logging.ts` can
+// reference them without importing this package, which would be a cycle. They
+// are re-exported here because this is where consumers already import them
+// from.
+export type { LogContext, LogLevel, LogRecord, LogTransport } from '@stacksjs/types'
+
 export type LogFormat = 'json' | 'text'
 
 const VALID_LEVELS: ReadonlySet<string> = new Set<LogLevel>(['debug', 'info', 'success', 'warning', 'error'])
@@ -276,7 +394,7 @@ async function initLogger(): Promise<void> {
     let cfgWriteToFile: boolean | undefined
     try {
       const cfg = await import('@stacksjs/config') as {
-        logging?: { level?: string, format?: string, writeToFile?: boolean, logsPath?: string }
+        logging?: { level?: string, format?: string, writeToFile?: boolean, logsPath?: string, transports?: unknown }
       }
       const logging = cfg.logging
       if (logging) {
@@ -286,6 +404,12 @@ async function initLogger(): Promise<void> {
         if (logging.logsPath) {
           const np = await import('node:path')
           cfgLogDir = np.dirname(logging.logsPath)
+        }
+        // Config-declared transports. Added directly rather than through
+        // `registerTransport`, which would re-enter this function.
+        if (Array.isArray(logging.transports)) {
+          for (const transport of logging.transports)
+            addTransport(transport)
         }
       }
     }
@@ -469,16 +593,21 @@ export const log: Log = {
   info: async (...args: any[]) => {
     const message = formatMessage(...args)
     const logger = await getLogger()
+    // Before the write, not after: a transport should still see the line if
+    // the console or file write is the thing that fails.
+    dispatch('info', message, args)
     await logger.info(message)
   },
 
   success: async (message: string) => {
     const logger = await getLogger()
+    dispatch('success', message, [message])
     await logger.success(message)
   },
 
   warn: async (message: string, context?: unknown) => {
     const logger = await getLogger()
+    dispatch('warning', message, context === undefined ? [message] : [message, context])
     // No context → call with a single arg. Passing a nullish second arg makes
     // clarity stringify it and append a stray " undefined" / " null" to the
     // line (e.g. `log.warn('… All data will be lost.')`, or `log.warn(msg,
@@ -495,6 +624,7 @@ export const log: Log = {
 
   warning: async (message: string) => {
     const logger = await getLogger()
+    dispatch('warning', message, [message])
     await logger.warn(message)
   },
 
@@ -532,6 +662,10 @@ export const log: Log = {
     }
 
     const logger = await getLogger()
+    // The raw call, not the assembled line: a transport building structured
+    // output wants the `Error` itself and the context as an object, which is
+    // exactly what `line` has just finished flattening into a string.
+    dispatch('error', line, legacyOptions ? [message] : [message, error, context].filter(a => a !== undefined))
     await logger.error(line)
 
     // Legacy fatal path: only exit when explicitly asked.
@@ -548,10 +682,24 @@ export const log: Log = {
     // logger.debug and left a floating Promise, despite emitting nothing.
     // Mirrors the underlying logger: debug ranks below info/warn/error.
     const lvl = ((process.env.LOG_LEVEL as string) || 'info').toLowerCase()
-    if (lvl === 'info' || lvl === 'warn' || lvl === 'error')
+    const suppressed = lvl === 'info' || lvl === 'warn' || lvl === 'error'
+
+    // The fast path is unchanged when nothing is attached, which is the common
+    // case. A transport, though, is allowed to be more verbose than the
+    // terminal: shipping debug lines to a log service while keeping the console
+    // at info is a normal thing to want, and suppressing them here would make
+    // it impossible.
+    if (suppressed && _transports.length === 0)
       return
+
     const message = formatMessage(...args)
+    if (suppressed) {
+      dispatch('debug', message, args)
+      return
+    }
+
     const logger = await getLogger()
+    dispatch('debug', message, args)
     await logger.debug(message)
   },
 
@@ -619,6 +767,12 @@ export const log: Log = {
     // write must not abort the shutdown drain.
     if (pendingWrites.size > 0)
       await Promise.allSettled([...pendingWrites])
+
+    // Transports drain after the in-flight writes, so a record dispatched by
+    // one of those writes is in the transport's buffer before we ask it to
+    // deliver. `beforeExit` already calls this, so a buffering transport gets
+    // its chance on a natural shutdown without registering its own hook.
+    await flushTransports()
 
     // If the logger never initialized there's nothing to flush — `getLogger`
     // would create one we don't need. Same for the init-in-flight case;

--- a/storage/framework/core/logging/tests/transports.test.ts
+++ b/storage/framework/core/logging/tests/transports.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Transports: the seam for shipping the log stream somewhere else.
+ *
+ * The framework logs at every interesting point already. Before this existed,
+ * the only injectable hook was clarity's `formatter`, which is the wrong shape
+ * for the job: it is handed the finished string, after the level has been
+ * flattened and after an `Error` has been rendered into text. Anything wanting
+ * to build structured output had to parse back out what the logger had just
+ * finished formatting.
+ *
+ * So the contract these tests pin down is mostly about what survives: the raw
+ * arguments, the severity, and the request context.
+ */
+
+import type { LogRecord, LogTransport } from '@stacksjs/types'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { AsyncLocalStorage } from 'node:async_hooks'
+import process from 'node:process'
+import { log, registerTransport, transports, withLogContext } from '../src'
+
+const TRACE_KEY = Symbol.for('stacks.router.traceStorage')
+
+let detachers: Array<() => void> = []
+
+/** Attach a sink that records everything it is given, and clean it up after. */
+function sink(options: Partial<LogTransport> = {}): LogRecord[] {
+  const records: LogRecord[] = []
+  detachers.push(registerTransport({
+    name: options.name ?? 'test-sink',
+    level: options.level,
+    log: record => records.push(record),
+    flush: options.flush,
+  }))
+  return records
+}
+
+afterEach(() => {
+  for (const detach of detachers) detach()
+  detachers = []
+  delete (globalThis as Record<symbol, unknown>)[TRACE_KEY]
+})
+
+describe('registration', () => {
+  it('delivers to a registered transport', async () => {
+    const records = sink()
+
+    await log.info('checkout started')
+
+    expect(records).toHaveLength(1)
+    expect(records[0]!.level).toBe('info')
+    expect(records[0]!.message).toBe('checkout started')
+  })
+
+  it('stops delivering once detached', async () => {
+    const records = sink()
+    await log.info('before')
+
+    detachers.pop()!()
+    await log.info('after')
+
+    expect(records.map(r => r.message)).toEqual(['before'])
+  })
+
+  it('delivers to every attached transport', async () => {
+    const first = sink({ name: 'first' })
+    const second = sink({ name: 'second' })
+
+    await log.info('fan out')
+
+    expect(first).toHaveLength(1)
+    expect(second).toHaveLength(1)
+  })
+
+  it('reports the attached list without handing over the internals', () => {
+    sink({ name: 'listed' })
+
+    const attached = transports()
+    expect(attached.some(t => t.name === 'listed')).toBe(true)
+
+    // Mutating the returned array must not detach anything.
+    ;(attached as LogTransport[]).length = 0
+    expect(transports().some(t => t.name === 'listed')).toBe(true)
+  })
+
+  it('ignores a malformed transport instead of throwing', () => {
+    const before = transports().length
+
+    // No `log`, and no name. Both are refused, and neither takes the process
+    // down: a bad entry in `config/logging.ts` should not stop the app booting.
+    expect(() => registerTransport({ name: 'no-log' } as unknown as LogTransport)).not.toThrow()
+    expect(() => registerTransport({ log: () => {} } as unknown as LogTransport)).not.toThrow()
+
+    expect(transports()).toHaveLength(before)
+  })
+})
+
+describe('the record', () => {
+  it('carries the arguments before formatting flattened them', async () => {
+    const records = sink()
+    const boom = new Error('gateway timeout')
+
+    await log.error('payment failed', boom, { provider: 'stripe' })
+
+    const record = records[0]!
+    // The formatted line is there for anyone writing text...
+    expect(record.message).toContain('payment failed')
+    // ...but the Error is still an Error, which is the entire point.
+    expect(record.args[0]).toBe('payment failed')
+    expect(record.args[1]).toBe(boom)
+    expect((record.args[1] as Error).stack).toBeDefined()
+    expect(record.args[2]).toEqual({ provider: 'stripe' })
+  })
+
+  it('keeps a context object an object rather than a printed blob', async () => {
+    const records = sink()
+
+    await log.warn('slow query', { sql: 'select 1', durationMs: 900 })
+
+    expect(records[0]!.args[1]).toEqual({ sql: 'select 1', durationMs: 900 })
+  })
+
+  it('stamps a timestamp and the active trace id', async () => {
+    const records = sink()
+    const storage = new AsyncLocalStorage<string>()
+    ;(globalThis as Record<symbol, unknown>)[TRACE_KEY] = storage
+
+    await storage.run('req_abc', async () => {
+      await withLogContext({ userId: 7 }, () => log.info('inside a request'))
+    })
+
+    const record = records[0]!
+    expect(record.context?.trace_id).toBe('req_abc')
+    expect(record.context?.userId).toBe(7)
+    expect(Number.isNaN(Date.parse(record.timestamp))).toBe(false)
+  })
+
+  it('reports each severity under its own name', async () => {
+    const records = sink()
+
+    await log.info('i')
+    await log.success('s')
+    await log.warn('w')
+    await log.warning('w2')
+    await log.error('e')
+
+    expect(records.map(r => r.level)).toEqual(['info', 'success', 'warning', 'warning', 'error'])
+  })
+})
+
+describe('level filtering', () => {
+  it('drops anything below the transport threshold', async () => {
+    const records = sink({ level: 'warning' })
+
+    await log.info('ignored')
+    await log.warn('kept')
+    await log.error('kept too')
+
+    expect(records.map(r => r.message)).toEqual(['kept', 'kept too'])
+  })
+
+  it('treats success as an info-level outcome, not a severity', async () => {
+    const records = sink({ level: 'warning' })
+
+    await log.success('deployed')
+
+    // `success` is how a thing went, not how bad it is. A transport asking for
+    // warnings and above is not asking for good news.
+    expect(records).toHaveLength(0)
+  })
+
+  it('receives debug lines the console is configured to suppress', async () => {
+    const previous = process.env.LOG_LEVEL
+    process.env.LOG_LEVEL = 'info'
+    const records = sink()
+
+    try {
+      await log.debug('under the console threshold')
+      // A transport is allowed to be more verbose than the terminal. Shipping
+      // debug to a log service while keeping the console at info is normal.
+      expect(records.map(r => r.message)).toEqual(['under the console threshold'])
+    }
+    finally {
+      if (previous === undefined) delete process.env.LOG_LEVEL
+      else process.env.LOG_LEVEL = previous
+    }
+  })
+})
+
+describe('isolation', () => {
+  it('keeps logging when a transport throws', async () => {
+    const good: LogRecord[] = []
+    detachers.push(registerTransport({
+      name: 'throws',
+      log: () => { throw new Error('transport is broken') },
+    }))
+    detachers.push(registerTransport({
+      name: 'fine',
+      log: record => good.push(record),
+    }))
+
+    // The logger is very often the thing reporting a failure. It must not
+    // become a second one, and a broken transport must not starve a working
+    // one registered after it.
+    await log.info('still logged')
+
+    expect(good.map(r => r.message)).toEqual(['still logged'])
+  })
+
+  it('flushes a buffering transport', async () => {
+    let flushed = 0
+    const buffered: LogRecord[] = []
+    detachers.push(registerTransport({
+      name: 'buffered',
+      log: record => buffered.push(record),
+      flush: async () => { flushed++ },
+    }))
+
+    await log.info('buffer me')
+    await log.flush()
+
+    expect(buffered).toHaveLength(1)
+    expect(flushed).toBe(1)
+  })
+
+  it('survives a transport whose flush rejects', () => {
+    detachers.push(registerTransport({
+      name: 'bad-flush',
+      log: () => {},
+      flush: async () => { throw new Error('drain failed') },
+    }))
+
+    // `log.flush()` is on every exit path, including `log.exit`. A transport
+    // that cannot drain must not turn a clean shutdown into a crash.
+    return expect(log.flush()).resolves.toBeUndefined()
+  })
+})

--- a/storage/framework/core/types/src/logging.ts
+++ b/storage/framework/core/types/src/logging.ts
@@ -1,4 +1,101 @@
 /**
+ * The severities the framework logs at.
+ *
+ * Note `success`, which is an outcome rather than a severity: it ranks with
+ * `info` when a transport filters by level.
+ */
+export type LogLevel = 'debug' | 'info' | 'success' | 'warning' | 'error'
+
+/**
+ * Request-scoped fields carried alongside a log line.
+ *
+ * Populated automatically from the router's trace storage, and extendable by
+ * any caller through `withLogContext`.
+ */
+export interface LogContext {
+  requestId?: string
+  userId?: string | number
+  [key: string]: unknown
+}
+
+/**
+ * One log call, as a transport sees it.
+ *
+ * `message` is the formatted line, which is what a transport wants if it is
+ * writing text. `args` is the same call before formatting, which is what a
+ * transport wants if it is building structured output: an `Error` is still an
+ * `Error` there, and a context object is still an object rather than a
+ * pretty-printed blob inside a string.
+ */
+export interface LogRecord {
+  level: LogLevel
+  /** The formatted, human-readable line. */
+  message: string
+  /** The arguments exactly as the caller passed them, before formatting. */
+  args: unknown[]
+  /** Trace id, request id, and anything `withLogContext` added. */
+  context?: LogContext
+  /** ISO-8601, stamped when the call was made rather than when it is written. */
+  timestamp: string
+}
+
+/**
+ * A destination for log records, alongside the console and the log file.
+ *
+ * This is the seam for shipping logs somewhere else: a hosted log service, an
+ * OpenTelemetry exporter, an in-memory sink in a test. Register one in
+ * `config/logging.ts` or at runtime with `registerTransport()`.
+ *
+ * @example
+ * ```ts
+ * // config/logging.ts
+ * export default {
+ *   logsPath: 'storage/logs/console.log',
+ *   deploymentsPath: 'storage/logs/deployments.log',
+ *   transports: [
+ *     {
+ *       name: 'memory',
+ *       level: 'warning',
+ *       log: record => lines.push(record),
+ *     },
+ *   ],
+ * } satisfies LoggingConfig
+ * ```
+ */
+export interface LogTransport {
+  /** Identifies the transport in diagnostics. Keep it short and stable. */
+  name: string
+
+  /**
+   * Drop records less severe than this. Unset means the transport receives
+   * everything, including `debug` lines the console is configured to suppress,
+   * so a transport can be more verbose than the terminal.
+   */
+  level?: LogLevel
+
+  /**
+   * Handle one record.
+   *
+   * Deliberately synchronous and expected to return immediately. A transport
+   * that needs to do I/O should buffer here and do the work on its own timer,
+   * because this runs on the caller's path and a log call must not become the
+   * slowest thing in a request. Throwing is caught and does not disturb the
+   * logger, but a transport that throws is reported once to stderr.
+   */
+  log: (record: LogRecord) => void
+
+  /**
+   * Drain anything buffered.
+   *
+   * Called by `log.flush()`, which the framework already runs on `beforeExit`,
+   * so a buffering transport gets a chance to deliver before a natural
+   * shutdown. Rejections are swallowed: a failed drain must not break an exit
+   * path.
+   */
+  flush?: () => Promise<void>
+}
+
+/**
  * **Logging Options**
  *
  * This configuration defines all of your logging options. Because Stacks is fully-typed, you
@@ -34,7 +131,7 @@ export interface LoggingOptions {
    *
    * @default 'info'
    */
-  level?: 'debug' | 'info' | 'success' | 'warning' | 'error'
+  level?: LogLevel
 
   /**
    * **Output Format**
@@ -57,6 +154,21 @@ export interface LoggingOptions {
    * @default true
    */
   writeToFile?: boolean
+
+  /**
+   * **Transports**
+   *
+   * Additional destinations for every log record, on top of the console and
+   * the log file. See {@link LogTransport}.
+   *
+   * Loaded when the logger first initializes, which is on the first log call.
+   * A package that needs to attach earlier, or without the application editing
+   * its config, should call `registerTransport()` from `@stacksjs/logging`
+   * instead.
+   *
+   * @default []
+   */
+  transports?: LogTransport[]
 }
 
 export type LoggingConfig = Partial<LoggingOptions>


### PR DESCRIPTION
## The problem

A Stacks app already logs at every interesting point, but there is no supported way to send that stream anywhere but the console and the log file. `LoggingOptions` is five keys, and the words "transport", "channel", and "sink" appear nowhere in `@stacksjs/logging` or `@stacksjs/types`.

The one hook that exists is clarity's `formatter`, and it is the wrong shape for the job. It is called for its return value, on the finished string, after the level has been flattened and after an `Error` has been rendered to text. Building structured output through it means parsing back out what the logger just finished formatting, and because its return value *is* the console line, a formatter cannot be more or less verbose than the terminal.

So anything wanting to ship logs to a hosted service, an OTel exporter, or an in-memory sink in a test has to monkey-patch the `log` singleton.

## The change

`LogTransport`, declared in `@stacksjs/types` where `config/logging.ts` can name it without a cycle, plus a `transports` key on `LoggingOptions`:

```ts
// config/logging.ts
export default {
  logsPath: storagePath('logs/stacks.log'),
  deploymentsPath: storagePath('logs/deployments.log'),
  transports: [
    {
      name: 'my-log-service',
      level: 'info',
      log: record => buffer.push(record),
      flush: () => deliver(buffer.splice(0)),
    },
  ],
} satisfies LoggingConfig
```

And `registerTransport()` for a package that has to attach without the application editing its config. It returns its own detach function:

```ts
import { registerTransport } from '@stacksjs/logging'

const detach = registerTransport({ name: 'otel', log: record => exporter.emit(record) })
```

The record is the call **before** formatting:

```ts
interface LogRecord {
  level: LogLevel
  message: string      // the formatted line, for anyone writing text
  args: unknown[]      // the call as made: an Error is still an Error
  context?: LogContext // trace id, request id, whatever withLogContext added
  timestamp: string    // when the call was made, not when it is written
}
```

## Decisions worth reviewing

- **`log()` is synchronous by contract.** A transport doing I/O buffers there and delivers on its own timer. This runs on the caller's path and a log call must not become the slowest thing in a request. `flush()` drains it, and the existing `beforeExit` flush already calls that, so a buffering transport gets its shot at a natural shutdown for free.
- **A transport can be more verbose than the console.** `log.debug` keeps its cheap exit when nothing is attached, but with a transport registered the record is dispatched even when the console level suppresses the line. Shipping debug to a log service while keeping the terminal at info is a normal thing to want, and the existing early return made it impossible.
- **`success` ranks with `info` for level filtering.** It is an outcome, not a severity. A transport asking for warnings and above is not asking for good news.
- **A throwing transport is contained and reported once to stderr, never removed.** This package is very often the one reporting a failure and it must not become a second one. One bad line should not detach a transport for the rest of the process.

## Compatibility

`LogLevel` and `LogContext` move to `@stacksjs/types` alongside the new types and are re-exported from `@stacksjs/logging`, so every existing import keeps working. Both names are referenced only inside the logging package and its tests today.

Nothing changes for an app that declares no transports: the dispatch is a length check on an empty array at each call site.

## Testing

15 new tests in `storage/framework/core/logging/tests/transports.test.ts` covering registration and detachment, the record contents, level filtering, the debug-below-console case, isolation of a throwing transport, and flush including a transport whose flush rejects.

- `bun test` in `core/logging`: 106 pass, 0 fail
- `bun run build` in `core/logging` and `core/types`: clean, declarations emit under `isolatedDeclarations`
- `bun tsc --noEmit`: zero errors in the changed files (the pre-existing `isolatedDeclarations` errors across `storage/framework/defaults` are unrelated and unchanged)

## Why I wanted this

I am writing a loghq SDK for Stacks and hit the wall above: the only way to see the log stream was to patch the singleton, which is per-process, has a startup window where lines are lost, and breaks if two copies of a package do it. With this, the integration is one line in `config/logging.ts` and applies to every process that boots the framework, including the scheduler and queue workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)