### PR TITLE
feat(dashboard): a production dashboard server, denying by default

### DIFF
--- a/storage/framework/core/actions/src/dev/defaults-resources.ts
+++ b/storage/framework/core/actions/src/dev/defaults-resources.ts
@@ -24,6 +24,22 @@ import { dirname, join, resolve } from 'node:path'
  * Returns the vendored path if neither resolves, letting the caller (stx serve)
  * surface a clear missing-directory error rather than a silent empty glob.
  */
+export function resolveDefaultsRoot(): string {
+  const projectRoot = resolve(import.meta.dir, '../../../../../..')
+  const vendored = join(projectRoot, 'storage/framework/defaults')
+
+  if (existsSync(vendored))
+    return vendored
+
+  try {
+    const pkgJson = Bun.resolveSync('@stacksjs/defaults/package.json', process.cwd())
+    return dirname(pkgJson)
+  }
+  catch {
+    return vendored
+  }
+}
+
 export function resolveDefaultsResources(): string {
   /*
    * Located from this file, not the working directory.

--- a/storage/framework/core/actions/src/serve/dashboard-gate.ts
+++ b/storage/framework/core/actions/src/serve/dashboard-gate.ts
@@ -1,0 +1,116 @@
+/**
+ * Who may see a dashboard page in production.
+ *
+ * The dev dashboard runs with `auth: false` on purpose - it serves one
+ * developer on localhost. Deploying that same server unchanged publishes every
+ * staff page to the internet, so this is the piece that has to exist before a
+ * dashboard can be exposed at all.
+ *
+ * DENY BY DEFAULT is the whole design. stx's page middleware
+ * (`definePageMeta({ middleware: ['auth'] })`) is opt-in per page, which means
+ * a page that forgets the declaration is public - and in the app this was
+ * built for, ZERO of eleven dashboard pages declared it. An allowlist of the
+ * few pages that must render signed-out is the only shape where forgetting
+ * something fails closed.
+ *
+ * The decision is pure and lives here alone so it can be tested without a
+ * server, a database or a browser. `serve/dashboard.ts` only supplies the
+ * request and a token validator.
+ */
+
+/** What the gate decided, and why. */
+export type GateDecision =
+  /** Render it: no session needed for this path. */
+  | { allow: true, reason: 'public-page' | 'asset' | 'delegated' }
+  /** Render it: a valid session was presented. */
+  | { allow: true, reason: 'authenticated' }
+  /** Send them to sign in. */
+  | { allow: false, reason: 'no-session' | 'invalid-session' }
+
+export interface GateOptions {
+  /** Page paths that must render for a signed-out visitor. */
+  publicPaths?: readonly string[]
+}
+
+/**
+ * Paths that must work before anyone can possibly be signed in.
+ *
+ * Deliberately short. `/login` is the page itself; the stx runtime chunks and
+ * the favicon are what that page needs in order to render and be usable.
+ */
+const DEFAULT_PUBLIC_PATHS = ['/login', '/health'] as const
+
+/**
+ * A request for a file rather than a page.
+ *
+ * Assets are allowed through unauthenticated because the sign-in page needs
+ * its stylesheet and scripts to render at all, and because a filename is not
+ * the data being protected. The test is deliberately narrow: a trailing
+ * extension, or one of the runtime's own prefixes. Every extensionless path -
+ * which is what a dashboard page looks like - falls through to the gate.
+ */
+export function isAssetPath(pathname: string): boolean {
+  if (pathname.startsWith('/_stx/') || pathname.startsWith('/@'))
+    return true
+
+  const last = pathname.slice(pathname.lastIndexOf('/') + 1)
+  return last.includes('.')
+}
+
+/**
+ * Whether this request even reaches the page layer.
+ *
+ * Anything under `/api/` and every mutating verb belongs to the router, which
+ * authenticates on its own terms - a POST to `/login` has to arrive
+ * unauthenticated, by definition. Gating those here would either break sign-in
+ * or double-gate an endpoint that already returns 401.
+ */
+export function isDelegatedRequest(method: string, pathname: string): boolean {
+  if (pathname === '/api' || pathname.startsWith('/api/'))
+    return true
+
+  return method !== 'GET' && method !== 'HEAD'
+}
+
+/**
+ * Decide whether a dashboard request may be rendered.
+ *
+ * `validate` resolves a token to its user, or to anything falsy for a token
+ * that is forged, expired or revoked - the same check a bearer token gets. It
+ * throwing counts as invalid: a malformed token that breaks the lookup is not
+ * an authenticated visitor.
+ */
+export async function decideDashboardAccess(
+  request: { method: string, pathname: string, token: string | undefined },
+  validate: (token: string) => Promise<unknown>,
+  options: GateOptions = {},
+): Promise<GateDecision> {
+  const publicPaths = options.publicPaths ?? DEFAULT_PUBLIC_PATHS
+
+  if (isDelegatedRequest(request.method, request.pathname))
+    return { allow: true, reason: 'delegated' }
+
+  if (isAssetPath(request.pathname))
+    return { allow: true, reason: 'asset' }
+
+  // Compared with the trailing slash normalised away, so `/login/` cannot slip
+  // past the allowlist and land on the gate, and more importantly so a gated
+  // path cannot be reached by adding one.
+  const pathname = request.pathname.length > 1 ? request.pathname.replace(/\/+$/, '') : request.pathname
+  if (publicPaths.includes(pathname))
+    return { allow: true, reason: 'public-page' }
+
+  if (!request.token)
+    return { allow: false, reason: 'no-session' }
+
+  try {
+    const user = await validate(request.token)
+    if (user)
+      return { allow: true, reason: 'authenticated' }
+  }
+  catch {
+    // Fall through: an exception is an invalid token, not a pass.
+  }
+
+  return { allow: false, reason: 'invalid-session' }
+}

--- a/storage/framework/core/actions/src/serve/dashboard.ts
+++ b/storage/framework/core/actions/src/serve/dashboard.ts
@@ -1,0 +1,151 @@
+/**
+ * Production Dashboard Server Entry Point
+ *
+ * The staff dashboard, served as its own process — the deployable counterpart
+ * to `dev/dashboard.ts`.
+ *
+ * It needs to be a separate server rather than a route on the main site
+ * because a dashboard page resolves against a different tree entirely: its own
+ * `layoutsDir`, its own `componentsDir`, and a page set drawn from BOTH the
+ * app's `resources/views/dashboard` and the framework's own dashboard views.
+ * `layouts/default` means the dashboard chrome here and the site's marketing
+ * layout there, so the two cannot share one server without one shadowing the
+ * other.
+ *
+ * WHY THIS FILE EXISTS AT ALL: until it did, an app could run its dashboard in
+ * dev and had no supported way to deploy it. Pointing the production web
+ * server at those views renders a 200 with an EMPTY BODY — the layout does not
+ * resolve, so the page's sections render into nothing — which is how a whole
+ * staff dashboard shipped to production looking like a working deploy.
+ *
+ * SECURITY: `dev/dashboard.ts` runs `auth: false`, deliberately, because it
+ * serves one developer on localhost. Deploying that unchanged would publish
+ * every staff page. This server DENIES BY DEFAULT instead: every page render
+ * requires a valid session unless its path is explicitly public. See
+ * `./dashboard-gate.ts` — the decision is pure and tested on its own.
+ *
+ * Deploy with:
+ *   bun node_modules/@stacksjs/actions/dist/serve/dashboard.js
+ *
+ * Environment variables:
+ *   - PORT_DASHBOARD / PORT: port to bind (default: 3002)
+ *   - APP_ENV: environment (production, staging, ...)
+ *
+ * NETWORK EXPOSURE: `serve()` binds every interface, so what keeps this port
+ * off the internet is the host firewall, not the process. The box this was
+ * built for runs ufw with `policy DROP` and only 22/25/80/443 open, which is
+ * the same thing already protecting every other service on it (the API on
+ * 3008, each tenant's site on 31xx). Deploying this somewhere without that
+ * firewall would expose the dashboard directly on the host's public IP,
+ * bypassing the gateway's TLS — check before you do.
+ */
+
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+import { projectPath, publicPath } from '@stacksjs/path'
+import { resolveDefaultsRoot } from '../dev/defaults-resources'
+import { decideDashboardAccess } from './dashboard-gate'
+
+process.env.APP_ENV ||= 'production'
+process.env.NODE_ENV ||= 'production'
+
+const port = Number(process.env.PORT_DASHBOARD || process.env.PORT) || 3002
+
+const defaultsRoot = resolveDefaultsRoot()
+const frameworkDashboard = join(defaultsRoot, 'views/dashboard')
+const appDashboard = projectPath('resources/views/dashboard')
+
+const { authCookieName } = await import('@stacksjs/auth')
+const authCookie = authCookieName()
+
+/**
+ * Read one cookie without trusting the header's shape.
+ *
+ * A value containing `=` (a JWT does not, a signed session can) must survive,
+ * so the split is on the FIRST separator only.
+ */
+function readCookie(header: string | null, name: string): string | undefined {
+  if (!header)
+    return undefined
+
+  for (const part of header.split(';')) {
+    const raw = part.trim()
+    const eq = raw.indexOf('=')
+    if (eq < 1)
+      continue
+    if (raw.slice(0, eq) === name)
+      return decodeURIComponent(raw.slice(eq + 1))
+  }
+
+  return undefined
+}
+
+// Routes must be loaded before the first request: the gate delegates `/api/**`
+// and every mutating verb to the Stacks router, and an unloaded router 404s
+// the POST that signs a person in.
+const router = await import('@stacksjs/router')
+const routeRegistry = (await import(projectPath('app/Routes.ts'))).default
+await router.loadRoutes(routeRegistry)
+
+const { Auth } = await import('@stacksjs/auth')
+const { serve } = await import('bun-plugin-stx/serve')
+
+await serve({
+  // Both trees, exactly as the dev server discovers them: an app's own page
+  // wins, and everything it does not define still comes from the framework.
+  patterns: [appDashboard, frameworkDashboard].filter(dir => existsSync(dir)),
+  port,
+
+  // The dashboard's own chrome and components, NOT the site's.
+  layoutsDir: frameworkDashboard,
+  partialsDir: frameworkDashboard,
+  componentsDir: join(defaultsRoot, 'resources/components/Dashboard'),
+  // Assets belong to the application even when the page came from framework
+  // storage.
+  publicDir: publicPath(),
+
+  quiet: true,
+
+  /**
+   * The gate.
+   *
+   * Runs before page resolution, so a path that renders nothing and a path
+   * that renders a staff record are refused identically — an attacker learns
+   * nothing from the difference.
+   */
+  onRequest: async (req: Request): Promise<Response | null> => {
+    const url = new URL(req.url)
+
+    const decision = await decideDashboardAccess(
+      {
+        method: req.method,
+        pathname: url.pathname,
+        token: readCookie(req.headers.get('cookie'), authCookie),
+      },
+      token => Auth.getUserFromToken(token),
+    )
+
+    if (decision.allow)
+      return null
+
+    // `next` so signing in returns to the page that was asked for. The value
+    // is the path only — never the full URL — so this cannot be turned into
+    // an open redirect to another host.
+    const next = encodeURIComponent(url.pathname + url.search)
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        'location': `/login?next=${next}`,
+        // A refused page must never be cached, by the browser or by anything
+        // between: a cached redirect for one visitor is a cached redirect for
+        // the next, and a cached PAGE would outlive the session that earned it.
+        'cache-control': 'no-store, private',
+      },
+    })
+  },
+})
+
+// eslint-disable-next-line no-console
+console.log(`Dashboard server listening on port ${port}`)

