### PR TITLE
fix(orm): publish the model definitions the types point at

### DIFF
--- a/storage/framework/core/orm/build.ts
+++ b/storage/framework/core/orm/build.ts
@@ -1,5 +1,5 @@
 import { dts } from 'bun-plugin-dtsx'
-import { rm } from 'node:fs/promises'
+import { cp, readFile, rm, writeFile } from 'node:fs/promises'
 import { frameworkExternal, intro, outro } from '../build/src'
 
 const { startTime } = await intro({
@@ -29,6 +29,70 @@ const result = await Bun.build({
     }),
   ],
 })
+
+/**
+ * Ship the model definitions the declarations point at.
+ *
+ * `src/index.ts` types every model off its definition file:
+ *
+ *   export const Post = lazyModel<typeof import('../../../defaults/app/Models/Content/Post').default>('Post')
+ *
+ * That specifier is correct inside this monorepo and NONSENSE once published.
+ * From `node_modules/@stacksjs/orm/dist/` it climbs out of the package
+ * entirely, resolves to nothing, and TypeScript silently falls back to `any`
+ * - so an installed app got `any` for all 101 models and no error to explain
+ * why. `Post.where(...)` returning `any` is how a typo in a column name ships.
+ *
+ * So the definitions are copied in beside the declarations and the specifiers
+ * rewritten to point at the copy. They stay `.ts` on purpose: they are read
+ * for their types only (`typeof import(...)`), never executed, and the
+ * `defineModel` call in each one IS the type.
+ */
+const MODELS_SOURCE = '../../defaults/app/Models'
+const MODELS_DIST = './dist/models'
+
+await cp(MODELS_SOURCE, MODELS_DIST, { recursive: true })
+
+// What the models import from OUTSIDE their own directory has to come along,
+// or the copy resolves no better than the path it replaced. Today that is one
+// file - `User` reads the password-length constants from it - and the build
+// fails loudly rather than silently shipping a broken reference if a model
+// ever reaches for a sibling that is not listed here.
+const MODEL_SIBLINGS = ['password-policy.ts']
+
+for (const sibling of MODEL_SIBLINGS)
+  await cp(`../../defaults/app/${sibling}`, `./dist/${sibling}`)
+
+const escaping = new Set<string>()
+const glob = new Bun.Glob('**/*.ts')
+
+for await (const entry of glob.scan(MODELS_DIST)) {
+  const source = await readFile(`${MODELS_DIST}/${entry}`, 'utf8')
+  for (const match of source.matchAll(/from '(\.\.\/[^']*)'/g)) {
+    const target = `${match[1]!.replace(/^\.\.\//, '')}.ts`
+    if (!MODEL_SIBLINGS.includes(target))
+      escaping.add(`${entry}: ${match[1]}`)
+  }
+}
+
+if (escaping.size) {
+  throw new Error(
+    `Model definitions import files that are not published with them:\n  ${[...escaping].join('\n  ')}\n`
+    + 'Add them to MODEL_SIBLINGS in core/orm/build.ts, or the published types resolve to `any`.',
+  )
+}
+
+for (const declaration of ['./dist/index.d.ts', './dist/routes.d.ts']) {
+  const file = Bun.file(declaration)
+  if (!(await file.exists()))
+    continue
+
+  const source = await readFile(declaration, 'utf8')
+  const rewritten = source.replaceAll('../../../defaults/app/Models/', './models/')
+
+  if (rewritten !== source)
+    await writeFile(declaration, rewritten)
+}
 
 await outro({
   dir: import.meta.dir,


### PR DESCRIPTION
Every model in an installed app was typed `any`, with nothing to say so.

`core/orm/src/index.ts` types each model off its definition file:

```ts
export const Post = lazyModel<typeof import('../../../defaults/app/Models/Content/Post').default>('Post')
```

That specifier is correct inside this monorepo and nonsense once published. From `node_modules/@stacksjs/orm/dist/` it climbs **out of the package entirely**, resolves to nothing, and TypeScript quietly falls back to `any` - no error, no warning. All **101 models**, in every app that installs Stacks rather than vendoring it.

The consequence is not academic. In an installed app this compiled clean:

```ts
const posts = await Post.where('status', '=', 'published').get()
posts[0].definitely_not_a_column   // no error - `any` all the way down
```

## The fix

The definitions are copied into `dist/models/` at build time and the specifiers rewritten to point there. They stay `.ts` on purpose: they are read for their types only (`typeof import(...)`), never executed, and the `defineModel` call in each one *is* the type.

A model importing anything from outside its own directory needs that file published too, or the copy resolves no better than the path it replaced. Today that is exactly one - the password-length constants `User` reads. The build now **scans for such imports and throws** on any not explicitly listed, so the next one is a failed build rather than a silent regression back to `any`.

## Verification

Built the package and dropped it into a real installed app (CampusHQ, previously on `@stacksjs/orm` 0.72.13):

| | before | after |
|---|---|---|
| app typecheck errors | 6 (all `TS7006` implicit any) | **0** |
| reading a nonexistent column | compiled clean | **rejected** |

The second row is the one that matters - the errors disappearing could just mean the types got looser. A probe with `@ts-expect-error` on a bogus column confirms tsc now genuinely rejects it, so the typing is real rather than absent.