### PR TITLE
fix(audio,video): unpack the asset verifiers so lint can read them

### DIFF
--- a/storage/framework/core/audio/src/index.ts
+++ b/storage/framework/core/audio/src/index.ts
@@ -94,7 +94,17 @@ export function audioResponseHeaders(bytes: number, etag: string, contentType: s
 export function signAudioAsset(path: string, expires: number, secret: string): string {
   return createHmac('sha256', secret).update(`${path}\n${expires}`).digest('base64url')
 }
-export function verifyAudioAsset(path: string, expires: number, signature: string, secret: string, now: number = Date.now()): boolean { if (!Number.isInteger(expires) || expires * 1000 <= now) return false; const expected = Buffer.from(signAudioAsset(path, expires, secret)); const actual = Buffer.from(signature); return expected.length === actual.length && timingSafeEqual(expected, actual) }
+export function verifyAudioAsset(path: string, expires: number, signature: string, secret: string, now: number = Date.now()): boolean {
+  if (!Number.isInteger(expires) || expires * 1000 <= now)
+    return false
+
+  const expected = Buffer.from(signAudioAsset(path, expires, secret))
+  const actual = Buffer.from(signature)
+
+  // The length check has to come first: timingSafeEqual throws on a length
+  // mismatch rather than returning false, and && short-circuits before it.
+  return expected.length === actual.length && timingSafeEqual(expected, actual)
+}
 
 export interface AudioSegment { uri: string, duration: number, data: Uint8Array }
 export interface AudioHlsProtection { key: Uint8Array, keyUri: string }

--- a/storage/framework/core/audio/tests/audio.test.ts
+++ b/storage/framework/core/audio/tests/audio.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import { assertAudioPlanExecutable, audio, createProtectedAudioPlaylist, createWaveform, negotiateAudioOutput, normalizeTranscript } from '../src'
+import { assertAudioPlanExecutable, audio, createProtectedAudioPlaylist, createWaveform, negotiateAudioOutput, normalizeTranscript, signAudioAsset, verifyAudioAsset } from '../src'
 const profile = { codec: 'flac', container: 'flac', duration: 60, sampleRate: 48000, channels: 2, bitrate: 800000 }
 describe('@stacksjs/audio', () => {
   test('reports unavailable encoding honestly', () => { const plan = audio('episode.flac').profile(profile).content('speech').generate(); expect(plan.outputs.every(value => value.action === 'transcode' && !value.available)).toBe(true); expect(() => assertAudioPlanExecutable(plan)).toThrow(/unavailable/) })
   test('negotiates formats by q-value', () => { const plan = audio('episode.flac').profile(profile).runtime({ encoder: true, codecs: ['opus', 'aac', 'mp3'] }).generate(); expect(negotiateAudioOutput(plan.outputs, 'audio/mpeg;q=.5,audio/ogg;q=1')?.format).toBe('opus') })
   test('normalizes waveforms and transcripts', () => { expect(createWaveform([new Float32Array([-.5, .25, -1, .75])], 4, 2).peaks).toEqual([[-.5, .25, -1, .75]]); expect(normalizeTranscript('EN', [{ startTime: 0, endTime: 1.25, text: ' Hello ' }]).vtt).toContain('00:00:01.250') })
   test('encrypts audio HLS segments', async () => { const source = new Uint8Array([1, 2, 3]); const result = await createProtectedAudioPlaylist([{ uri: 'one.m4s', duration: 4, data: source }], { key: new Uint8Array(16).fill(4), keyUri: '/keys/audio' }); expect(result.files['one.m4s']).not.toEqual(source); expect(result.playlist).toContain('METHOD=AES-128') })
+
+  test('accepts its own signature and rejects a tampered or expired one', () => { const expires = 2000; const signature = signAudioAsset('/episode.flac', expires, 'secret'); expect(verifyAudioAsset('/episode.flac', expires, signature, 'secret', 1000)).toBe(true); expect(verifyAudioAsset('/other.flac', expires, signature, 'secret', 1000)).toBe(false); expect(verifyAudioAsset('/episode.flac', expires, signature, 'secret', 2_000_000)).toBe(false); expect(verifyAudioAsset('/episode.flac', 1.5, signature, 'secret', 1000)).toBe(false) })
+
+  // timingSafeEqual throws on a length mismatch instead of returning false, so
+  // a short signature must be turned away by the length check ahead of it. A
+  // reordering that looks equivalent turns a denied request into a 500.
+  test('rejects a wrong-length signature without throwing', () => { const expires = 2000; expect(() => verifyAudioAsset('/episode.flac', expires, 'short', 'secret', 1000)).not.toThrow(); expect(verifyAudioAsset('/episode.flac', expires, 'short', 'secret', 1000)).toBe(false) })
 })

--- a/storage/framework/core/video/src/index.ts
+++ b/storage/framework/core/video/src/index.ts
@@ -103,7 +103,17 @@ export function videoResponseHeaders(bytes: number, etag: string, contentType: s
 export function signVideoAsset(path: string, expires: number, secret: string): string {
   return createHmac('sha256', secret).update(`${path}\n${expires}`).digest('base64url')
 }
-export function verifyVideoAsset(path: string, expires: number, signature: string, secret: string, now: number = Date.now()): boolean { if (!Number.isInteger(expires) || expires * 1000 <= now) return false; const expected = Buffer.from(signVideoAsset(path, expires, secret)); const actual = Buffer.from(signature); return expected.length === actual.length && timingSafeEqual(expected, actual) }
+export function verifyVideoAsset(path: string, expires: number, signature: string, secret: string, now: number = Date.now()): boolean {
+  if (!Number.isInteger(expires) || expires * 1000 <= now)
+    return false
+
+  const expected = Buffer.from(signVideoAsset(path, expires, secret))
+  const actual = Buffer.from(signature)
+
+  // The length check has to come first: timingSafeEqual throws on a length
+  // mismatch rather than returning false, and && short-circuits before it.
+  return expected.length === actual.length && timingSafeEqual(expected, actual)
+}
 
 export interface VideoSegment { uri: string, duration: number, data: Uint8Array }
 export interface VideoHlsProtection { key: Uint8Array, keyUri: string, iv?: (_index: number) => Uint8Array }

--- a/storage/framework/core/video/tests/video.test.ts
+++ b/storage/framework/core/video/tests/video.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import { assertVideoPlanExecutable, createHlsMaster, createPreviewVtt, createProtectedVideoPlaylist, deriveVideoLadder, video, videoAssetHeaders } from '../src'
+import { assertVideoPlanExecutable, createHlsMaster, createPreviewVtt, createProtectedVideoPlaylist, deriveVideoLadder, signVideoAsset, verifyVideoAsset, video, videoAssetHeaders } from '../src'
 const profile = { width: 1920, height: 1080, duration: 120, frameRate: 30, container: 'mp4' as const, videoCodec: 'h264', audioCodec: 'aac', hasAudio: true }
 describe('@stacksjs/video', () => {
   test('creates distinct ladders without upscaling', () => expect(deriveVideoLadder(profile).map(value => value.height)).toEqual([240, 360, 480, 540, 720, 1080]))
   test('fails early when encoders are unavailable', () => { const plan = video('demo.mp4').profile(profile).generate(); expect(plan.outputs[1]).toMatchObject({ action: 'transcode', available: false }); expect(() => assertVideoPlanExecutable(plan)).toThrow(/unavailable/) })
   test('emits HLS metadata and preview VTT', () => { const plan = video('demo.mp4').profile(profile).output(['mp4']).runtime({ videoEncoder: true, audioEncoder: true, videoCodecs: ['h264'], audioCodecs: ['aac'] }).generate(); expect(createHlsMaster(plan, item => `${item.name}.m3u8`)).toContain('RESOLUTION=1920x1080'); expect(createPreviewVtt([{ startTime: 0, endTime: 10, uri: 'sprite.jpg', x: 0, y: 0, width: 160, height: 90 }])).toContain('#xywh=0,0,160,90') })
   test('encrypts HLS segments and protects manifest caching', async () => { const source = new Uint8Array([1, 2, 3]); const result = await createProtectedVideoPlaylist([{ uri: 'one.m4s', duration: 4, data: source }], { key: new Uint8Array(16).fill(4), keyUri: '/keys/video' }); expect(result.files['one.m4s']).not.toEqual(source); expect(result.playlist).toContain('METHOD=AES-128'); expect(videoAssetHeaders('master.m3u8', undefined, undefined, true)['Cache-Control']).toBe('private, no-store') })
+
+  test('accepts its own signature and rejects a tampered or expired one', () => { const expires = 2000; const signature = signVideoAsset('/demo.mp4', expires, 'secret'); expect(verifyVideoAsset('/demo.mp4', expires, signature, 'secret', 1000)).toBe(true); expect(verifyVideoAsset('/other.mp4', expires, signature, 'secret', 1000)).toBe(false); expect(verifyVideoAsset('/demo.mp4', expires, signature, 'secret', 2_000_000)).toBe(false); expect(verifyVideoAsset('/demo.mp4', 1.5, signature, 'secret', 1000)).toBe(false) })
+
+  // timingSafeEqual throws on a length mismatch instead of returning false, so
+  // a short signature must be turned away by the length check ahead of it. A
+  // reordering that looks equivalent turns a denied request into a 500.
+  test('rejects a wrong-length signature without throwing', () => { const expires = 2000; expect(() => verifyVideoAsset('/demo.mp4', expires, 'short', 'secret', 1000)).not.toThrow(); expect(verifyVideoAsset('/demo.mp4', expires, 'short', 'secret', 1000)).toBe(false) })
 })


### PR DESCRIPTION
Main has been red on `lint` since v0.72.20 (`1cc499fa00`). Ten errors, all of them `pickier/no-unused-vars` against `verifyAudioAsset` and `verifyVideoAsset`.

## What is actually wrong

Both functions were written as a single ~330-character line, in files where the other eight exported functions are each multi-line. pickier loses the body of a one-line function whose first statement is a guard clause, so every parameter looks unused, even though all five are used.

Minimal repro, reduced from the real code and confirmed on the SDK path that `buddy lint` uses:

```ts
// 5 errors: every parameter reported unused
export function verify(path: string, expires: number, signature: string, secret: string, now: number = Date.now()): boolean { if (expires <= now) return false; return (path + secret).length === signature.length }

// 0 errors: same parameters, same one-line body, no guard clause
export function verify(path: string, expires: number, signature: string, secret: string, now: number = Date.now()): boolean { const a = path + secret + expires + now; return a.length === signature.length }
```

## The pickier bump in that release is innocent

That is the obvious suspect and it is worth ruling out explicitly, because I first blamed it. `0.1.56` reports the same ten errors through `runLint`, and `runLint` is the path `buddy lint` takes (`storage/framework/core/actions/src/lint/lint.ts`). It reads as version-specific only if you test with the pickier CLI, which resolves different configuration from its SDK and is silent on `0.1.56`. Pinning the version back would not have fixed this.

## Tests

Neither verifier had a single test, which is how a signed-URL check reached main unexercised. Both now pin:

- a signature from `sign*Asset` verifies
- a signature for a different path does not
- an expired timestamp does not
- a non-integer `expires` does not
- a wrong-length signature returns `false` instead of throwing

That last one guards the ordering of `expected.length === actual.length && timingSafeEqual(...)`. `timingSafeEqual` throws on a length mismatch rather than returning `false`, so swapping those two operands turns a denied request into a 500. Both new tests were mutation-checked: reordering the length guard, and removing the expiry guard, each fail the suite.

## Verification

- `runLint` on the two sources, `0.1.56` and `0.1.57`: 10 errors before, 0 after
- `bun test ./storage/framework/core/audio/tests ./storage/framework/core/video/tests`: 14 pass, 0 fail
- No behaviour change: the reformat preserves statement order exactly

## One thing this does not fix

A full local `buddy lint` reports a different set of 20 same-class false positives that CI does not report, on both pickier versions, and those same files are clean when linted on their own. So the rule's results depend on batch composition, not only on file content. That is an upstream pickier bug worth filing separately; it means a future CI run could surface a different set. It does not affect this fix, which removes the construct CI is actually failing on.