--- a/storage/framework/core/actions/tests/dashboard-gate.test.ts
+++ b/storage/framework/core/actions/tests/dashboard-gate.test.ts
@@ -1,0 +1,121 @@
+// The gate that decides who sees a staff dashboard page in production.
+//
+// The dev dashboard runs `auth: false` because it serves one developer on
+// localhost. Deploying that unchanged publishes every staff page — for the app
+// this was built for, that is student and family records. So these tests are
+// written as the questions an attacker would ask, and the default answer to
+// every one of them has to be "no".
+
+import { describe, expect, test } from 'bun:test'
+import { decideDashboardAccess, isAssetPath, isDelegatedRequest } from '../src/serve/dashboard-gate'
+
+/** A validator that accepts exactly one token and nothing else. */
+const onlyValid = async (token: string) => (token === 'valid-token' ? { id: 1 } : undefined)
+
+function get(pathname: string, token?: string) {
+  return { method: 'GET', pathname, token }
+}
+
+describe('deny by default', () => {
+  test('refuses a dashboard page with no session', async () => {
+    const decision = await decideDashboardAccess(get('/messages'), onlyValid)
+    expect(decision).toEqual({ allow: false, reason: 'no-session' })
+  })
+
+  test('refuses a page a developer forgot to declare auth on', async () => {
+    // The real failure mode: stx page middleware is opt-in, and zero of the
+    // eleven pages in the app declared it. An unknown path must still be shut.
+    for (const page of ['/events', '/gala', '/reports', '/families/2031/records', '/some-page-added-tomorrow'])
+      expect((await decideDashboardAccess(get(page), onlyValid)).allow).toBe(false)
+  })
+
+  test('refuses a forged token', async () => {
+    const decision = await decideDashboardAccess(get('/messages', 'forged'), onlyValid)
+    expect(decision).toEqual({ allow: false, reason: 'invalid-session' })
+  })
+
+  test('refuses when the validator throws', async () => {
+    // A malformed token that breaks the lookup is an invalid token, not a
+    // visitor. Failing open here would turn a crash into an access grant.
+    const explodes = async () => { throw new Error('malformed token') }
+    const decision = await decideDashboardAccess(get('/messages', '{{'), explodes)
+    expect(decision).toEqual({ allow: false, reason: 'invalid-session' })
+  })
+
+  test('refuses an empty token', async () => {
+    expect((await decideDashboardAccess(get('/messages', ''), onlyValid)).allow).toBe(false)
+  })
+
+  test('admits a valid session', async () => {
+    const decision = await decideDashboardAccess(get('/messages', 'valid-token'), onlyValid)
+    expect(decision).toEqual({ allow: true, reason: 'authenticated' })
+  })
+})
+
+describe('the allowlist', () => {
+  test('lets a signed-out visitor reach the sign-in page', async () => {
+    expect((await decideDashboardAccess(get('/login'), onlyValid)).reason).toBe('public-page')
+  })
+
+  test('is not widened by a trailing slash', async () => {
+    expect((await decideDashboardAccess(get('/login/'), onlyValid)).allow).toBe(true)
+  })
+
+  test('cannot be reached by dressing a gated path up as a public one', async () => {
+    // Prefix and suffix tricks against the allowlist.
+    for (const path of ['/login/../messages', '/messages/login', '/loginx', '/login-secrets'])
+      expect((await decideDashboardAccess(get(path), onlyValid)).allow).toBe(false)
+  })
+
+  test('is replaceable, and replacing it does not add anything', async () => {
+    const options = { publicPaths: ['/signin'] }
+    expect((await decideDashboardAccess(get('/signin'), onlyValid, options)).allow).toBe(true)
+    expect((await decideDashboardAccess(get('/login'), onlyValid, options)).allow).toBe(false)
+  })
+})
+
+describe('assets', () => {
+  test('render for a signed-out visitor, so the sign-in page works', async () => {
+    for (const asset of ['/_stx/router.js', '/favicon.ico', '/assets/app.css', '/img/logo.svg'])
+      expect((await decideDashboardAccess(get(asset), onlyValid)).reason).toBe('asset')
+  })
+
+  test('a page is not an asset just because a segment above it has a dot', async () => {
+    // Only the LAST segment decides, or `/v1.2/families` would read as a file
+    // and skip the gate entirely.
+    expect(isAssetPath('/v1.2/families')).toBe(false)
+    expect((await decideDashboardAccess(get('/v1.2/families'), onlyValid)).allow).toBe(false)
+  })
+
+  test('an extensionless path is never an asset', () => {
+    expect(isAssetPath('/messages')).toBe(false)
+    expect(isAssetPath('/')).toBe(false)
+  })
+})
+
+describe('what the router owns', () => {
+  test('API paths pass through to be authenticated there', async () => {
+    // These return 401 on their own terms; gating them here would either
+    // double-gate or, worse, redirect a JSON call to an HTML login page.
+    expect((await decideDashboardAccess(get('/api/campushq/messages'), onlyValid)).reason).toBe('delegated')
+  })
+
+  test('a path merely starting with the letters api is NOT delegated', async () => {
+    expect((await decideDashboardAccess(get('/apiary'), onlyValid)).allow).toBe(false)
+  })
+
+  test('sign-in can be posted while signed out', async () => {
+    expect(isDelegatedRequest('POST', '/login')).toBe(true)
+  })
+
+  test('a mutating verb never renders a page, so it belongs to the router', () => {
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE'])
+      expect(isDelegatedRequest(method, '/messages')).toBe(true)
+  })
+
+  test('HEAD is gated exactly like GET', async () => {
+    // HEAD leaks existence and headers if it skips the gate.
+    expect(isDelegatedRequest('HEAD', '/messages')).toBe(false)
+    expect((await decideDashboardAccess({ method: 'HEAD', pathname: '/messages', token: undefined }, onlyValid)).allow).toBe(false)
+  })
+})


