### PR TITLE
fix(router): stop a dead duplicate registration rewriting the live route

### DIFF
--- a/storage/framework/core/router/src/stacks-router.ts
+++ b/storage/framework/core/router/src/stacks-router.ts
@@ -1444,7 +1444,34 @@ function createMiddlewareHandler(routeKey: string, handler: StacksHandler): Rout
 /**
  * Create a chainable route object (for .middleware() support)
  */
-function createChainableRoute(routeKey: string): ChainableRoute {
+/**
+ * A chain for a registration that will never serve.
+ *
+ * Returned instead of the real chain when a duplicate `METHOD:/path` is
+ * registered (stacksjs/stacks#2332). Every method is a no-op, so
+ * `.middleware('auth')` or `.skipCsrf()` written against a dead duplicate
+ * cannot reach the live route's registries. Chainable, so calling code is
+ * unchanged.
+ */
+function createInertRoute(): ChainableRoute {
+  // Not cast: the annotation makes TypeScript fail here if `ChainableRoute`
+  // grows a member, rather than letting a new one silently reach the live
+  // route from a dead duplicate.
+  const inert: ChainableRoute = {
+    middleware: () => inert,
+    name: () => inert,
+    skipCsrf: () => inert,
+    requireCsrf: () => inert,
+    rateLimit: () => inert,
+  }
+
+  return inert
+}
+
+function createChainableRoute(routeKey: string, shadowed = false): ChainableRoute {
+  if (shadowed)
+    return createInertRoute()
+
   // Initialize middleware list for this route
   if (!routeMiddlewareRegistry.has(routeKey)) {
     routeMiddlewareRegistry.set(routeKey, [])
@@ -2875,30 +2902,64 @@ export function createStacksRouter(config: StacksRouterConfig = {}): StacksRoute
   let currentGroupMiddleware: string[] = []
   let currentGroupApiResponse = false
 
+  /**
+   * Every `METHOD:/path` THIS router has already registered.
+   *
+   * Instance-scoped on purpose: bun-router dedupes per instance, so the same
+   * path registered on two routers is live on both. A module-level set would
+   * declare the second one shadowed and silently strip its middleware.
+   */
+  const registeredRouteKeys = new Set<string>()
+
   // Helper to register a route with group middleware applied
   function registerRoute(method: string, path: string, _handler: StacksHandler) {
     const fullPath = currentPrefix + path
     const routeKey = `${method}:${fullPath}`
     log.debug(`[router] ${method} ${fullPath} → ${typeof _handler === 'string' ? _handler : 'function'}`)
 
+    // A second registration of the same method+path never serves: bun-router's
+    // compiler skips it (`RouteCompiler.addRoute` returns false on a duplicate
+    // key) and the static fast map only fills an empty slot, so the FIRST
+    // registration is the live one. That is the whole basis of the override
+    // model in `route-loader.ts`, which loads user routes before framework
+    // defaults precisely so a user route wins.
+    //
+    // The registries below are keyed by `routeKey` alone, so without this
+    // guard the shadowed registration writes into the LIVE route's state:
+    // a user's public `route.get('/dashboard/home', ...)` was answering 401,
+    // because the framework's later duplicate inside
+    // `route.group({ middleware: 'auth' }, ...)` stamped `auth` onto it
+    // (stacksjs/stacks#2332). `.skipCsrf()` on a dead duplicate could likewise
+    // disable CSRF on the live route.
+    //
+    // Tracked per ROUTER INSTANCE, not per module, because bun-router's
+    // duplicate skip is per instance: two `createStacksRouter()` instances
+    // registering the same path both serve it, and both must keep their own
+    // middleware.
+    const shadowed = registeredRouteKeys.has(routeKey)
+    if (!shadowed)
+      registeredRouteKeys.add(routeKey)
+
     // Pre-populate middleware registry with group middleware
-    if (currentGroupMiddleware.length > 0) {
+    if (!shadowed && currentGroupMiddleware.length > 0) {
       routeMiddlewareRegistry.set(routeKey, [...currentGroupMiddleware])
     }
 
     // Pre-populate apiResponse registry with the group flag so the request
     // handler can flip `req._forceJson` without re-walking the group stack.
-    if (currentGroupApiResponse) {
+    if (!shadowed && currentGroupApiResponse) {
       routeApiResponseRegistry.add(routeKey)
     }
 
     // Track string handlers so the CSRF gate can look up action-level
-    // skipCsrf flags without re-importing on every request.
-    if (typeof _handler === 'string') {
+    // skipCsrf flags without re-importing on every request. Guarded for the
+    // same reason, and it is also what made `listRegisteredRoutes()` name a
+    // handler that never runs.
+    if (!shadowed && typeof _handler === 'string') {
       routeHandlerKeyRegistry.set(routeKey, _handler)
     }
 
-    return { fullPath, routeKey }
+    return { fullPath, routeKey, shadowed }
   }
 
   const stacksRouter: StacksRouterInstance = {
@@ -2912,39 +2973,39 @@ export function createStacksRouter(config: StacksRouterConfig = {}): StacksRoute
 
     // HTTP methods with string handler support
     get(path: string, handler: StacksHandler) {
-      const { fullPath, routeKey } = registerRoute('GET', path, handler)
+      const { fullPath, routeKey, shadowed } = registerRoute('GET', path, handler)
       bunRouter.get(fullPath, createMiddlewareHandler(routeKey, handler))
-      return createChainableRoute(routeKey)
+      return createChainableRoute(routeKey, shadowed)
     },
 
     post(path: string, handler: StacksHandler) {
-      const { fullPath, routeKey } = registerRoute('POST', path, handler)
+      const { fullPath, routeKey, shadowed } = registerRoute('POST', path, handler)
       bunRouter.post(fullPath, createMiddlewareHandler(routeKey, handler))
-      return createChainableRoute(routeKey)
+      return createChainableRoute(routeKey, shadowed)
     },
 
     put(path: string, handler: StacksHandler) {
-      const { fullPath, routeKey } = registerRoute('PUT', path, handler)
+      const { fullPath, routeKey, shadowed } = registerRoute('PUT', path, handler)
       bunRouter.put(fullPath, createMiddlewareHandler(routeKey, handler))
-      return createChainableRoute(routeKey)
+      return createChainableRoute(routeKey, shadowed)
     },
 
     patch(path: string, handler: StacksHandler) {
-      const { fullPath, routeKey } = registerRoute('PATCH', path, handler)
+      const { fullPath, routeKey, shadowed } = registerRoute('PATCH', path, handler)
       bunRouter.patch(fullPath, createMiddlewareHandler(routeKey, handler))
-      return createChainableRoute(routeKey)
+      return createChainableRoute(routeKey, shadowed)
     },
 
     delete(path: string, handler: StacksHandler) {
-      const { fullPath, routeKey } = registerRoute('DELETE', path, handler)
+      const { fullPath, routeKey, shadowed } = registerRoute('DELETE', path, handler)
       bunRouter.delete(fullPath, createMiddlewareHandler(routeKey, handler))
-      return createChainableRoute(routeKey)
+      return createChainableRoute(routeKey, shadowed)
     },
 
     options(path: string, handler: StacksHandler) {
-      const { fullPath, routeKey } = registerRoute('OPTIONS', path, handler)
+      const { fullPath, routeKey, shadowed } = registerRoute('OPTIONS', path, handler)
       bunRouter.options(fullPath, createMiddlewareHandler(routeKey, handler))
-      return createChainableRoute(routeKey)
+      return createChainableRoute(routeKey, shadowed)
     },
 
     // Route grouping with prefix and middleware support
@@ -3053,9 +3114,16 @@ export function createStacksRouter(config: StacksRouterConfig = {}): StacksRoute
     // Match multiple HTTP methods for a single route
     match(methods: string[], path: string, handler: StacksHandler) {
       log.debug(`[router] Match: [${methods.join(', ')}] ${path} → ${typeof handler === 'string' ? handler : 'function'}`)
-      for (const method of methods) {
+      // The chain returned below belongs to `methods[0]`, so it is that
+      // method's own shadow state that decides whether it is inert. Taking
+      // "any method shadowed" would silently inert a chain whose first method
+      // is perfectly live.
+      let firstShadowed = false
+      for (const [index, method] of methods.entries()) {
         const m = method.toUpperCase()
-        const { fullPath, routeKey } = registerRoute(m, path, handler)
+        const { fullPath, routeKey, shadowed } = registerRoute(m, path, handler)
+        if (index === 0)
+          firstShadowed = shadowed
         const wrappedHandler = createMiddlewareHandler(routeKey, handler)
         switch (m) {
           case 'GET':
@@ -3078,7 +3146,7 @@ export function createStacksRouter(config: StacksRouterConfig = {}): StacksRoute
             break
         }
       }
-      return createChainableRoute(`${methods[0]}:${currentPrefix}${path}`)
+      return createChainableRoute(`${methods[0]}:${currentPrefix}${path}`, firstShadowed)
     },
 
     // Health check route — probes critical dependencies and returns

--- a/storage/framework/core/router/tests/duplicate-route-registration.test.ts
+++ b/storage/framework/core/router/tests/duplicate-route-registration.test.ts
@@ -1,0 +1,129 @@
+/**
+ * A duplicate registration must not reach the live route (stacksjs/stacks#2332).
+ *
+ * bun-router serves the FIRST registration of a `METHOD:/path` and discards
+ * the second. But the Stacks registries beside it - middleware, apiResponse,
+ * CSRF-skip, handler-key - are keyed by `METHOD:/path` alone, so the discarded
+ * registration used to write straight into the live route's state.
+ *
+ * That silently broke the override model `route-loader.ts` documents. It loads
+ * user routes BEFORE framework defaults precisely so a user route wins, and a
+ * user's public `route.get('/dashboard/home', ...)` answered 401 Unauthorized,
+ * because the framework's later duplicate inside
+ * `route.group({ middleware: 'auth' }, ...)` stamped `auth` onto it.
+ *
+ * The CSRF direction is worse: a dead duplicate calling `.skipCsrf()` turned
+ * the check off for a live route that never asked.
+ */
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { clearMiddlewareCache, clearRouteMiddlewareRegistry, createStacksRouter, url } from '../src/stacks-router'
+
+beforeEach(() => {
+  clearMiddlewareCache()
+  clearRouteMiddlewareRegistry()
+})
+
+/** A path per test, so module-scoped registries cannot leak between them. */
+let counter = 0
+function uniquePath(): string {
+  counter += 1
+  return `/dup-${process.pid}-${counter}`
+}
+
+describe('a shadowed registration cannot modify the live route (#2332)', () => {
+  test('group middleware from a dead duplicate does not attach to the live route', async () => {
+    const router = createStacksRouter()
+    const path = uniquePath()
+
+    // First registration wins and is deliberately unguarded.
+    router.get(path, () => new Response('LIVE'))
+
+    // The shadowed one, inside an auth group - the shape the framework's
+    // default routes use, and what turned a user's public page into a 401.
+    router.group({ middleware: 'auth' }, () => {
+      router.get(path, () => new Response('SHADOWED'))
+    })
+
+    const res = await router.handleRequest(new Request(`http://localhost${path}`))
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('LIVE')
+  })
+
+  test('.middleware() called on a dead duplicate does not attach either', async () => {
+    const router = createStacksRouter()
+    const path = uniquePath()
+
+    router.get(path, () => new Response('LIVE'))
+    router.get(path, () => new Response('SHADOWED')).middleware('auth')
+
+    const res = await router.handleRequest(new Request(`http://localhost${path}`))
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('LIVE')
+  })
+
+  test('.skipCsrf() on a dead duplicate does not disable CSRF on the live route', async () => {
+    const router = createStacksRouter()
+    const path = uniquePath()
+
+    // The live route never opted out, so the default-on CSRF check must still
+    // reject a cookie-less POST.
+    router.post(path, () => new Response('LIVE'))
+    router.post(path, () => new Response('SHADOWED')).skipCsrf()
+
+    const res = await router.handleRequest(new Request(`http://localhost${path}`, { method: 'POST' }))
+
+    expect(res.status).not.toBe(200)
+  })
+
+  test('the live route keeps the middleware IT declared', async () => {
+    // The guard must not overshoot: a first registration still gets its own
+    // group middleware. Without this, the fix would strip auth from every
+    // protected framework route rather than only from shadowed ones.
+    const router = createStacksRouter()
+    const path = uniquePath()
+
+    router.group({ middleware: 'auth' }, () => {
+      router.get(path, () => new Response('LIVE'))
+    })
+
+    const res = await router.handleRequest(new Request(`http://localhost${path}`))
+
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('the shadow test is per router instance, not per module (#2332)', () => {
+  test('a second router registering the same path is still live, not inert', () => {
+    // bun-router dedupes per INSTANCE, so the same path on a second router is
+    // genuinely served by that router. Tracking registered keys at module
+    // scope would mark it shadowed and return an inert chain, so `.name()`
+    // would quietly do nothing and `url()` could not resolve it.
+    //
+    // This is the shape `stacks-router.test.ts`'s `url()` tests already use -
+    // several of them build a fresh router and re-register
+    // `/api/email/unsubscribe` - which is how a module-scoped guard was caught.
+    const path = uniquePath()
+
+    const first = createStacksRouter()
+    first.get(path, () => new Response('FIRST')).name('dup.first')
+
+    const second = createStacksRouter()
+    second.get(path, () => new Response('SECOND')).name('dup.second')
+
+    expect(url('dup.first')).toContain(path)
+    expect(url('dup.second')).toContain(path)
+  })
+})
+
+/**
+ * Not covered here, and deliberately: the middleware/apiResponse/CSRF
+ * registries are MODULE-scoped and keyed by `METHOD:/path` alone, so two
+ * router instances sharing a path also share those entries. Measured
+ * identical before and after this change, so it is pre-existing and out of
+ * scope for #2332 - but it means cross-instance middleware isolation does not
+ * exist today, and a test asserting it would be asserting a wish.
+ */
+


### PR DESCRIPTION
Closes #2332 — though the issue as I filed it understated this badly. I filed it as a cosmetic introspection mismatch with an OpenAPI consequence. The introspection part is real, the OpenAPI part turned out to be nil, and underneath was something considerably worse.

## The actual bug

bun-router serves the **first** registration of a `METHOD:/path` and discards the second (`RouteCompiler.addRoute` returns false on a duplicate key). The Stacks registries beside it — middleware, apiResponse, CSRF-skip, handler-key — are keyed by `METHOD:/path` alone, so the **discarded** registration wrote straight into the **live** route's state.

That silently breaks the override model `route-loader.ts` documents, which loads user routes before framework defaults precisely so a user route wins. Measured on `main`:

```ts
route.get('/dashboard/home', () => new Response('USER-PUBLIC-PAGE'))
await route.importRoutes()
// GET /dashboard/home -> 401 {"error":"Unauthorized"}
```

The framework's later duplicate inside `route.group({ prefix: '/dashboard', middleware: 'auth' }, …)` stamped `auth` onto the user's public page. With this change it returns `200 USER-PUBLIC-PAGE`. A control path the framework never registers returned 200 either way, so the duplicate is doing it.

Blast radius: 24 `middleware: 'auth'` groups in `defaults/routes/dashboard.ts`, one in `auth.ts`, one `apiResponse` group in `dashboard-api.ts` — and `route-loader.ts`, `dashboard.ts` and `RobotsAction.ts` all explicitly tell users these paths are theirs to override.

**The CSRF direction is worse.** `.skipCsrf()` on a dead duplicate added the shared routeKey to `csrfSkipRegistry`, disabling the default-on CSRF check for a live route that never asked.

## The fix

`registerRoute` marks a repeat registration `shadowed` and skips all three registry writes. The chain returned for a shadowed registration is **inert**, so `.middleware()` / `.skipCsrf()` / `.name()` written against a dead duplicate cannot reach the live route either. `match()` uses `methods[0]`'s own flag, since that is whose chain it returns.

**Tracked per router instance, not per module.** bun-router dedupes per instance, so the same path on a second router is genuinely live. A module-scoped set marks it shadowed and inerts its `.name()`, which breaks `url()` resolution — 378 pass / 1 fail when tried, on `stacks-router.test.ts`'s existing `url() with query params` test.

## Verification

- **Mutation-checked**: reverting the source turns exactly the three bug assertions red, and leaves the two guard assertions green.
- **Does not overshoot**: `/dashboard/home`, `/dashboard/analytics` and `/api/dashboard/commerce/products` return identical statuses before and after when nothing shadows them, so framework auth is intact. A test pins that a first registration still gets its own group middleware.
- Router suite 384/0 across both shards, root 330/0, framework typecheck clean.

## Corrections to the issue, for the record

- **The OpenAPI consequence is nil.** I claimed `generate-openapi` would document the wrong action. `RobotsAction` declares no `validations`/`responses`, and `loadAction`'s result feeds only those two, so the generated `/robots.txt` operation is byte-identical either way.
- **`buddy route:list` is not a consumer.** It reads `route.routes` and prints `[fn]` for every route, since every handler is wrapped.
- **`/robots.txt` was never a last-write-over-first-write collision.** `core.ts:16` registers an inline **function**, and only string handlers are recorded, so the slot was filled solely by the later dead string registration. A naive "first write wins on that map" guard would have fixed nothing.

## Not fixed here

The middleware/apiResponse/CSRF registries are module-scoped and keyed by path alone, so two router *instances* sharing a path share those entries. Measured identical before and after, so it is pre-existing and out of scope — but cross-instance middleware isolation does not exist today. Noted in the test file rather than asserted, since a test for it would be asserting a wish.
