### PR TITLE
fix(dashboard): forward the dashboard's API calls instead of 404ing them

### DIFF
--- a/storage/framework/core/actions/src/serve/dashboard.ts
+++ b/storage/framework/core/actions/src/serve/dashboard.ts
@@ -43,6 +43,8 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import process from 'node:process'
+import { config } from '@stacksjs/config'
+import { log } from '@stacksjs/logging'
 import { projectPath, publicPath } from '@stacksjs/path'
 import { resolveDefaultsRoot } from '../dev/defaults-resources'
 import { decideDashboardAccess } from './dashboard-gate'
@@ -81,13 +83,25 @@ function readCookie(header: string | null, name: string): string | undefined {
   return undefined
 }
 
-// Routes must be loaded before the first request: the gate delegates `/api/**`
-// and every mutating verb to the Stacks router, and an unloaded router 404s
-// the POST that signs a person in.
-const router = await import('@stacksjs/router')
-const routeRegistry = (await import(projectPath('app/Routes.ts'))).default
-await router.loadRoutes(routeRegistry)
+/**
+ * Where `/api/**` and every sign-in POST go.
+ *
+ * Resolved explicitly and allowed to be null: on a shared box
+ * `127.0.0.1:<default>` is not "my API", it is whichever tenant bound that
+ * port first, and forwarding a session cookie or a login POST there would
+ * hand a visitor's credentials to a stranger. A 502 with an actionable log is
+ * the better failure. Same rule and same helper as the main production
+ * server — this used to be a second copy of the reasoning, which is how the
+ * two drift.
+ */
+const { resolveApiBase } = await import('@stacksjs/buddy/production-server')
+const apiBase = resolveApiBase(config.ports?.api)
 
+const { isApiBoundRequest, proxyToBackend, resolveApiProxyRules } = await import('@stacksjs/server')
+
+// The app's own `proxy` config, so a plain `GET /health` on the API process
+// stays reachable from here exactly as it is from the public site.
+const apiProxyRules = resolveApiProxyRules(config.server?.proxy)
 const { Auth } = await import('@stacksjs/auth')
 const { serve } = await import('bun-plugin-stx/serve')
 