### PR DESCRIPTION
An app could run its staff dashboard in dev and had **no supported way to deploy it**. `serve/` held only `api.ts`; the dashboard existed solely as `dev/dashboard.ts`.

Pointing the production web server at those views does not work, and fails in the worst way: **200 with an empty body**. A dashboard page resolves against a different tree entirely — its own `layoutsDir`, its own `componentsDir`, and a page set drawn from *both* the app's `resources/views/dashboard` and the framework's own dashboard views. So `layouts/default` means the dashboard chrome there and the site's marketing layout on the main server. Without the right tree the layout does not resolve, the page's sections render into nothing, and the deploy looks healthy. A whole staff dashboard shipped to production that way.

`dev/dashboard.ts` cannot simply be deployed either — it runs `auth: false`, deliberately, because it serves one developer on localhost. Deploying it unchanged publishes every staff page.

## Deny by default

stx's page middleware (`definePageMeta({ middleware: ['auth'] })`) is **opt-in per page**, so a page that forgets the declaration is public. In the app this was built for, **zero of eleven** dashboard pages declared it. An allowlist of the few paths that must render signed-out is the only shape where forgetting something fails closed.

The decision lives in `serve/dashboard-gate.ts` as a pure function — tested without a server, a database or a browser:

- every page render needs a session validated by `Auth.getUserFromToken`, the same check a bearer token gets, so forged/expired/revoked tokens are refused alike — and a validator that **throws** counts as invalid rather than as a pass
- `/api/**` and every mutating verb delegate to the router, which authenticates on its own terms (a POST to `/login` must arrive unauthenticated by definition)
- assets pass so the sign-in page can render, decided by the **last path segment only**, so `/v1.2/families` is a page and not a file
- the allowlist normalises trailing slashes, so a gated path cannot be reached by adding one

Refusals redirect to `/login?next=<path>` — path only, never a full URL, so it cannot become an open redirect — and carry `no-store, private`, because a cached redirect for one visitor is a cached redirect for the next.

## Verified against a real app, not just unit tests

| request | result |
|---|---|
| `/messages`, `/events`, `/gala`, `/reports`, `/website`, `/admissions` — no session | **302** → `/login?next=…` |
| `/messages` — forged token | **302** |
| `/messages` — session minted via `Auth.login` | **200**, 525KB, chrome *and* page content |
| `/login`, `/_stx/router.js` — signed out | **200** |

18 gate tests written as the questions an attacker would ask (trailing-slash bypass, `/loginx`, `/apiary`, dotted path segments, HEAD, a throwing validator). The actions suite stays at **439 pass**.

Also adds `resolveDefaultsRoot()` beside the existing resources resolver, since the dashboard views are a sibling of `resources/` rather than inside it.

**Network note, called out in the file:** `serve()` binds every interface, so what keeps the port off the internet is the host firewall, not the process — the same thing already protecting the API on 3008 and each tenant's site on 31xx.