### PR TITLE
chore(deps): stop shipping a craft-native every app downloads and cannot use

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -120,7 +120,6 @@
         "@stacksjs/stx": "^0.2.184",
         "@stacksjs/ts-cloud": "^0.8.3",
         "@stacksjs/ts-md": "^0.1.1",
-        "craft-native": ">=0.0.55",
       },
       "devDependencies": {
         "@stacksjs/api": "workspace:*",
@@ -144,9 +143,11 @@
         "better-dx": "^0.2.23",
       },
       "peerDependencies": {
+        "craft-native": ">=0.0.65",
         "pickier": "^0.1.35",
       },
       "optionalPeers": [
+        "craft-native",
         "pickier",
       ],
     },
@@ -214,7 +215,7 @@
       "version": "0.72.8",
       "dependencies": {
         "@stacksjs/bun-router": "^0.0.22",
-        "@stacksjs/ts-auth": "^0.4.3",
+        "@stacksjs/ts-auth": "^0.4.4",
       },
       "devDependencies": {
         "@stacksjs/error-handling": "workspace:*",
@@ -752,7 +753,6 @@
       "devDependencies": {
         "@stacksjs/build": "workspace:*",
         "better-dx": "^0.2.23",
-        "craft-native": ">=0.0.55",
       },
       "peerDependencies": {
         "craft-native": ">=0.0.65",

--- a/storage/framework/core/actions/package.json
+++ b/storage/framework/core/actions/package.json
@@ -66,8 +66,7 @@
     "@stacksjs/registry": "workspace:*",
     "@stacksjs/stx": "^0.2.184",
     "@stacksjs/ts-cloud": "^0.8.3",
-    "@stacksjs/ts-md": "^0.1.1",
-    "craft-native": ">=0.0.55"
+    "@stacksjs/ts-md": "^0.1.1"
   },
   "devDependencies": {
     "@stacksjs/api": "workspace:*",
@@ -91,10 +90,14 @@
     "@stacksjs/validation": "workspace:*"
   },
   "peerDependencies": {
-    "pickier": "^0.1.35"
+    "pickier": "^0.1.35",
+    "craft-native": ">=0.0.65"
   },
   "peerDependenciesMeta": {
     "pickier": {
+      "optional": true
+    },
+    "craft-native": {
       "optional": true
     }
   }

--- a/storage/framework/core/mobile/package.json
+++ b/storage/framework/core/mobile/package.json
@@ -33,8 +33,7 @@
   },
   "devDependencies": {
     "@stacksjs/build": "workspace:*",
-    "better-dx": "^0.2.23",
-    "craft-native": ">=0.0.55"
+    "better-dx": "^0.2.23"
   },
   "peerDependencies": {
     "craft-native": ">=0.0.65"


### PR DESCRIPTION
Part of #2322. This is the half of that issue that is implementable here; the substantive fix is upstream.

`craft-native` is unusable at the only version published to npm. 0.0.55 declares exactly one export, `"."`, so `craft-native/mobile`, `/android` and `/ios` do not resolve for anyone installing from the registry. Two declarations in this repo made that worse than it needed to be.

## What changes

**`core/mobile`** declared it both as a `>=0.0.55` devDependency and a `>=0.0.65` optional peer, three lines apart. The ranges contradict each other, and the devDependency installs a version that provably cannot supply the subpath the package imports. Dropped.

**`core/actions`** declared it as a hard `dependency`, so every app installing `@stacksjs/actions` downloaded a copy it can never use. All four call sites already resolve it dynamically inside try/catch:

- `src/dev/dashboard.ts:631` — `await import('craft-native')`
- `src/build/android.ts:33` — `const packageEntry = 'craft-native/android'` then `await import(packageEntry)`
- `src/build/ios.ts:34` — same shape

An optional peer describes that relationship honestly. `core/desktop` keeps its hard dependency: `src/index.ts:4` statically imports the **root** entry, which does exist at 0.0.55 and is legitimately Node-only.

No behaviour changes. This stops the install lying about what is needed.

## One extra lockfile line

`@stacksjs/ts-auth` `^0.4.3` → `^0.4.4`. `1ec4254fbb` set that in `core/auth/package.json` without regenerating the lock, so it was already stale. Reverting it would leave the lockfile inconsistent with the manifest, so it stays.

## What I deliberately did NOT do, having recommended it earlier

I suggested on #2322 that a root-entry fallback in `craftNative()` would light up ~11 of the 18 mobile surfaces today with no upstream work. **That was wrong**, and I have corrected it on the issue. `craft-native`'s root entry is the full desktop SDK:

```
$ grep -oE 'require\("node:[a-z_]+"\)' node_modules/craft-native/dist/index.cjs | sort -u
require("node:child_process")   require("node:fs")   require("node:os")
require("node:path")            require("node:util")

$ bun build ./probe.js --target=browser
error: Browser build cannot require() Node.js builtin: "child_process"
    at node_modules/craft-native/dist/index.cjs:296:36    (also :8490, :9811)
```

`@stacksjs/mobile` is imported by five `Native*.stx` components that compile into STX **client** bundles, so the fallback would break all five. With the default `bundlerFallback: "warn"` it would break them **silently** — a `console.warn`, the raw unbundled script shipped, and the component simply never hydrates.

The real fix is upstream in home-lang/craft: emit `dist/api/mobile.js` as a browser-clean entry (today only the `.d.ts` exists; the implementation is inlined into the Node-only `dist/index.js`) and add the `./mobile`, `./android`, `./ios` exports entries. The android/ios builders already ship as real JS in the tarball and are unreachable only because of the exports map.

## Verification

`actions` 421/0, `mobile` 5/0, root 330/0, framework typecheck clean. `craft-native` still resolves for the packages that legitimately use it (`Bun.resolveSync` → `node_modules/craft-native/dist/index.js`). Lockfile stays `lockfileVersion: 1`.