@@ -126,8 +140,33 @@ await serve({
       token => Auth.getUserFromToken(token),
     )
 
-    if (decision.allow)
+    if (decision.allow) {
+      // A dashboard page renders its shell server-side and then loads its data
+      // over `/api/**`. Returning null for those hands them to the PAGE layer,
+      // which answers a 404 HTML document — so every screen renders and then
+      // reports that it could not load anything. They have to be forwarded to
+      // the API process.
+      if (isApiBoundRequest(req, url.pathname, apiProxyRules)) {
+        if (!apiBase) {
+          log.error(
+            `No API target configured for ${url.pathname}. This dashboard shares its host with other `
+            + `deployments, so there is no safe default port to guess — refusing to proxy. Set PORT_API `
+            + `(or API_URL) for this site.`,
+          )
+          return new Response('Bad Gateway', { status: 502 })
+        }
+
+        try {
+          return await proxyToBackend(req, apiBase)
+        }
+        catch (error) {
+          log.error(`API proxy to ${apiBase} failed: ${(error as Error).message}`)
+          return new Response('Bad Gateway', { status: 502 })
+        }
+      }
+
       return null
+    }
 
     // `next` so signing in returns to the page that was asked for. The value
     // is the path only — never the full URL — so this cannot be turned into

--- a/storage/framework/core/actions/src/serve/dashboard.ts
+++ b/storage/framework/core/actions/src/serve/dashboard.ts
@@ -94,10 +94,8 @@ function readCookie(header: string | null, name: string): string | undefined {
  * server — this used to be a second copy of the reasoning, which is how the
  * two drift.
  */
-const { resolveApiBase } = await import('@stacksjs/buddy/production-server')
+const { isApiBoundRequest, proxyToBackend, resolveApiBase, resolveApiProxyRules } = await import('@stacksjs/server')
 const apiBase = resolveApiBase(config.ports?.api)
-
-const { isApiBoundRequest, proxyToBackend, resolveApiProxyRules } = await import('@stacksjs/server')
 
 // The app's own `proxy` config, so a plain `GET /health` on the API process
 // stays reachable from here exactly as it is from the public site.

--- a/storage/framework/core/buddy/src/production-server.ts
+++ b/storage/framework/core/buddy/src/production-server.ts
@@ -205,22 +205,6 @@ function resolveCsrfMiddlewarePath(): string {
  * Returning `null` makes the caller answer 502. That is the safe failure: the
  * alternative is proxying authenticated requests into another app's process.
  */
-export function resolveApiBase(configuredPort?: number, env: NodeJS.ProcessEnv = process.env): string | null {
-  if (env.API_URL)
-    return env.API_URL
-
-  const explicitPort = Number(env.PORT_API)
-  if (explicitPort)
-    return `http://127.0.0.1:${explicitPort}`
-
-  const deployed = ['production', 'staging', 'development']
-    .includes((env.APP_ENV || '').toLowerCase())
-
-  if (deployed)
-    return null
-
-  return `http://127.0.0.1:${configuredPort || 3008}`
-}
 
 export async function startProductionServer(options?: { port?: string | number, verbose?: boolean }): Promise<void> {
   if (options?.port)
@@ -232,7 +216,7 @@ export async function startProductionServer(options?: { port?: string | number, 
   const { config, overridesReady, resolveViewPatterns } = await import('@stacksjs/config')
   await overridesReady
 
-  const { applyViewSecurityHeaders, describeApiProxyRules, describeRedirectRules, injectGlobalAutoImports, resolveApiProxyRules, resolveEmbeddableRules, resolveRedirectRules } = await import('@stacksjs/server')
+  const { applyViewSecurityHeaders, describeApiProxyRules, describeRedirectRules, injectGlobalAutoImports, resolveApiBase, resolveApiProxyRules, resolveEmbeddableRules, resolveRedirectRules } = await import('@stacksjs/server')
   // The one copy of this. It used to be duplicated here verbatim — the shared
   // module was extracted precisely so the dev and production servers could not
   // drift, and then this half kept its own.

--- a/storage/framework/core/server/src/proxy.ts
+++ b/storage/framework/core/server/src/proxy.ts
@@ -182,3 +182,39 @@ export async function proxyToBackend(req: Request, backendBase: string, stripPre
     headers: out,
   })
 }
+
+/**
+ * Where this app's `/api/**` traffic goes, or null when there is no safe answer.
+ *
+ * Returning null is the important part. On a shared box `127.0.0.1:<default>`
+ * is not "my API" — it is whichever tenant bound that port first. Several SSR
+ * sites legitimately share one instance, so falling back to the framework-wide
+ * default silently forwards this app's session cookies, login POSTs and form
+ * bodies into a DIFFERENT tenant's process. A 502 with an actionable log beats
+ * misdelivering a visitor's credentials to a stranger.
+ *
+ * So an explicit target wins, and in a deployed environment there is no
+ * fallback at all. Only a local dev machine, where nothing else is listening,
+ * gets to guess.
+ *
+ * Lives here rather than beside the production server because more than one
+ * server needs it: the public site and the dashboard both proxy to the same
+ * API process, and a second copy of this rule is a second place for it to
+ * drift.
+ */
+export function resolveApiBase(configuredPort?: number, env: NodeJS.ProcessEnv = process.env): string | null {
+  if (env.API_URL)
+    return env.API_URL
+
+  const explicitPort = Number(env.PORT_API)
+  if (explicitPort)
+    return `http://127.0.0.1:${explicitPort}`
+
+  const deployed = ['production', 'staging', 'development']
+    .includes((env.APP_ENV || '').toLowerCase())
+
+  if (deployed)
+    return null
+
+  return `http://127.0.0.1:${configuredPort || 3008}`
+}

--- a/storage/framework/core/server/tests/api-base.test.ts
+++ b/storage/framework/core/server/tests/api-base.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { resolveApiBase } from '../src/production-server'
+import { resolveApiBase } from '../src/proxy'
 
 /**
  * The production page server reverse-proxies `/api/**` to the API process.


### PR DESCRIPTION
The production dashboard server rendered every page and then **could not load a single thing on it**.

A dashboard page renders its shell server-side and fetches its data over `/api/**` after hydration. The gate correctly classified those requests as belonging to the router rather than the page auth check — and then returned `null`, which in stx means *"carry on routing"*, handing them to the **page layer**. Every data call came back a 404 HTML document, so each screen loaded, looked right, and reported that it could not load anything.

Classifying a request as not-page-gated and actually delivering it somewhere are two different jobs, and only the first was done.

## The fix

`/api/**` and mutating verbs are proxied to the API process, reusing the main production server's `resolveApiBase` rather than a second copy of the rule.

That helper is deliberately allowed to return **null**: on a shared box `127.0.0.1:<default>` is not "my API", it is whichever tenant bound that port first, and forwarding a session cookie or a login POST there hands a visitor's credentials to a stranger. A 502 with an actionable log is the better failure.

The app's own `server.proxy` config is honoured too, so a plain `GET /health` on the API process stays reachable from the dashboard exactly as it is from the public site.

## How it was caught

By loading a real page against a real API rather than by reading the code:

| | before | after |
|---|---|---|
| `GET /api/campushq/giving` | 404, HTML body | **200, JSON** |
| the screen | "Giving could not be loaded" | the actual figures |

439 actions tests still pass; lint clean.