### PR TITLE
fix(deploy): say why SSH never came up, instead of guessing

### DIFF
--- a/storage/framework/core/buddy/src/commands/deploy.ts
+++ b/storage/framework/core/buddy/src/commands/deploy.ts
@@ -613,31 +613,95 @@ function fmtDuration(secs: number): string {
 }
 
 /**
+ * Why the last attempt failed, as one line fit for an error message.
+ *
+ * `sshExecOrThrow` already puts the remote stderr in its message
+ * (``ssh `true` on 1.2.3.4 failed (255): Permission denied (publickey).``), so
+ * the diagnosis exists on every attempt and only needs carrying out of the loop.
+ * Newlines are collapsed because ssh spreads one refusal over several lines, and
+ * the result is capped so a chatty banner cannot bury the summary above it.
+ */
+export function pollFailureDetail(error: unknown): string | undefined {
+  const raw = error instanceof Error ? error.message : typeof error === 'string' ? error : ''
+  const collapsed = raw.replace(/\s+/g, ' ').trim()
+  if (!collapsed)
+    return undefined
+  return collapsed.length > 300 ? `${collapsed.slice(0, 297)}...` : collapsed
+}
+
+/**
+ * What to print when SSH never came up.
+ *
+ * The old text named one cause for a condition with several: "The box may still
+ * be booting - raise TS_CLOUD_SSH_WAIT_SECS and retry." A rejected key and a
+ * fail2ban ban produce exactly that line, and waiting longer fixes neither, which
+ * is how a one-line answer turns into a multi-hour misdiagnosis
+ * (stacksjs/stacks#2342).
+ *
+ * So it leads with what the last attempt actually said and then maps the three
+ * causes that look identical from here onto their different fixes, instead of
+ * asserting the one that happens to be most common.
+ */
+export function sshUnreachableMessage(opts: {
+  ip: string
+  waitSecs: number
+  elapsedSecs: number
+  lastError?: unknown
+}): string {
+  const detail = pollFailureDetail(opts.lastError)
+  return `SSH did not become reachable on ${opts.ip} within ${fmtDuration(opts.waitSecs)} (waited ${opts.elapsedSecs}s).`
+    + (detail ? `\nLast attempt: ${detail}` : '')
+    + `\nA connection timeout means the box is probably still booting, so raise TS_CLOUD_SSH_WAIT_SECS and retry. `
+    + `"Permission denied" means the key is not authorized, and a refused or reset connection (especially after earlier attempts got further) `
+    + `usually means fail2ban banned this IP. Waiting longer fixes neither.`
+}
+
+/** What to print when cloud-init never put bun on the box. */
+export function bunRuntimeMissingMessage(opts: {
+  waitSecs: number
+  elapsedSecs: number
+  lastError?: unknown
+}): string {
+  const detail = pollFailureDetail(opts.lastError)
+  return `bun runtime did not appear at /usr/local/bin/bun within ${fmtDuration(opts.waitSecs)} (waited ${opts.elapsedSecs}s).`
+    + (detail ? `\nLast attempt: ${detail}` : '')
+    + `\ncloud-init may have failed: SSH in and check /var/log/cloud-init-output.log. `
+    + `Raise TS_CLOUD_BOOT_WAIT_SECS for slow regions.`
+}
+
+/**
  * Poll `check()` (awaited each attempt, so it may be sync or async) until it
  * stops throwing or the timeout elapses, emitting a heartbeat every ~30s so a
  * multi-minute wait never looks frozen (and, when backgrounded, so the caller
  * can see it is still alive).
+ *
+ * The last error is kept and handed to `timeoutMessage`. Discarding it is what
+ * made every reachability failure read as the same "the box may still be booting"
+ * guess: a rejected key and a fail2ban ban produced that identical line, and the
+ * advice it gave (wait longer) is useless for both.
  */
