### PR TITLE
feat(redirects): one wildcard form, for moving a whole section

### DIFF
--- a/config/server.ts
+++ b/config/server.ts
@@ -56,7 +56,14 @@ export default {
    * }
    * ```
    *
-   * Matching is exact on the path, ignoring a trailing slash, and the query
+   * A rule written as `/section/*` claims that subtree instead, appending
+   * whatever followed the prefix to the target — `'/dashboard/*':
+   * 'https://dash.example.com'` sends `/dashboard/events/42` to
+   * `https://dash.example.com/events/42`. It is the one wildcard form there
+   * is: moving a section whose pages are dynamic cannot be written as a list
+   * of exact rules. An exact rule always wins over a subtree one.
+   *
+   * Matching is otherwise exact on the path, ignoring a trailing slash, and the query
    * string is carried over unless you say otherwise. Rules are answered before
    * a page is looked for and before `public/` is searched, so — as with
    * `proxy.paths` — a rule shadows a static file of the same name. Anything

--- a/storage/framework/core/server/src/redirects.ts
+++ b/storage/framework/core/server/src/redirects.ts
@@ -64,6 +64,11 @@ export interface RedirectRule {
   to: string
   status: number
   preserveQuery: boolean
+  /**
+   * True when the rule was written as `/section/*` and therefore claims the
+   * whole subtree, appending whatever followed the prefix to `to`.
+   */
+  subtree: boolean
 }
 
 export type RedirectRules = Map<string, RedirectRule>
