### PR TITLE
fix(deploy): say why an attach target resolved to nothing

### DIFF
--- a/storage/framework/core/buddy/src/commands/deploy.ts
+++ b/storage/framework/core/buddy/src/commands/deploy.ts
@@ -1553,7 +1553,7 @@ async function deployToHetzner(tsCloudConfig: any, deployEnv: string, options: D
   const verbose = options.verbose === true
   const environment = (deployEnv === 'prod' ? 'production' : deployEnv) as 'production' | 'staging' | 'development'
 
-  const apiToken = tsCloudConfig.hetzner?.apiToken || process.env.HCLOUD_TOKEN || process.env.HETZNER_API_TOKEN
+  const apiToken = resolveHetznerApiToken(tsCloudConfig)
   const persistedAttachBox = resolvePersistedAttachTargetBox(tsCloudConfig, environment)
   if (!apiToken && !persistedAttachBox) {
     log.error('No Hetzner API token found. Set HCLOUD_TOKEN in your .env (or hetzner.apiToken in config/cloud.ts).')
@@ -2024,7 +2024,14 @@ async function runHetznerDeploy(args: {
   // left undefined, it simply skips them.
   let ipv6: string | undefined
   if (attachTo) {
-    let box = persistedAttachBox ?? await resolveAttachTargetBox(attachTo, environment)
+    // Kept so the error below can name what actually went wrong. A persisted box
+    // means no lookup ran at all, which is itself worth not misreporting.
+    let lookup: AttachLookupResult | undefined
+    let box: AttachTargetBox | null | undefined = persistedAttachBox
+    if (!box) {
+      lookup = await resolveAttachTargetBox(attachTo, environment, tsCloudConfig)
+      box = lookup.box
+    }
     // A state file written before publicIpv6 was persisted pins the tenant to
     // IPv4 forever: the cached box short-circuits the Hetzner lookup, the AAAA
     // pass is skipped for want of an address, and the deploy then rewrites the
@@ -2032,12 +2039,12 @@ async function runHetznerDeploy(args: {
     // tenant heals itself on its next deploy instead of needing the file
     // deleted by hand.
     if (box && !box.publicIpv6) {
-      const resolved = await resolveAttachTargetBox(attachTo, environment)
-      if (resolved?.publicIpv6)
-        box = { ...box, publicIpv6: resolved.publicIpv6 }
+      const resolved = await resolveAttachTargetBox(attachTo, environment, tsCloudConfig)
+      if (resolved.box?.publicIpv6)
+        box = { ...box, publicIpv6: resolved.box.publicIpv6 }
     }
     if (!box?.publicIp) {
-      log.error(`Attach target '${attachTo}' has no reachable box for '${environment}'. Is '${attachTo}-${environment}-app' provisioned (by its owner)?`)
+      log.error(describeAttachLookupFailure(attachTo, environment, lookup?.failure))
       process.exit(ExitCode.FatalError)
     }
     ip = box.publicIp
@@ -2478,14 +2485,15 @@ async function runHetznerDeploy(args: {
     const mailOwner = mailServerOwnerFromConfig(emailConfig)
     let mailIp: string | undefined = ip
     if (mailOwner) {
-      const mailBox = await resolveAttachTargetBox(mailOwner, environment)
-      if (mailBox?.publicIp) {
-        mailIp = mailBox.publicIp
-        log.info(`Mail: reconciling on '${mailOwner}' box '${mailBox.serverName}' (${mailIp})`)
+      const mailLookup = await resolveAttachTargetBox(mailOwner, environment, tsCloudConfig)
+      if (mailLookup.box?.publicIp) {
+        mailIp = mailLookup.box.publicIp
+        log.info(`Mail: reconciling on '${mailOwner}' box '${mailLookup.box.serverName}' (${mailIp})`)
       }
       else {
         mailIp = undefined
-        log.warn(`Mail: attach target '${mailOwner}' has no reachable '${environment}' box; application deploy remains live`)
+        log.warn(`Mail: ${describeAttachLookupFailure(mailOwner, environment, mailLookup.failure)}`)
+        log.warn('Mail: skipping mail reconciliation; the application deploy remains live.')
       }
     }
 
@@ -2663,58 +2671,158 @@ systemctl reset-failed`
  *      RFC 5228 `forwards.sieve` (live-reloaded).
  *
 /**
+ * The Hetzner token, resolved the same way everywhere.
+ *
+ * `deployToHetzner` accepted `hetzner.apiToken` from the config or either env
+ * var, while `resolveAttachTargetBox` read only `process.env.HCLOUD_TOKEN`. A
+ * project that configured the token in `config/cloud.ts`, or set only
+ * `HETZNER_API_TOKEN`, therefore passed the token check at the top of the deploy
+ * and then failed attach resolution with no request made and no reason given
+ * (stacksjs/stacks#2344). One resolver, so the two cannot drift again.
+ */
+export function resolveHetznerApiToken(tsCloudConfig?: any): string | undefined {
+  return tsCloudConfig?.hetzner?.apiToken || process.env.HCLOUD_TOKEN || process.env.HETZNER_API_TOKEN
+}
+
+/**
+ * A shared box as the Hetzner API just described it.
+ *
+ * Distinct from {@link AttachedComputeBox}, which is the persisted pin: that one
+ * is validated on read and so guarantees a `publicIp`, whereas a live lookup can
+ * legitimately turn up a server that has no IPv4 yet. Collapsing the two would
+ * mean either lying about the pin or re-checking it at every use.
+ */
+export interface AttachTargetBox {
+  serverId: number
+  serverName: string
+  publicIp?: string
+  publicIpv6?: string
+}
+
+/**
+ * Why an attach lookup produced no box.
+ *
+ * These three were previously indistinguishable: every one of them ended as an
+ * empty array, and the caller reported the same "is it provisioned?" for all of
+ * them. Only `no-match` actually justifies that question.
+ */
+export type AttachLookupFailure =
+  | { kind: 'no-token' }
+  | { kind: 'request-failed', status: number, detail?: string }
+  | { kind: 'no-match' }
+
+export interface AttachLookupResult {
+  box: AttachTargetBox | null
+  failure?: AttachLookupFailure
+}
+
+/**
+ * What to tell the operator when no box came back.
+ *
+ * The old message named one cause for four conditions: "Is
+ * '<owner>-<env>-app' provisioned (by its owner)?" A missing token, a 401, and a
+ * network error all printed that, while the box sat there running, which is how
+ * this became a multi-hour diagnosis rather than a one-line one. Each cause now
+ * gets its own answer, and the provisioning question is only asked when nothing
+ * matched.
+ */
+export function describeAttachLookupFailure(
+  owner: string,
+  environment: string,
+  failure: AttachLookupFailure | undefined,
+): string {
+  if (failure?.kind === 'no-token') {
+    return `Attach target '${owner}': no Hetzner API token to look it up with, so no lookup was attempted. `
+      + `Set HCLOUD_TOKEN (or HETZNER_API_TOKEN, or hetzner.apiToken in config/cloud.ts).`
+  }
+
+  if (failure?.kind === 'request-failed') {
+    const where = failure.status > 0 ? `returned HTTP ${failure.status}` : 'could not be reached'
+    return `Attach target '${owner}': the Hetzner API ${where}, so whether the box exists is unknown.`
+      + (failure.detail ? ` ${failure.detail}` : '')
+      + (failure.status === 401 || failure.status === 403
+        ? ' That is an auth failure, not a missing server: check the token is valid for this Hetzner project.'
+        : '')
+  }
+
+  return `Attach target '${owner}' has no reachable box for '${environment}'. `
+    + `Nothing matched ts-cloud/project=${owner},ts-cloud/environment=${environment},ts-cloud/role=app, `
+    + `and no server is named '${owner}-${environment}-app'. Is it provisioned (by its owner)?`
+}
+
+/**
  * Resolve the shared box owned by another project (`cloud.attachTo`) so this
  * project can deploy its sites onto it without provisioning. Looks the box up
  * by the owner's ts-cloud labels (`ts-cloud/project=<owner>`,
- * `environment=<env>`, `role=app`) — the same labels ts-cloud stamps on every
- * app server — falling back to the conventional `<owner>-<env>-app` name. Needs
- * only read access via HCLOUD_TOKEN (the same token the owner provisions with).
+ * `environment=<env>`, `role=app`) - the same labels ts-cloud stamps on every
+ * app server - falling back to the conventional `<owner>-<env>-app` name. Needs
+ * only read access via the Hetzner token.
+ *
+ * Returns why it found nothing, rather than just nothing. Every failure used to
+ * collapse into an empty array inside `req()`: a 401, a network error and a
+ * genuinely empty result were indistinguishable, and none were logged.
  */
-async function resolveAttachTargetBox(
+export async function resolveAttachTargetBox(
   owner: string,
   environment: string,
-): Promise<{ serverId: number, serverName: string, publicIp?: string, publicIpv6?: string } | null> {
-  const token = process.env.HCLOUD_TOKEN
+  tsCloudConfig?: any,
+): Promise<AttachLookupResult> {
+  const token = resolveHetznerApiToken(tsCloudConfig)
   if (!token)
-    return null
+    return { box: null, failure: { kind: 'no-token' } }
+
   const pick = (servers: any[]): any | undefined =>
     servers.find(s => s?.status !== 'off' && s?.public_net?.ipv4?.ip) || servers[0]
+
+  // Kept from the FIRST failing request: by the time the name fallback also
+  // comes back empty, the label query's 401 is the more useful thing to report.
+  let requestFailure: AttachLookupFailure | undefined
+
   const req = async (qs: string): Promise<any[]> => {
     try {
       const res = await fetch(`https://api.hetzner.cloud/v1/servers?${qs}`, {
         headers: { Authorization: `Bearer ${token}` },
       })
-      if (!res.ok)
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        requestFailure ??= { kind: 'request-failed', status: res.status, detail: pollFailureDetail(body) }
         return []
+      }
       return ((await res.json()) as any).servers || []
     }
-    catch {
+    catch (err) {
+      // status 0: the request never got an answer at all.
+      requestFailure ??= { kind: 'request-failed', status: 0, detail: pollFailureDetail(getErrorMessage(err)) }
       return []
     }
   }
+
   // Label match first (robust to renames), then the conventional name.
   const byLabel = await req(`label_selector=${encodeURIComponent(`ts-cloud/project=${owner},ts-cloud/environment=${environment},ts-cloud/role=app`)}`)
   const chosen = pick(byLabel) || pick(await req(`name=${encodeURIComponent(`${owner}-${environment}-app`)}`))
   if (!chosen)
-    return null
+    return { box: null, failure: requestFailure ?? { kind: 'no-match' } }
+
   // Hetzner reports the routed block (`2a01:4f8:c014:6186::/64`), not the
-  // address the interface holds — normalizePublicIpv6 narrows it to something
+  // address the interface holds - normalizePublicIpv6 narrows it to something
   // an AAAA record can actually point at.
   //
   // This used to call `hetznerBoxIpv6?.(…)`, a name ts-cloud no longer exports.
   // The optional call turned that into `undefined` silently, so every attached
   // tenant resolved no IPv6, the AAAA pass was skipped, and the whole shared box
-  // quietly served IPv4 only — with nothing in the deploy log to say so. The
+  // quietly served IPv4 only - with nothing in the deploy log to say so. The
   // call is unconditional now, and a missing export warns instead of vanishing.
   const { normalizePublicIpv6 } = await import('@stacksjs/ts-cloud') as any
   if (typeof normalizePublicIpv6 !== 'function')
     log.warn('DNS: @stacksjs/ts-cloud does not export normalizePublicIpv6 — AAAA records will be skipped. Upgrade ts-cloud.')
   const reportedIpv6 = chosen.public_net?.ipv6?.ip
   return {
-    serverId: chosen.id,
-    serverName: chosen.name,
-    publicIp: chosen.public_net?.ipv4?.ip,
-    publicIpv6: typeof normalizePublicIpv6 === 'function' ? normalizePublicIpv6(reportedIpv6) : undefined,
+    box: {
+      serverId: chosen.id,
+      serverName: chosen.name,
+      publicIp: chosen.public_net?.ipv4?.ip,
+      publicIpv6: typeof normalizePublicIpv6 === 'function' ? normalizePublicIpv6(reportedIpv6) : undefined,
+    },
   }
 }
 

--- a/storage/framework/core/buddy/tests/deploy-attach-lookup.test.ts
+++ b/storage/framework/core/buddy/tests/deploy-attach-lookup.test.ts
@@ -1,0 +1,213 @@
+import type { AttachLookupFailure } from '../src/commands/deploy'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  describeAttachLookupFailure,
+  resolveAttachTargetBox,
+  resolveHetznerApiToken,
+} from '../src/commands/deploy'
+
+const TOKEN_VARS = ['HCLOUD_TOKEN', 'HETZNER_API_TOKEN'] as const
+
+let saved: Record<string, string | undefined>
+let realFetch: typeof globalThis.fetch
+
+beforeEach(() => {
+  saved = Object.fromEntries(TOKEN_VARS.map(k => [k, process.env[k]]))
+  for (const k of TOKEN_VARS) delete process.env[k]
+  realFetch = globalThis.fetch
+})
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+  globalThis.fetch = realFetch
+})
+
+/** Record every URL requested, answering each call from a queue. */
+function stubFetch(responses: Array<Response | Error>): { urls: string[] } {
+  const urls: string[] = []
+  let i = 0
+  globalThis.fetch = (async (input: any) => {
+    urls.push(String(input))
+    const next = responses[Math.min(i, responses.length - 1)]
+    i++
+    if (next instanceof Error) throw next
+    return next
+  }) as any
+  return { urls }
+}
+
+function serversResponse(servers: unknown[]): Response {
+  return new Response(JSON.stringify({ servers }), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+
+const runningBox = {
+  id: 501,
+  name: 'statushq-production-app',
+  status: 'running',
+  public_net: { ipv4: { ip: '167.233.116.134' } },
+}
+
+describe('resolveHetznerApiToken', () => {
+  it('prefers the config token, as deployToHetzner already did', () => {
+    process.env.HCLOUD_TOKEN = 'from-env'
+
+    expect(resolveHetznerApiToken({ hetzner: { apiToken: 'from-config' } })).toBe('from-config')
+  })
+
+  it('falls back to HCLOUD_TOKEN and then HETZNER_API_TOKEN', () => {
+    process.env.HETZNER_API_TOKEN = 'legacy'
+    expect(resolveHetznerApiToken({})).toBe('legacy')
+
+    process.env.HCLOUD_TOKEN = 'preferred'
+    expect(resolveHetznerApiToken({})).toBe('preferred')
+  })
+
+  it('is undefined when nothing supplies one', () => {
+    expect(resolveHetznerApiToken({})).toBeUndefined()
+    expect(resolveHetznerApiToken(undefined)).toBeUndefined()
+  })
+})
+
+describe('describeAttachLookupFailure', () => {
+  it('does not blame provisioning when there was no token to look with', () => {
+    const message = describeAttachLookupFailure('uptime-status', 'production', { kind: 'no-token' })
+
+    expect(message).toContain('no Hetzner API token')
+    expect(message).toContain('HCLOUD_TOKEN')
+    expect(message).toContain('hetzner.apiToken')
+    expect(message).not.toContain('provisioned')
+  })
+
+  it('reports an auth failure as an auth failure, not a missing server', () => {
+    const failure: AttachLookupFailure = {
+      kind: 'request-failed',
+      status: 401,
+      detail: '{"error":{"message":"unable to authenticate","code":"unauthorized"}}',
+    }
+
+    const message = describeAttachLookupFailure('uptime-status', 'production', failure)
+
+    expect(message).toContain('HTTP 401')
+    expect(message).toContain('unable to authenticate')
+    expect(message).toContain('auth failure')
+    expect(message).not.toContain('provisioned')
+  })
+
+  it('says the API was unreachable when the request never got an answer', () => {
+    const message = describeAttachLookupFailure('uptime-status', 'production', { kind: 'request-failed', status: 0 })
+
+    expect(message).toContain('could not be reached')
+    expect(message).not.toContain('provisioned')
+  })
+
+  it('asks about provisioning only when nothing actually matched, and shows both queries', () => {
+    const message = describeAttachLookupFailure('uptime-status', 'production', { kind: 'no-match' })
+
+    expect(message).toContain('ts-cloud/project=uptime-status')
+    expect(message).toContain('ts-cloud/environment=production')
+    expect(message).toContain("named 'uptime-status-production-app'")
+    expect(message).toContain('Is it provisioned')
+  })
+
+  it('falls back to the no-match wording when no failure was recorded', () => {
+    expect(describeAttachLookupFailure('uptime-status', 'production', undefined)).toContain('Is it provisioned')
+  })
+})
+
+describe('resolveAttachTargetBox', () => {
+  it('does not even call the API without a token, and says so', async () => {
+    const { urls } = stubFetch([serversResponse([runningBox])])
+
+    const result = await resolveAttachTargetBox('uptime-status', 'production', {})
+
+    expect(result.box).toBeNull()
+    expect(result.failure).toEqual({ kind: 'no-token' })
+    // The bug this replaces: no request was made, yet the operator was told the
+    // box might not be provisioned.
+    expect(urls).toEqual([])
+  })
+
+  it('uses a token from config, which the old lookup ignored entirely', async () => {
+    const { urls } = stubFetch([serversResponse([runningBox])])
+
+    const result = await resolveAttachTargetBox('uptime-status', 'production', {
+      hetzner: { apiToken: 'from-config' },
+    })
+
+    expect(urls).toHaveLength(1)
+    expect(result.box?.serverName).toBe('statushq-production-app')
+    expect(result.box?.publicIp).toBe('167.233.116.134')
+  })
+
+  it('reports the status and body when the API rejects the lookup', async () => {
+    process.env.HCLOUD_TOKEN = 'bad-token'
+    stubFetch([new Response('{"error":{"message":"unable to authenticate"}}', { status: 401 })])
+
+    const result = await resolveAttachTargetBox('uptime-status', 'production', {})
+
+    expect(result.box).toBeNull()
+    expect(result.failure?.kind).toBe('request-failed')
+    expect((result.failure as any).status).toBe(401)
+    expect((result.failure as any).detail).toContain('unable to authenticate')
+  })
+
+  it('reports a thrown request as unreachable rather than as an empty result', async () => {
+    process.env.HCLOUD_TOKEN = 'token'
+    stubFetch([new Error('getaddrinfo ENOTFOUND api.hetzner.cloud')])
+
+    const result = await resolveAttachTargetBox('uptime-status', 'production', {})
+
+    expect(result.failure?.kind).toBe('request-failed')
+    expect((result.failure as any).status).toBe(0)
+    expect((result.failure as any).detail).toContain('ENOTFOUND')
+  })
+
+  it('keeps the FIRST failure, so a 401 is not masked by the name fallback', async () => {
+    process.env.HCLOUD_TOKEN = 'token'
+    stubFetch([
+      new Response('{"error":{"message":"unable to authenticate"}}', { status: 401 }),
+      serversResponse([]),
+    ])
+
+    const result = await resolveAttachTargetBox('uptime-status', 'production', {})
+
+    expect((result.failure as any).status).toBe(401)
+  })
+
+  it('distinguishes a genuinely empty result from a failed call', async () => {
+    process.env.HCLOUD_TOKEN = 'token'
+    const { urls } = stubFetch([serversResponse([]), serversResponse([])])
+
+    const result = await resolveAttachTargetBox('uptime-status', 'production', {})
+
+    expect(result.box).toBeNull()
+    expect(result.failure).toEqual({ kind: 'no-match' })
+    // Both lookup paths were tried: label selector, then conventional name.
+    expect(urls).toHaveLength(2)
+    expect(decodeURIComponent(urls[0]!)).toContain('ts-cloud/project=uptime-status')
+    expect(decodeURIComponent(urls[1]!)).toContain('name=uptime-status-production-app')
+  })
+
+  it('falls back to the conventional name when the label selector matches nothing', async () => {
+    process.env.HCLOUD_TOKEN = 'token'
+    stubFetch([serversResponse([]), serversResponse([runningBox])])
+
+    const result = await resolveAttachTargetBox('statushq', 'production', {})
+
+    expect(result.box?.serverId).toBe(501)
+    expect(result.failure).toBeUndefined()
+  })
+
+  it('skips a powered-off server in favour of a running one', async () => {
+    process.env.HCLOUD_TOKEN = 'token'
+    stubFetch([serversResponse([
+      { id: 1, name: 'old', status: 'off', public_net: { ipv4: { ip: '10.0.0.1' } } },
+      runningBox,
+    ])])
+
+    expect((await resolveAttachTargetBox('uptime-status', 'production', {})).box?.serverId).toBe(501)
+  })
+})


### PR DESCRIPTION
Fixes #2344.

## The reported symptom

`resolveAttachTargetBox` returns nothing for a server that is running, on both lookup paths, including an exact `name=` match, while the identical requests succeed from the same runner with the same token seconds earlier.

## One cause is now proven, not guessed

`deployToHetzner` gates on:

```ts
tsCloudConfig.hetzner?.apiToken || process.env.HCLOUD_TOKEN || process.env.HETZNER_API_TOKEN
```

`resolveAttachTargetBox` read:

```ts
const token = process.env.HCLOUD_TOKEN
if (!token) return null
```

So a project that configures its token in `config/cloud.ts`, or sets only `HETZNER_API_TOKEN`, **passes the deploy's token gate and then fails attach resolution having made no HTTP request at all** - and is told its box might not be provisioned. That is exactly the "Also worth a look" note in the issue, and it is a real bug independent of the reporter's own case.

Both sites now call one `resolveHetznerApiToken`, so they cannot drift apart again.

## The rest is diagnosis

`req()` swallowed everything, with nothing logged:

```ts
if (!res.ok) return []
} catch { return [] }
```

Four outcomes collapsed into one `null`, and the caller asserted the single explanation that cannot be checked from the message and that sends you to inspect the box, which is the one thing that was never wrong.

| outcome | what it now says |
|---|---|
| `no-token` | no lookup was attempted, and where to set a token |
| `request-failed` | the status and response body, plus "that is an auth failure, not a missing server" on 401/403 |
| unreachable | the request never got an answer |
| `no-match` | both queries shown, and **the only case that still asks whether the box is provisioned** |

The **first** failure is kept rather than the last, so a 401 on the label query is not masked by the name fallback returning an honest empty list.

## What this does not do

**It does not explain the reporter's case, and does not claim to.** Their `HCLOUD_TOKEN` was present with a matching fingerprint, and the same requests succeeded from the same runner. Under those conditions a request *was* made and came back unusable, and I cannot reproduce that from here.

What changes is that the next run names which of the four it was, with the status and body attached, instead of the operator reconstructing it by hand with a temporary workflow step. That is what the issue asks for, and it is the difference between a one-minute diagnosis and the multi-hour one described.

## Verification

- 16 new tests in `deploy-attach-lookup.test.ts`, including that **no HTTP request is made** when there is no token, that a config-supplied token is now used, and that a 401 on the label query survives the name fallback
- Mutation-checked: reverting the token resolution fails 3 tests, re-swallowing non-ok responses fails 2, last-failure-wins fails 1, and always emitting the no-match wording fails 1
- `bun test ./storage/framework/core/buddy/tests`: 475 pass, 0 fail
- Root suite: 330 pass, 0 fail
- `lint` (via `runLint`, the path CI uses) and `typecheck` clean on the changed file

`AttachTargetBox` is deliberately separate from `AttachedComputeBox`: the persisted pin is validated on read and guarantees a `publicIp`, whereas a live lookup can turn up a server that has no IPv4 yet.