-async function pollUntil(opts: {
+export async function pollUntil(opts: {
   label: string
   timeoutSecs: number
   intervalMs?: number
   check: () => unknown | Promise<unknown>
-  timeoutMessage: (elapsedSecs: number) => string
+  timeoutMessage: (elapsedSecs: number, lastError: unknown) => string
 }): Promise<void> {
   log.info(`${opts.label} (up to ${fmtDuration(opts.timeoutSecs)})...`)
   const started = Date.now()
   const deadline = started + opts.timeoutSecs * 1000
   let lastHeartbeat = 0
+  let lastError: unknown
   for (;;) {
     try {
       await opts.check()
       return
     }
-    catch {
+    catch (err) {
+      lastError = err
       const elapsedSecs = Math.floor((Date.now() - started) / 1000)
       if (Date.now() > deadline)
-        throw new Error(opts.timeoutMessage(elapsedSecs))
+        throw new Error(opts.timeoutMessage(elapsedSecs, lastError))
       if (elapsedSecs - lastHeartbeat >= 30) {
         log.info(`  … still waiting (${elapsedSecs}s elapsed)`)
         lastHeartbeat = elapsedSecs
@@ -676,9 +740,8 @@ async function waitForRemoteReady(ip: string): Promise<void> {
     label: 'Waiting for SSH to come up',
     timeoutSecs: sshWaitSecs,
     check: () => run('true'),
-    timeoutMessage: elapsed =>
-      `SSH did not become reachable on ${ip} within ${fmtDuration(sshWaitSecs)} (waited ${elapsed}s). `
-      + `The box may still be booting — raise TS_CLOUD_SSH_WAIT_SECS and retry.`,
+    timeoutMessage: (elapsed, lastError) =>
+      sshUnreachableMessage({ ip, waitSecs: sshWaitSecs, elapsedSecs: elapsed, lastError }),
   })
   log.success('SSH is up')
 
@@ -696,10 +759,8 @@ async function waitForRemoteReady(ip: string): Promise<void> {
     label: 'Waiting for the bun runtime',
     timeoutSecs: bootWaitSecs,
     check: () => run('test -x /usr/local/bin/bun'),
-    timeoutMessage: elapsed =>
-      `bun runtime did not appear at /usr/local/bin/bun within ${fmtDuration(bootWaitSecs)} (waited ${elapsed}s). `
-      + `cloud-init may have failed — SSH in and check /var/log/cloud-init-output.log; `
-      + `raise TS_CLOUD_BOOT_WAIT_SECS for slow regions.`,
+    timeoutMessage: (elapsed, lastError) =>
+      bunRuntimeMissingMessage({ waitSecs: bootWaitSecs, elapsedSecs: elapsed, lastError }),
   })
   log.success('Server is ready (bun installed)')
 }

--- a/storage/framework/core/buddy/tests/deploy-ssh-wait-diagnosis.test.ts
+++ b/storage/framework/core/buddy/tests/deploy-ssh-wait-diagnosis.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  bunRuntimeMissingMessage,
+  pollFailureDetail,
+  pollUntil,
+  sshUnreachableMessage,
+} from '../src/commands/deploy'
+
+describe('pollFailureDetail', () => {
+  it("carries the remote stderr out of sshExecOrThrow's message", () => {
+    const err = new Error('ssh `true` on 203.0.113.51 failed (255): Permission denied (publickey).')
+
+    expect(pollFailureDetail(err)).toContain('Permission denied (publickey)')
+  })
+
+  it('collapses the several lines ssh spreads one refusal over', () => {
+    const err = new Error('ssh failed (255):\nkex_exchange_identification: read: Connection reset by peer\n\nConnection reset')
+
+    const detail = pollFailureDetail(err)!
+
+    expect(detail).not.toContain('\n')
+    expect(detail).toContain('Connection reset by peer')
+  })
+
+  it('caps a chatty banner so it cannot bury the summary', () => {
+    const detail = pollFailureDetail(new Error('x'.repeat(900)))!
+
+    expect(detail).toHaveLength(300)
+    expect(detail.endsWith('...')).toBe(true)
+  })
+
+  it('accepts a thrown string as well as an Error', () => {
+    expect(pollFailureDetail('Connection timed out')).toBe('Connection timed out')
+  })
+
+  it('reports nothing rather than an empty line when there is nothing to say', () => {
+    expect(pollFailureDetail(undefined)).toBeUndefined()
+    expect(pollFailureDetail(new Error(''))).toBeUndefined()
+    expect(pollFailureDetail(new Error('   \n  '))).toBeUndefined()
+    expect(pollFailureDetail({ nope: true })).toBeUndefined()
+  })
+})
+
+describe('sshUnreachableMessage', () => {
+  const base = { ip: '203.0.113.51', waitSecs: 480, elapsedSecs: 485 }
+
+  it('still states the host and how long it waited', () => {
+    const message = sshUnreachableMessage(base)
+
+    expect(message).toContain('203.0.113.51')
+    expect(message).toContain('within 8m')
+    expect(message).toContain('waited 485s')
+  })
+
+  it('leads with what the last attempt actually said', () => {
+    const message = sshUnreachableMessage({
+      ...base,
+      lastError: new Error('ssh `true` on 203.0.113.51 failed (255): Permission denied (publickey).'),
+    })
+
+    expect(message).toContain('Last attempt: ')
+    expect(message).toContain('Permission denied (publickey)')
+  })
+
+  it('distinguishes the three causes that look identical from here', () => {
+    // The whole point of #2342: a rejected key and a fail2ban ban used to
+    // produce the same "the box may still be booting" line.
+    const message = sshUnreachableMessage(base)
+
+    expect(message).toContain('TS_CLOUD_SSH_WAIT_SECS')
+    expect(message).toContain('Permission denied')
+    expect(message).toContain('fail2ban')
+    expect(message).toContain('Waiting longer fixes neither')
+  })
+
+  it('no longer asserts booting as the cause', () => {
+    expect(sshUnreachableMessage(base)).not.toContain('The box may still be booting')
+  })
+
+  it('omits the detail line entirely when there is no error to show', () => {
+    expect(sshUnreachableMessage(base)).not.toContain('Last attempt:')
+  })
+
+  it('keeps the fail2ban hint reachable when a ban is what happened', () => {
+    const message = sshUnreachableMessage({
+      ...base,
+      lastError: new Error('ssh failed (255): kex_exchange_identification: read: Connection reset by peer'),
+    })
+
+    expect(message).toContain('Connection reset by peer')
+    expect(message).toContain('fail2ban')
+  })
+})
+
+describe('bunRuntimeMissingMessage', () => {
+  it('points at the cloud-init log and includes the last failure', () => {
+    const message = bunRuntimeMissingMessage({
+      waitSecs: 720,
+      elapsedSecs: 725,
+      lastError: new Error('ssh `test -x /usr/local/bin/bun` on 203.0.113.51 failed (1): '),
+    })
+
+    expect(message).toContain('within 12m')
+    expect(message).toContain('/var/log/cloud-init-output.log')
+    expect(message).toContain('TS_CLOUD_BOOT_WAIT_SECS')
+    expect(message).toContain('Last attempt: ')
+  })
+})
+
+describe('pollUntil', () => {
+  it('hands the last failure to timeoutMessage, which is the whole fix', async () => {
+    // Without `lastError = err` in the loop, timeoutMessage can only ever see
+    // elapsed time, and every cause reads the same. This is what pins it.
+    let seen: unknown
+    const attempt = new Error('ssh `true` on 203.0.113.51 failed (255): Permission denied (publickey).')
+
+    await expect(pollUntil({
+      label: 'Waiting for SSH to come up',
+      timeoutSecs: 0,
+      intervalMs: 1,
+      check: () => {
+        throw attempt
+      },
+      timeoutMessage: (elapsed, lastError) => {
+        seen = lastError
+        return `gave up after ${elapsed}s: ${pollFailureDetail(lastError) ?? 'no detail'}`
+      },
+    })).rejects.toThrow('Permission denied (publickey)')
+
+    expect(seen).toBe(attempt)
+  })
+
+  it('returns as soon as the check stops throwing', async () => {
+    let calls = 0
+
+    await pollUntil({
+      label: 'Waiting',
+      timeoutSecs: 30,
+      intervalMs: 1,
+      check: () => {
+        calls++
+        if (calls < 3)
+          throw new Error('not yet')
+      },
+      timeoutMessage: () => 'should not be reached',
+    })
+
+    expect(calls).toBe(3)
+  })
+})


### PR DESCRIPTION
Fixes the item raised under "Separately worth fixing" in #2342.

## The problem

`pollUntil` caught every failed attempt with a bare `catch {}` and handed `timeoutMessage` nothing but an elapsed count. So the message could only ever name **one** cause for a condition with several:

```
SSH did not become reachable on <ip> within 8m (waited 485s).
The box may still be booting - raise TS_CLOUD_SSH_WAIT_SECS and retry.
```

A rejected key prints that. A fail2ban ban prints that. A genuinely slow boot prints that. Waiting longer fixes only the third, so the single piece of advice offered is useless two thirds of the time and sends the operator off to raise a timeout that was never the problem.

## Nothing had to be gathered

`sshExecOrThrow` already builds its error as:

```
ssh `true` on 203.0.113.51 failed (255): Permission denied (publickey).
```

The diagnosis was present on **every attempt** and then thrown away by the empty catch. The loop now keeps the last error and passes it to `timeoutMessage`.

## After

```
SSH did not become reachable on 203.0.113.51 within 8m (waited 485s).
Last attempt: ssh `true` on 203.0.113.51 failed (255): Permission denied (publickey).
A connection timeout means the box is probably still booting, so raise TS_CLOUD_SSH_WAIT_SECS and retry. "Permission denied" means the key is not authorized, and a refused or reset connection (especially after earlier attempts got further) usually means fail2ban banned this IP. Waiting longer fixes neither.
```

It leads with what actually happened, then maps the three causes that look identical from the client onto their different fixes instead of asserting the most common one. Newlines are collapsed, because ssh spreads one refusal over several lines, and the detail is capped at 300 characters so a chatty SSH banner cannot bury the summary above it. The same treatment is applied to the `bun` runtime wait.

## On the shape of it

The two messages are extracted as pure exported functions so the **user-visible text** is what gets tested, not merely the string helper feeding it.

`pollUntil` is exported for a related reason: with tests only on the message builders, deleting `lastError = err` from the loop would leave every assertion green while the fix was gone. There is now a test that drives the loop to its deadline and asserts the thrown message carries the attempt's own error.

Confirmed by mutation. Removing the error capture, the fail2ban guidance, or the length cap each fail the suite.

## Verification

- 14 new tests in `storage/framework/core/buddy/tests/deploy-ssh-wait-diagnosis.test.ts`
- `bun test ./storage/framework/core/buddy/tests`: 459 pass, 0 fail
- Root suite: 330 pass, 0 fail
- Typecheck clean for both changed files
- Incidentally removes two em-dashes from operator-facing strings

This does not touch the five commands #2342 actually asks for, which stay open.