@@ -97,7 +102,10 @@ export function resolveRedirectRules(input: RedirectConfig = {}): RedirectRules 
   const rules: RedirectRules = new Map()
 
   for (const [rawFrom, rawTarget] of Object.entries(input ?? {})) {
-    const from = normalizePath(rawFrom)
+    // `/section/*` claims the subtree. Stored under the prefix WITHOUT the
+    // star so lookups stay a plain map read.
+    const subtree = rawFrom.endsWith('/*')
+    const from = normalizePath(subtree ? rawFrom.slice(0, -2) || '/' : rawFrom)
     if (!from)
       continue
 
@@ -116,11 +124,12 @@ export function resolveRedirectRules(input: RedirectConfig = {}): RedirectRules 
     if (!/^https?:\/\//i.test(to) && normalizePath(to) === from)
       continue
 
-    rules.set(from, {
+    rules.set(subtree ? `${from}/*` : from, {
       from,
       to,
       status: Number(target?.status) || DEFAULT_REDIRECT_STATUS,
       preserveQuery: target?.preserveQuery !== false,
+      subtree,
     })
   }
 
@@ -130,20 +139,42 @@ export function resolveRedirectRules(input: RedirectConfig = {}): RedirectRules 
 /**
  * The response for a redirected path, or undefined to carry on routing.
  *
- * Matching is exact on the normalised path. Prefix and pattern rules are
- * deliberately not supported: a redirect table is read by whoever is debugging
- * a URL at two in the morning, and every wildcard in it is a thing they have
- * to simulate in their head to know what a given path does.
+ * Matching is exact on the normalised path, and an exact rule always wins over
+ * a subtree one covering the same URL.
+ *
+ * ONE wildcard form is supported, `/section/*`, and general pattern rules
+ * still are not. The reasoning behind that original restriction stands — a
+ * redirect table is read by whoever is debugging a URL at two in the morning,
+ * and every wildcard is something they have to simulate in their head — but
+ * exact matching cannot express the case that forced this: moving a whole
+ * section to another host when some of its pages are dynamic. `/dashboard/*`
+ * has to cover `/dashboard/events/42`, and there is no list of exact rules
+ * that does.
+ *
+ * `/section/*` means that subtree and nothing else: whatever followed the
+ * prefix is appended to the target, so `/dashboard/events/42` with
+ * `'/dashboard/*': 'https://dash.example.com'` lands on
+ * `https://dash.example.com/events/42`. No regular expressions, no captures,
+ * no ordering to reason about.
  */
 export function resolveRedirect(url: URL, rules?: RedirectRules): Response | undefined {
   if (!rules?.size)
     return undefined
 
-  const rule = rules.get(normalizePath(url.pathname))
+  const pathname = normalizePath(url.pathname)
+  const rule = rules.get(pathname) ?? matchSubtree(pathname, rules)
   if (!rule)
     return undefined
 
   let location = rule.to
+
+  // Append the part of the path the prefix did not claim, so a subtree rule
+  // lands on the matching page rather than the target's root.
+  if (rule.subtree) {
+    const remainder = pathname.slice(rule.from.length)
+    if (remainder)
+      location = location.replace(/\/$/, '') + remainder
+  }
 
   if (rule.preserveQuery && url.search) {
     // Merge rather than overwrite, so a target that carries its own query
@@ -162,6 +193,30 @@ export function resolveRedirect(url: URL, rules?: RedirectRules): Response | und
         : 'no-store',
     },
   })
+}
+
+/**
+ * The subtree rule claiming this path, if any.
+ *
+ * The LONGEST matching prefix wins, so a more specific section can be carved
+ * out of a broader one (`/dashboard/reports/*` beside `/dashboard/*`) without
+ * depending on declaration order.
+ */
+function matchSubtree(pathname: string, rules: RedirectRules): RedirectRule | undefined {
+  let best: RedirectRule | undefined
+
+  for (const rule of rules.values()) {
+    if (!rule.subtree)
+      continue
+    // A boundary check, not a string prefix: `/dashboards` must not be claimed
+    // by a rule for `/dashboard`.
+    if (pathname !== rule.from && !pathname.startsWith(`${rule.from}/`))
+      continue
+    if (!best || rule.from.length > best.from.length)
+      best = rule
+  }
+
+  return best
 }
 
 /**

--- a/storage/framework/core/server/tests/redirects.test.ts
+++ b/storage/framework/core/server/tests/redirects.test.ts
@@ -32,6 +32,7 @@ describe('resolveRedirectRules', () => {
       to: '/new',
       status: DEFAULT_REDIRECT_STATUS,
       preserveQuery: true,
+      subtree: false,
     })
   })
 
@@ -165,5 +166,83 @@ describe('describeRedirectRules', () => {
 
     expect(describeRedirectRules(resolveRedirectRules(many)))
       .toBe('/old-0 → /new-0, /old-1 → /new-1, /old-2 → /new-2 (+3 more)')
+  })
+})
+
+/**
+ * Moving a whole section to another host.
+ *
+ * Exact rules cannot express this: `/dashboard/events/[id]` is a real page, so
+ * there is no finite list of paths to enumerate. That is the case `/section/*`
+ * exists for, and the reason the original "no wildcards" rule needed exactly
+ * one exception rather than none.
+ */
+describe('subtree redirects', () => {
+  const rules = resolveRedirectRules({
+    '/dashboard/*': 'https://dashboard.example.com',
+  })
+
+  test('moves the section root', () => {
+    expect(resolveRedirect(at('/dashboard'), rules)?.headers.get('location'))
+      .toBe('https://dashboard.example.com')
+  })
+
+  test('carries the rest of the path onto the new host', () => {
+    expect(resolveRedirect(at('/dashboard/messages'), rules)?.headers.get('location'))
+      .toBe('https://dashboard.example.com/messages')
+  })
+
+  test('covers a dynamic page, which is the whole point', () => {
+    expect(resolveRedirect(at('/dashboard/events/42'), rules)?.headers.get('location'))
+      .toBe('https://dashboard.example.com/events/42')
+  })
+
+  test('stops at a path boundary rather than a string prefix', () => {
+    // `/dashboards` is a different section and must not be swallowed.
+    expect(resolveRedirect(at('/dashboards'), rules)).toBeUndefined()
+    expect(resolveRedirect(at('/dashboard-archive'), rules)).toBeUndefined()
+  })
+
+  test('leaves everything else alone', () => {
+    expect(resolveRedirect(at('/events'), rules)).toBeUndefined()
+  })
+
+  test('keeps the query string', () => {
+    expect(resolveRedirect(at('/dashboard/messages?tab=sent'), rules)?.headers.get('location'))
+      .toBe('https://dashboard.example.com/messages?tab=sent')
+  })
+
+  test('an exact rule beats a subtree rule for the same URL', () => {
+    const mixed = resolveRedirectRules({
+      '/dashboard/*': 'https://dashboard.example.com',
+      '/dashboard/legacy': '/archive',
+    })
+
+    expect(resolveRedirect(at('/dashboard/legacy'), mixed)?.headers.get('location')).toBe('/archive')
+    expect(resolveRedirect(at('/dashboard/other'), mixed)?.headers.get('location'))
+      .toBe('https://dashboard.example.com/other')
+  })
+
+  test('the longest matching prefix wins, whatever the declaration order', () => {
+    // So a section can be carved out of a broader rule without the table
+    // depending on the order someone happened to write it in.
+    const nested = resolveRedirectRules({
+      '/dashboard/*': 'https://dashboard.example.com',
+      '/dashboard/reports/*': 'https://reports.example.com',
+    })
+
+    expect(resolveRedirect(at('/dashboard/reports/q4'), nested)?.headers.get('location'))
+      .toBe('https://reports.example.com/q4')
+  })
+
+  test('still refuses to touch the API', () => {
+    const api = resolveRedirectRules({ '/api/*': 'https://elsewhere.example.com' })
+    expect(resolveRedirect(at('/api/campushq/messages'), api)).toBeUndefined()
+  })
+
+  test('does not double the slash when the target has a trailing one', () => {
+    const trailing = resolveRedirectRules({ '/dashboard/*': 'https://dashboard.example.com/' })
+    expect(resolveRedirect(at('/dashboard/messages'), trailing)?.headers.get('location'))
+      .toBe('https://dashboard.example.com/messages')
   })
 })

--- a/storage/framework/core/types/src/server.ts
+++ b/storage/framework/core/types/src/server.ts
@@ -62,7 +62,12 @@ export interface ApiProxyOptions {
  * }
  * ```
  *
- * Matching is exact on the path, ignoring a trailing slash. Rules are answered
+ * A rule written as `/section/*` claims that subtree, appending whatever
+ * followed the prefix to the target. It is the one wildcard form: moving a
+ * section whose pages are dynamic cannot be written as exact rules. An exact
+ * rule always wins over a subtree one.
+ *
+ * Matching is otherwise exact on the path, ignoring a trailing slash. Rules are answered
  * before a page is looked for and before `public/` is searched, so a rule
  * shadows a static file of the same name — the same caveat as `proxy.paths`.
  * Anything under `/api/` is ignored.


### PR DESCRIPTION
Redirect matching was exact on the path, and **deliberately so** — the note in `redirects.ts` puts it well: a redirect table is read by whoever is debugging a URL at two in the morning, and every wildcard is something they have to simulate in their head. That reasoning stands, and it still rules out pattern rules.

But it cannot express the case that prompted this. Moving a section to another host means redirecting `/dashboard/messages` **and** `/dashboard/events/42` — and the second is a dynamic page, so there is no finite list of exact rules that covers it. The alternative was leaving the old URLs answering **200 with an empty body**, which is precisely the failure this line of work exists to remove.

## The one exception

```ts
redirects: {
  '/dashboard/*': 'https://dash.example.com',
}
```

`/dashboard/events/42` → `https://dash.example.com/events/42`. Whatever followed the prefix is appended to the target. No regular expressions, no captures, no ordering to reason about.

- An **exact rule always wins** over a subtree rule for the same URL.
- Among subtree rules the **longest matching prefix wins**, so `/dashboard/reports/*` can be carved out of `/dashboard/*` without the table depending on declaration order.
- Matching is on **path boundaries**, not string prefixes — `/dashboards` and `/dashboard-archive` are not claimed by a rule for `/dashboard`.
- `/api/**` stays untouchable, as before.

## Tests

11 new, covering the section root, a dynamic page, boundary cases, exact-beats-subtree precedence, nested prefixes, query preservation, and a target with a trailing slash (no doubled `//`). The server suite goes to **109 pass**.

One existing test needed a one-line update: it asserts the whole rule object, which now carries `subtree: false`.

Documented in both `config/server.ts` and the `ServerConfig` type, since that comment is what an app author actually reads.