### PR TITLE
fix(db): wait for the project config before choosing what to back up

### DIFF
--- a/storage/framework/core/buddy/src/commands/db.ts
+++ b/storage/framework/core/buddy/src/commands/db.ts
@@ -23,8 +23,40 @@ import {
 const DEFAULT_BACKUP_DIR = 'storage/backups/database'
 const DEFAULT_RETAIN = 7
 
-async function backupTarget(): Promise<BackupTarget | null> {
-  const { config } = await import('@stacksjs/config')
+/**
+ * The database this app actually opens.
+ *
+ * `@stacksjs/config` merges `config/*.ts` asynchronously and only re-binds its
+ * exports once `overridesReady` resolves, so reading `config.database` before
+ * then answers with the FRAMEWORK DEFAULT rather than the project's config
+ * (stacksjs/stacks#2333). There is no barrier anywhere above this: the CLI
+ * does not await it, so this function has to.
+ *
+ * That matters most where it is least visible. `applyPreMigrationBackup`
+ * splices `db:backup --before-migrations` into a site's `preStart` ahead of
+ * `migrate`, so an early read means dumping one database while `migrate`
+ * changes another - and reporting success. A backup of the wrong database is
+ * worse than no backup, because it is one you would restore from.
+ *
+ * The rejection is swallowed on purpose. `overridesReady` rejects when boot
+ * validation finds ANY issue in ANY config file, but that check runs after
+ * every config module has already merged into `overrides` in place, so the
+ * values here are complete either way. Letting it propagate would mean a typo
+ * in an unrelated file - `ports.frontend`, say - aborts the pre-migration
+ * backup and therefore the deploy, which is a worse failure than the one it
+ * would be reporting. The validator has already printed the issues itself.
+ *
+ * Deliberately untested, which is worth stating rather than hiding. In this
+ * repo `database.default` comes from `DB_CONNECTION` in the environment,
+ * available synchronously, so early and late reads agree and no assertion can
+ * tell them apart - measured over three runs, and an ordering assertion also
+ * passed with the barrier removed. Reproducing the divergence needs a
+ * `config/database.ts` that is not env-derived or that carries a top-level
+ * await. A test that passes either way would only look like coverage.
+ */
+export async function backupTarget(): Promise<BackupTarget | null> {
+  const { config, overridesReady } = await import('@stacksjs/config')
+  await overridesReady.catch(() => {})
   return resolveBackupTarget((config as any)?.database)
 }
 


### PR DESCRIPTION
Closes #2333, and corrects its framing: this is hardening, not a bug reachable in this repo today.

## The problem

`backupTarget()` read `config.database` immediately after importing `@stacksjs/config`. That package merges `config/*.ts` asynchronously and only re-binds its exports once `overridesReady` resolves, so an early read answers with the **framework default** rather than the project's configuration. Nothing above it awaits that promise — the CLI has no barrier — so the function has to.

It matters most where it is least visible. `applyPreMigrationBackup` splices `db:backup --before-migrations` into a site's `preStart` immediately ahead of `migrate`. An early read means dumping one database while `migrate` changes another, and reporting success. A backup of the wrong database is worse than no backup, because it is one you would restore from.

## Why the rejection is swallowed

`overridesReady` rejects when boot validation finds an issue in **any** config file. That check runs in a `.then()` *after* every config module has already merged into `overrides` in place, so the values read here are complete either way — catching loses nothing.

Letting it propagate would be actively worse: a typo in an unrelated file (`ports.frontend`, say) would abort the pre-migration backup and therefore the deploy. Measured: with a bare `await overridesReady` and `ports.frontend: 'not-a-port'`, `buddy db:backup` exits 1 on a config error that has no bearing on which database gets dumped. The validator has already printed the issues itself.

## Scope, stated honestly

I filed the issue implying this was reachable today. It is not, in this repo. `database.default` comes from `DB_CONNECTION` in the environment, which is available synchronously, so the early and late reads agree — measured over three runs:

```
EARLY default: "postgres"   LATE default: "postgres"   DIFFER: false
```

The divergence needs a `config/database.ts` that is not env-derived, or one carrying a top-level await. It is deterministic once that exists, which is why the one-line barrier is still worth having.

## No test, deliberately

An ordering assertion (spawn a subprocess, flag when `overridesReady` settles, call `backupTarget()`, assert the flag) **passed with the barrier removed** — by then the config import has already settled, so it proved nothing. A value assertion cannot discriminate either, for the reason above.

I would rather ship no test than one that cannot fail, having spent today pointing out exactly that pattern elsewhere. The reasoning is recorded on the function so the next person does not have to re-derive it.

## Related, not fixed here

The `Storage credentials` probe in `commands/doctor.ts` reads `filesystems` the same way and branches on `driver === 's3'` — the exact key whose shape differs before and after ready (`{driver:'s3'}` with no `s3` key, versus `{driver:'bun', s3:{…}}`). That one **is** observable: with a slow `config/filesystems.ts` it reports `Default disk is 's3' but missing: S3_BUCKET, AWS_ACCESS_KEY_ID…` where the correct answer is `Default disk is 'bun'`. Left for a separate change since it also needs the `S3_BUCKET` / `AWS_S3_BUCKET` name mismatch in that probe resolved.
