### PR TITLE
fix(database): stop regeneration from silently dropping columns

### DIFF
--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -2396,6 +2396,193 @@ export function tablesOperatedOn(sql: string): string[] {
   return [...tables]
 }
 
+/**
+ * The columns a CREATE TABLE statement defines, in order.
+ *
+ * Splits on top-level commas only, so `DECIMAL(10, 2)` and a multi-column
+ * `PRIMARY KEY (a, b)` do not read as column boundaries. Table constraints
+ * carry no column name and are skipped.
+ */
+export function columnsDefinedByCreate(statement: string): string[] {
+  const body = statement.match(/^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`]?\w+["'`]?\s*\(([\s\S]*)\)\s*;?\s*$/i)?.[1]
+  if (!body)
+    return []
+
+  const parts: string[] = []
+  let depth = 0
+  let current = ''
+
+  for (const char of body) {
+    if (char === '(')
+      depth++
+    if (char === ')')
+      depth--
+    if (char === ',' && depth === 0) {
+      parts.push(current)
+      current = ''
+      continue
+    }
+    current += char
+  }
+  parts.push(current)
+
+  const constraint = /^\s*(?:PRIMARY\s+KEY|FOREIGN\s+KEY|UNIQUE|CHECK|CONSTRAINT|KEY|INDEX)\b/i
+
+  return parts
+    .map(part => part.trim())
+    .filter(part => part && !constraint.test(part))
+    .flatMap(part => part.match(/^["'`]?(\w+)["'`]?/)?.[1] ?? [])
+}
+
+/**
+ * Which columns of `table` the migrations on disk actually produce.
+ *
+ * This is "what a database would have after running the corpus", which is not
+ * the same as what the models declare - and the gap between those two is the
+ * bug this exists to close.
+ */
+export function columnsProducedByMigrations(dir: string, files: readonly string[], table: string): Set<string> {
+  const columns = new Set<string>()
+  const target = table.toLowerCase()
+
+  for (const file of [...files].sort()) {
+    let content: string
+    try {
+      content = readFileSync(join(dir, file), 'utf8')
+    }
+    catch {
+      continue
+    }
+
+    for (const statement of sqlStatementsOf(content)) {
+      const stmt = statement.trim()
+
+      const create = stmt.match(/^CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`]?(\w+)["'`]?/i)
+      if (create?.[1]?.toLowerCase() === target) {
+        for (const column of columnsDefinedByCreate(stmt))
+          columns.add(column.toLowerCase())
+        continue
+      }
+
+      const added = stmt.match(/^ALTER\s+TABLE\s+["'`]?(\w+)["'`]?\s+ADD\s+(?:COLUMN\s+)?["'`]?(\w+)["'`]?/i)
+      if (added?.[1]?.toLowerCase() === target && added[2])
+        columns.add(added[2].toLowerCase())
+
+      const dropped = stmt.match(/^ALTER\s+TABLE\s+["'`]?(\w+)["'`]?\s+DROP\s+(?:COLUMN\s+)?["'`]?(\w+)["'`]?/i)
+      if (dropped?.[1]?.toLowerCase() === target && dropped[2])
+        columns.delete(dropped[2].toLowerCase())
+
+      // A SQLite rebuild replaces the table wholesale: whatever the temp table
+      // defines is what the real one ends up with.
+      const rebuilt = stmt.match(/^ALTER\s+TABLE\s+["'`]?_qb_tmp_(\w+)["'`]?\s+RENAME\s+TO\s+["'`]?(\w+)["'`]?/i)
+      if (rebuilt?.[2]?.toLowerCase() === target) {
+        const temp = sqlStatementsOf(content).find(s =>
+          new RegExp(`^CREATE\\s+TABLE\\s+["'\`]?_qb_tmp_${rebuilt[1]}["'\`]?`, 'i').test(s.trim()),
+        )
+        if (temp) {
+          columns.clear()
+          for (const column of columnsDefinedByCreate(temp))
+            columns.add(column.toLowerCase())
+        }
+      }
+    }
+  }
+
+  return columns
+}
+
+/**
+ * The ALTERs that bring a historically rooted table up to the model's shape.
+ *
+ * A rooted table's CREATE lives in preserved history, so regeneration omits
+ * the full CREATE it just generated - re-creating the table would sit after
+ * authored backfills that already ran against the old shape. That is right
+ * for a table whose columns have not changed and SILENTLY WRONG for one that
+ * gained some: the new columns were in the omitted CREATE and nowhere else,
+ * so no database could ever reach the declared schema, while the snapshot was
+ * written as though the whole corpus had been emitted.
+ *
+ * Observed on a real app: `posts`, `campaigns` and `campaign_sends` were
+ * short 20 columns after a full migrate from empty, with the models and the
+ * snapshot both insisting they were present.
+ *
+ * Emitting ADD COLUMN for exactly the gap keeps the root and the backfills in
+ * place and still lands the new columns.
+ */
+export function rootedTableCatchUpStatements(
+  createStatement: string,
+  existingColumns: ReadonlySet<string>,
+): string[] {
+  const table = createStatement.match(/^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`]?(\w+)["'`]?/i)?.[1]
+  if (!table)
+    return []
+
+  const body = createStatement.match(/\(([\s\S]*)\)\s*;?\s*$/)?.[1]
+  if (!body)
+    return []
+
+  const definitions = new Map<string, string>()
+  let depth = 0
+  let current = ''
+  const parts: string[] = []
+
+  for (const char of body) {
+    if (char === '(')
+      depth++
+    if (char === ')')
+      depth--
+    if (char === ',' && depth === 0) {
+      parts.push(current)
+      current = ''
+      continue
+    }
+    current += char
+  }
+  parts.push(current)
+
+  const constraint = /^\s*(?:PRIMARY\s+KEY|FOREIGN\s+KEY|UNIQUE|CHECK|CONSTRAINT|KEY|INDEX)\b/i
+  for (const raw of parts) {
+    const part = raw.trim()
+    if (!part || constraint.test(part))
+      continue
+    const name = part.match(/^["'`]?(\w+)["'`]?/)?.[1]
+    if (name)
+      definitions.set(name.toLowerCase(), part)
+  }
+
+  const statements: string[] = []
+  for (const [name, definition] of definitions) {
+    if (existingColumns.has(name))
+      continue
+
+    // SQLite refuses ADD COLUMN for PRIMARY KEY, UNIQUE, and AUTOINCREMENT.
+    // A column carrying one of those cannot be added after the fact, so it is
+    // left out rather than emitted as SQL that fails mid-run.
+    if (/\b(?:PRIMARY\s+KEY|UNIQUE|AUTOINCREMENT)\b/i.test(definition))
+      continue
+
+    // NOT NULL with no default is the subtle one: SQLite accepts it against an
+    // EMPTY table and rejects it against a populated one ("Cannot add a NOT
+    // NULL column with default value NULL"), because the existing rows would
+    // have nowhere to get a value. Emitting it as written therefore produces a
+    // migration that passes in CI, where every table starts empty, and fails
+    // on the production database it was written for.
+    //
+    // The constraint is dropped rather than the column. A missing column
+    // breaks every query that names it; a nullable one works and merely holds
+    // a weaker rule than the model asks for, which the model is still the
+    // source of truth for - a later regenerate emits the table rebuild that
+    // tightens it, once there is a value to backfill with.
+    const nullable = /\bNOT\s+NULL\b/i.test(definition) && !/\bDEFAULT\b/i.test(definition)
+      ? definition.replace(/\s*\bNOT\s+NULL\b/i, '')
+      : definition
+
+    statements.push(`ALTER TABLE "${table}" ADD COLUMN ${nullable.trim()}`)
+  }
+
+  return statements
+}
+
 /** The tables a set of generated statements creates, lowercased. */
 export function createdTablesOf(statements: readonly string[]): string[] {
   const tables = new Set<string>()
@@ -2741,6 +2928,27 @@ export async function regenerateMigrationCorpus(options: {
     // the replacement would run against the old shape. Keep the existing
     // generated ALTER chain and omit the late duplicate CREATE/index/alter
     // statements for that table. New tables still receive a full definition.
+    //
+    // Omitting them wholesale is what lost columns: a rooted table that GAINED
+    // attributes had them only in the CREATE being dropped, so no database
+    // could reach the declared schema and the snapshot was still written as if
+    // it could. The gap is emitted as ADD COLUMN instead, which leaves the root
+    // and the backfills exactly where they are.
+    const catchUp: string[] = []
+    for (const table of rootedTables) {
+      const create = groups
+        .flatMap(group => group.statements)
+        .find(statement => statementTable(statement) === table && /^\s*CREATE\s+TABLE\b/i.test(statement))
+      if (!create)
+        continue
+
+      const produced = columnsProducedByMigrations(dir, preserved, table)
+      if (produced.size === 0)
+        continue
+
+      catchUp.push(...rootedTableCatchUpStatements(create, produced))
+    }
+
     const writableGroups = groups
       .map(group => ({
         ...group,
@@ -2750,6 +2958,7 @@ export async function regenerateMigrationCorpus(options: {
         }),
       }))
       .filter(group => group.statements.length > 0)
+      .concat(catchUp.length > 0 ? [{ label: 'alter-rooted-tables-columns', statements: catchUp }] : [])
 
     // In a fully generated corpus, numbering continues past whatever is kept.
     // In a mixed historical corpus, new full CREATEs must sit immediately after

--- a/storage/framework/core/database/tests/rooted-table-catch-up.test.ts
+++ b/storage/framework/core/database/tests/rooted-table-catch-up.test.ts
@@ -1,0 +1,152 @@
+// Columns a rooted table gains must still reach the database.
+//
+// `migrate:regenerate` omits the full CREATE it generates for a table whose
+// original CREATE is preserved history — re-creating the table would sit after
+// authored backfills that already ran against the old shape. That is right for
+// a table whose columns have not changed, and silently wrong for one that
+// gained some: the new columns lived only in the omitted CREATE, so no
+// database could ever reach the declared schema while the model snapshot was
+// written as though the whole corpus had been emitted.
+//
+// Observed on a real app (CampusHQ): after a full migrate from an empty
+// database, `posts`, `campaigns` and `campaign_sends` were short 20 columns
+// between them, with both the models and the snapshot insisting otherwise.
+
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { columnsDefinedByCreate, columnsProducedByMigrations, rootedTableCatchUpStatements } from '../src/migrations'
+
+function corpus(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'rooted-'))
+  for (const [name, body] of Object.entries(files))
+    writeFileSync(join(dir, name), body)
+  return dir
+}
+
+describe('columnsDefinedByCreate', () => {
+  test('reads the column names', () => {
+    expect(columnsDefinedByCreate('CREATE TABLE "posts" (\n "id" INTEGER,\n "title" TEXT\n)')).toEqual(['id', 'title'])
+  })
+
+  test('does not split inside a type', () => {
+    // `DECIMAL(10, 2)` has a comma that is not a column boundary.
+    const sql = 'CREATE TABLE "orders" (\n "id" INTEGER,\n "total" DECIMAL(10, 2),\n "note" TEXT\n)'
+    expect(columnsDefinedByCreate(sql)).toEqual(['id', 'total', 'note'])
+  })
+
+  test('skips table constraints, which name no column', () => {
+    const sql = 'CREATE TABLE "t" (\n "a" INTEGER,\n "b" INTEGER,\n PRIMARY KEY ("a", "b"),\n UNIQUE ("b")\n)'
+    expect(columnsDefinedByCreate(sql)).toEqual(['a', 'b'])
+  })
+
+  test('names nothing for a statement that is not a create', () => {
+    expect(columnsDefinedByCreate('ALTER TABLE "t" ADD COLUMN "x" INTEGER')).toEqual([])
+  })
+})
+
+describe('columnsProducedByMigrations', () => {
+  test('reports what the corpus actually builds, not what a model declares', () => {
+    const dir = corpus({
+      '0000000001-create-posts-table.sql': 'CREATE TABLE "posts" ("id" INTEGER, "title" TEXT);',
+      '0000000002-alter-posts-columns.sql': 'ALTER TABLE "posts" ADD COLUMN "body" TEXT;',
+    })
+
+    expect(columnsProducedByMigrations(dir, ['0000000001-create-posts-table.sql', '0000000002-alter-posts-columns.sql'], 'posts'))
+      .toEqual(new Set(['id', 'title', 'body']))
+  })
+
+  test('forgets a dropped column', () => {
+    const dir = corpus({
+      '0000000001-create-posts-table.sql': 'CREATE TABLE "posts" ("id" INTEGER, "legacy" TEXT);',
+      '0000000002-alter-posts-columns.sql': 'ALTER TABLE "posts" DROP COLUMN "legacy";',
+    })
+
+    expect(columnsProducedByMigrations(dir, ['0000000001-create-posts-table.sql', '0000000002-alter-posts-columns.sql'], 'posts'))
+      .toEqual(new Set(['id']))
+  })
+
+  test('takes a SQLite rebuild as the whole new shape', () => {
+    // The copy-to-temp dance replaces the table wholesale, so whatever the
+    // temp table defines is what survives — including columns it drops.
+    const dir = corpus({
+      '0000000001-create-posts-table.sql': 'CREATE TABLE "posts" ("id" INTEGER, "old" TEXT);',
+      '0000000002-auto-misc.sql': [
+        'CREATE TABLE "_qb_tmp_posts" ("id" INTEGER, "title" TEXT);',
+        'INSERT INTO "_qb_tmp_posts" ("id") SELECT "id" FROM "posts";',
+        'DROP TABLE "posts";',
+        'ALTER TABLE "_qb_tmp_posts" RENAME TO "posts";',
+      ].join('\n'),
+    })
+
+    expect(columnsProducedByMigrations(dir, ['0000000001-create-posts-table.sql', '0000000002-auto-misc.sql'], 'posts'))
+      .toEqual(new Set(['id', 'title']))
+  })
+
+  test('ignores other tables', () => {
+    const dir = corpus({
+      '0000000001-create-posts-table.sql': 'CREATE TABLE "posts" ("id" INTEGER);\nCREATE TABLE "pages" ("id" INTEGER, "slug" TEXT);',
+    })
+
+    expect(columnsProducedByMigrations(dir, ['0000000001-create-posts-table.sql'], 'posts')).toEqual(new Set(['id']))
+  })
+})
+
+describe('rootedTableCatchUpStatements', () => {
+  const create = [
+    'CREATE TABLE "campaign_sends" (',
+    '  "id" INTEGER PRIMARY KEY AUTOINCREMENT,',
+    '  "status" TEXT,',
+    '  "channel" TEXT,',
+    '  "segments" INTEGER,',
+    '  "cost" INTEGER',
+    ')',
+  ].join('\n')
+
+  test('emits ADD COLUMN for exactly the gap', () => {
+    const statements = rootedTableCatchUpStatements(create, new Set(['id', 'status']))
+
+    expect(statements).toHaveLength(3)
+    expect(statements[0]).toContain('ALTER TABLE "campaign_sends" ADD COLUMN "channel" TEXT')
+    expect(statements[1]).toContain('"segments" INTEGER')
+    expect(statements[2]).toContain('"cost" INTEGER')
+  })
+
+  test('is silent when the corpus already produces every column', () => {
+    expect(rootedTableCatchUpStatements(create, new Set(['id', 'status', 'channel', 'segments', 'cost']))).toEqual([])
+  })
+
+  test('leaves out what SQLite cannot add after the fact', () => {
+    // ADD COLUMN refuses PRIMARY KEY, UNIQUE and AUTOINCREMENT. Emitting them
+    // would fail mid-run, which is worse than the column staying absent.
+    const statements = rootedTableCatchUpStatements(create, new Set(['status', 'channel', 'segments', 'cost']))
+    expect(statements).toEqual([])
+  })
+
+  test('names nothing for a statement that is not a create', () => {
+    expect(rootedTableCatchUpStatements('ALTER TABLE "t" ADD COLUMN "x" INTEGER', new Set())).toEqual([])
+  })
+
+  test('drops NOT NULL when the column has no default', () => {
+    // SQLite ACCEPTS this against an empty table and REJECTS it against a
+    // populated one, so emitting it as written passes in CI - where every
+    // table starts empty - and fails on the production database it was
+    // written for. The column matters more than the constraint: a missing one
+    // breaks every query that names it.
+    const create = 'CREATE TABLE "campaign_sends" (\n "id" INTEGER,\n "recipient" TEXT not null\n)'
+    const statements = rootedTableCatchUpStatements(create, new Set(['id']))
+
+    expect(statements).toHaveLength(1)
+    expect(statements[0]).toBe('ALTER TABLE "campaign_sends" ADD COLUMN "recipient" TEXT')
+    expect(statements[0]).not.toContain('not null')
+  })
+
+  test('keeps NOT NULL when a default makes it addable', () => {
+    const create = 'CREATE TABLE "campaigns" (\n "id" INTEGER,\n "timezone" TEXT not null default \'UTC\'\n)'
+    const statements = rootedTableCatchUpStatements(create, new Set(['id']))
+
+    expect(statements[0]).toContain('not null')
+    expect(statements[0]).toContain('default \'UTC\'')
+  })
+})


### PR DESCRIPTION
A table whose original CREATE is preserved history has its regenerated CREATE omitted — re-creating it would sit after authored backfills that already ran against the old shape. That is right for a table whose columns have not changed, and **silently wrong for one that gained some**: the new columns existed only in the CREATE being dropped, so no database could ever reach the declared schema.

What made it invisible is that the model snapshot was still written as though the whole corpus had been emitted. So `generate:migrations` had nothing to say either — it diffs against a snapshot that already claimed the columns were there.

## Found in the wild

After migrating a real app from an empty database:

```
posts:           missing 2  -> slug, site_id
campaigns:       missing 8  -> content, channel_settings, segment_definition, ...
campaign_sends:  missing 10 -> channel, recipient, idempotency_key, ...

total missing columns on a fresh database: 20
```

Both the models and the snapshot insisted these were present. Every query naming one of them fails at runtime.

## The fix

Regeneration now emits `ADD COLUMN` for exactly the gap between what the preserved corpus **actually produces** and what the model declares, in an `alter-rooted-tables-columns` migration. The root and the backfills stay where they are; the columns land.

Two things a catch-up ALTER deliberately cannot carry:

- **PRIMARY KEY / UNIQUE / AUTOINCREMENT** — SQLite rejects `ADD COLUMN` for these outright, so they are left out rather than emitted as SQL that fails mid-run.
- **NOT NULL with no default** — the subtle one. SQLite *accepts* it against an empty table and *rejects* it against a populated one (`Cannot add a NOT NULL column with default value NULL`). Emitted as written, it passes in CI — where every table starts empty — and fails on the production database it was written for. So the **constraint** is dropped, not the column: a missing column breaks every query that names it, while a nullable one works and merely holds a weaker rule than the model asks for. The model stays the source of truth, and a later regenerate emits the rebuild that tightens it.

## New exports

`columnsDefinedByCreate`, `columnsProducedByMigrations`, `rootedTableCatchUpStatements`. The second answers *"what would a database have after running this corpus"* — the question the snapshot was answering wrongly.

## Verification

Against the app above:

| | before | after |
|---|---|---|
| migrations from empty | failed | **213, exit 0** |
| columns missing vs snapshot | 20 | **0** |
| same corpus on a populated DB | would fail on NOT NULL | **applies cleanly** |

14 new tests, covering top-level comma splitting (`DECIMAL(10, 2)` is not a column boundary), SQLite rebuild blocks replacing a table wholesale, dropped columns, and both NOT NULL cases. The database suite stays at 783 pass / 0 fail.