### PR TITLE
fix: four deploy and migration defects (#2346, #2347, #2348, #2349)

### DIFF
--- a/docs/guide/buddy/commands.md
+++ b/docs/guide/buddy/commands.md
@@ -3284,6 +3284,7 @@ Rebuild database/migrations from your models for a given dialect
 | `--dry-run` | Show what would change without writing anything | boolean, optional | `false` |
 | `-f`, `--force` | Regenerate even though the database already has migrations recorded | boolean, optional | `false` |
 | `--replace-unmarked` | Also delete migrations carrying no @generated marker (pre-marker corpora only) | boolean, optional | `false` |
+| `--only-existing-tables` | Rebuild exactly the tables already in the corpus, for changing dialect without adopting the framework schema | boolean, optional | `false` |
 
 ### `migrate:status`
 

--- a/storage/framework/core/buddy/src/commands/deploy.ts
+++ b/storage/framework/core/buddy/src/commands/deploy.ts
@@ -1359,14 +1359,51 @@ export function applyScheduledWork(sites: Record<string, any>, schedulerFile: st
 }
 
 /**
+ * How a site's `start` says it is the API.
+ *
+ * Two spellings, because both are legitimate and only the first was recognised:
+ *
+ *   `buddy serve:api`                                    the script alias
+ *   `bun node_modules/@stacksjs/actions/dist/serve/api.js`  the entrypoint itself
+ *
+ * The second is what a generated config actually contains once it resolves the
+ * package rather than going through a bin shim, and matching only the
+ * colon-separated alias classified it as a page server (stacksjs/stacks#2349).
+ */
+const apiStartPattern = /\bserve:api\b|(?:^|[\s/])serve\/api\.[cm]?[jt]s\b/
+
+/**
  * Whether a site is the API process the page server proxies `/api/**` to.
  *
  * By name, because that is what the docs and every generated config call it,
- * or by what it actually runs - a site called something else that starts
- * `serve:api` is still the API.
+ * or by what it actually runs - a site called something else that starts the
+ * API is still the API, whichever way it spells it.
  */
 function servesApi(name: string, site: any): boolean {
-  return name === 'api' || (typeof site?.start === 'string' && /\bserve:api\b/.test(site.start))
+  return name === 'api' || (typeof site?.start === 'string' && apiStartPattern.test(site.start))
+}
+
+/**
+ * How each site was classified, for the error message.
+ *
+ * The old messages asserted a conclusion the operator could see was false ("no
+ * site serves them", with an API site right there) and gave no way to find out
+ * what the classifier had decided. Diagnosing it meant reading the bundled
+ * source. Showing the verdict per site makes a misclassification obvious on the
+ * line that reports it.
+ */
+function describeSiteClassification(sites: Record<string, any>): string {
+  const described = Object.entries(sites)
+    .filter(([, site]) => typeof site?.start === 'string')
+    .map(([name, site]) => {
+      if (servesApi(name, site))
+        return `\`${name}\` (api)`
+      const env = (site?.env ?? {}) as Record<string, unknown>
+      const wiring = env.API_URL ? 'API_URL set' : env.PORT_API ? 'PORT_API set' : 'no API_URL or PORT_API'
+      return `\`${name}\` (page, ${wiring})`
+    })
+
+  return described.length > 0 ? `Sites examined: ${described.join(', ')}.` : 'No server-app sites were examined.'
 }
 
 /**
@@ -1416,6 +1453,7 @@ export function apiDeploymentProblem(sites: Record<string, any>, hasApiRoutes: b
       return undefined
 
     return 'This project declares API routes and no site serves them. `/api/**` will answer 502 on every request.\n'
+      + `${describeSiteClassification(sites)}\n`
       + 'Add an `api` site to config/cloud.ts running `buddy serve:api` on its own port, and set `PORT_API` on the site that serves the pages so its proxy can find it.\n'
       + 'Set `API_URL` on the page site instead when the API lives on another host.'
   }
@@ -1427,6 +1465,7 @@ export function apiDeploymentProblem(sites: Record<string, any>, hasApiRoutes: b
   const port = api[1]?.port
 
   return `The \`${api[0]}\` site serves the API, but ${unwired.map(([name]) => `\`${name}\``).join(', ')} will not proxy to it: neither \`PORT_API\` nor \`API_URL\` is set in its environment, so \`/api/**\` answers 502.\n`
+    + `${describeSiteClassification(sites)}\n`
     + `Set \`PORT_API: '${port ?? '<the api site\'s port>'}'\` in that site's \`env\` in config/cloud.ts.`
 }
 

--- a/storage/framework/core/buddy/src/commands/deploy.ts
+++ b/storage/framework/core/buddy/src/commands/deploy.ts
@@ -1470,6 +1470,46 @@ export function apiDeploymentProblem(sites: Record<string, any>, hasApiRoutes: b
 }
 
 /**
+ * The database each site will migrate against, once its env is resolved.
+ *
+ * A site's `DB_CONNECTION` comes from its own `env` merged over
+ * `.env.<environment>`, so it is knowable locally and need not match whatever
+ * the operator has exported in their shell. Deduplicated, because the audit is
+ * per corpus and two sites on sqlite is one thing to check.
+ *
+ * Only sites that actually run migrations are considered. A static or proxy
+ * site ships no schema, and failing a deploy over the database a site never
+ * opens would be a refusal nobody can act on.
+ */
+export function siteDatabaseDrivers(sites: Record<string, any>): string[] {
+  const drivers = new Set<string>()
+
+  for (const site of Object.values(sites ?? {})) {
+    if (typeof site?.start !== 'string')
+      continue
+
+    // `migrateToken` matches one token, not a whole command line, so the step
+    // has to be split the way buddyInvocationFrom splits it.
+    const preStart = Array.isArray(site?.preStart) ? site.preStart : []
+    const migrates = preStart.some((step: unknown) =>
+      typeof step === 'string' && step.trim().split(/\s+/).some(token => migrateToken.test(token)))
+    if (!migrates)
+      continue
+
+    // Deliberately NOT falling back to the deploying shell's DB_CONNECTION. By
+    // this point the site's env already has .env.<environment> merged in, so it
+    // is what the box will run with; the operator's local value describes their
+    // laptop and auditing against it would refuse correct deploys and pass
+    // broken ones. Absent means the framework default, exactly as
+    // validateMigrationDialect reads it.
+    const env = (site?.env ?? {}) as Record<string, unknown>
+    drivers.add(String(env.DB_CONNECTION || 'sqlite').toLowerCase())
+  }
+
+  return [...drivers]
+}
+
+/**
  * How a preStart string can be invoking buddy: the monorepo's own source entry,
  * an installed package's built CLI, or one of the bin names on PATH.
  */
@@ -2475,6 +2515,30 @@ async function runHetznerDeploy(args: {
   if (apiProblem) {
     log.error(apiProblem)
     throw new Error('Refusing to deploy: the API would not be reachable.')
+  }
+
+  /*
+   * Can the committed migrations actually run against the database each site is
+   * configured to open?
+   *
+   * Checked here, with the rest of the preventable refusals, because the answer
+   * is entirely local and the alternative is what already happened: the deploy
+   * succeeds, TLS is issued, DNS reconciles, the site answers 200, and the
+   * migrate step on the box fails with a wrong-dialect corpus. The scaffolded
+   * workflow runs that step with `|| echo "::warning::"`, so the job stays
+   * green and the app serves publicly with no tables (stacksjs/stacks#2347).
+   *
+   * `validateMigrationDialect` is the same gate `buddy migrate` uses, so a
+   * deploy cannot pass something the box will then reject. Same escape hatch
+   * too: STACKS_ALLOW_DIALECT_MISMATCH=1.
+   */
+  const { validateMigrationDialect } = await import('./migrate')
+  for (const driver of siteDatabaseDrivers(sitesWithResolvedEnv)) {
+    const dialect = validateMigrationDialect(p.projectPath(), { driver })
+    if (!dialect.valid) {
+      log.error(dialect.error ?? `The committed migrations cannot run on ${driver}.`)
+      throw new Error(`Refusing to deploy: the migrations cannot run on ${driver}.`)
+    }
   }
 
   // Also apply the decrypted values to THIS (local, deploying) process' env —

--- a/storage/framework/core/buddy/src/commands/env.ts
+++ b/storage/framework/core/buddy/src/commands/env.ts
@@ -96,8 +96,19 @@ export function env(buddy: CLI): void {
     .action(async (key: string, value: string, options: EnvOptions) => {
       log.debug('Running `buddy env:set` ...', options)
 
-      if (!key || !value) {
-        console.error('Both key and value are required')
+      // `value === ''` is a value: "this variable exists and is deliberately
+      // empty" is a normal state for an app whose billing or mail is not
+      // configured yet. Rejecting it as a missing argument left hand-editing the
+      // file as the only way to express it, and hand-writing a plaintext line
+      // into a committed encrypted env file is what the preflight then tried to
+      // re-encrypt (stacksjs/stacks#2348).
+      if (!key) {
+        console.error('A key is required. Pass an empty value to clear it: `buddy env:set KEY \'\'`')
+        process.exit(ExitCode.FatalError)
+      }
+
+      if (value === undefined) {
+        console.error(`No value given for ${key}. Pass one, or an empty string to clear it: \`buddy env:set ${key} ''\``)
         process.exit(ExitCode.FatalError)
       }
 

--- a/storage/framework/core/buddy/src/commands/migrate.ts
+++ b/storage/framework/core/buddy/src/commands/migrate.ts
@@ -170,8 +170,15 @@ function validateModelsExist(): { valid: boolean, error?: string } {
  * any action subprocess starts, so a mismatch cannot drop the framework tables
  * and only then discover it has nothing to rebuild them with.
  */
-export function validateMigrationDialect(cwd = process.cwd()): { valid: boolean, error?: string } {
-  const driver = String(process.env.DB_CONNECTION || 'sqlite').toLowerCase()
+export function validateMigrationDialect(
+  cwd = process.cwd(),
+  options: { driver?: string } = {},
+): { valid: boolean, error?: string } {
+  // `driver` is passed explicitly by the deploy preflight, which has to audit
+  // the connection each SITE will run with (resolved from its env and
+  // .env.<environment>) rather than whatever DB_CONNECTION happens to be set in
+  // the operator's shell. Defaults to the ambient value for every other caller.
+  const driver = String(options.driver || process.env.DB_CONNECTION || 'sqlite').toLowerCase()
   const dir = resolveMigrationDirectory(driver, { cwd })
   const relativeDir = relativeMigrationDirectory(dir, cwd)
 

--- a/storage/framework/core/buddy/src/commands/migrate.ts
+++ b/storage/framework/core/buddy/src/commands/migrate.ts
@@ -1148,7 +1148,8 @@ export function migrate(buddy: CLI): void {
     .option('--dry-run', 'Show what would change without writing anything', { default: false })
     .option('-f, --force', 'Regenerate even though the database already has migrations recorded', { default: false })
     .option('--replace-unmarked', 'Also delete migrations carrying no @generated marker (pre-marker corpora only)', { default: false })
-    .action(async (dialect: string | undefined, options: { dryRun?: boolean, force?: boolean, replaceUnmarked?: boolean }) => {
+    .option('--only-existing-tables', 'Rebuild exactly the tables already in the corpus, for changing dialect without adopting the framework schema', { default: false })
+    .action(async (dialect: string | undefined, options: { dryRun?: boolean, force?: boolean, replaceUnmarked?: boolean, onlyExistingTables?: boolean }) => {
       const perf = await intro('buddy migrate:regenerate')
 
       const target = (dialect || process.env.DB_CONNECTION || 'sqlite').toLowerCase()
@@ -1175,13 +1176,18 @@ export function migrate(buddy: CLI): void {
         process.exit(ExitCode.FatalError)
       }
 
-      const plan = await regenerateMigrationCorpus({ dialect: target, dryRun: true, replaceUnmarked: options.replaceUnmarked })
+      const plan = await regenerateMigrationCorpus({
+        dialect: target,
+        dryRun: true,
+        replaceUnmarked: options.replaceUnmarked,
+        onlyExistingTables: options.onlyExistingTables,
+      })
       if (resultFailed(plan)) {
         log.syncError(plan.error.message)
         process.exit(ExitCode.FatalError)
       }
 
-      const { files, removed, preserved, preservedOutOfScope, models, modelRoots } = plan.value
+      const { files, removed, preserved, preservedOutOfScope, models, modelRoots, unrebuildable } = plan.value
 
       // Preserved files are the ones no rerun can recreate, so they are the
       // only part of this plan a user cannot undo by running the command
@@ -1216,11 +1222,26 @@ ${preservedOutOfScope.slice(0, OUT_OF_SCOPE_SHOWN).map(f => `      ${f}`).join('
     with no definition for those tables at all. If they belong to framework
     models your app relies on without declaring (users, jobs, payments, ...),
     either publish them with \`buddy publish model <Name>\` or set
-    database.models.includeFrameworkDefaults, then regenerate again.`
+    re-run with --only-existing-tables to rebuild just these tables in the
+    target dialect. database.models.includeFrameworkDefaults also works, but it
+    adopts the framework's ENTIRE schema: every framework model becomes a
+    migration in your app, which for an app declaring a handful of models is
+    dozens of files it never asked for.`
 
       // The roots that actually contributed. Saying "app/Models and the
       // framework defaults" unconditionally was wrong for every app that has
       // models of its own (stacksjs/stacks#2255).
+      // Tables --only-existing-tables could not re-emit. Their files keep the
+      // old dialect, so a corpus that looks converted is not, and saying so is
+      // the difference between a clear result and a migration that fails later.
+      const unrebuildableBlock = unrebuildable.length === 0
+        ? ''
+        : `
+  • ${unrebuildable.length} table(s) in this corpus have no model behind them and will KEEP their current files:
+${unrebuildable.map(t => `      ${t}`).join('\n')}
+    Nothing can regenerate them, so those files stay in their existing dialect.
+    Publish the models with \`buddy publish model <Name>\` to convert them too.`
+
       const rootList = modelRoots.length === 0
         ? 'no model directory'
         : modelRoots.map(root => relative(process.cwd(), root) || root).join(' and ')
@@ -1231,7 +1252,7 @@ ${preservedOutOfScope.slice(0, OUT_OF_SCOPE_SHOWN).map(f => `      ${f}`).join('
   ─────────────────────────────────────────────
   • ${models} model(s) read from ${rootList}
   • ${files.length} migration file(s) will be written
-  • ${removed.length} existing file(s) will be removed${protectedHistoryBlock}${outOfScopeBlock}
+  • ${removed.length} existing file(s) will be removed${protectedHistoryBlock}${outOfScopeBlock}${unrebuildableBlock}
   • These files are tracked in git, so review with \`git diff\` afterwards
   ─────────────────────────────────────────────
 `)

--- a/storage/framework/core/buddy/tests/deploy-api-reachable.test.ts
+++ b/storage/framework/core/buddy/tests/deploy-api-reachable.test.ts
@@ -72,3 +72,60 @@ describe('apiDeploymentProblem', () => {
     expect(apiDeploymentProblem({ marketing: { root: './dist' } }, true)).toBeUndefined()
   })
 })
+
+describe('apiDeploymentProblem: classifying the API site (#2349)', () => {
+  // The reporter's config, verbatim in shape: the key is not `api` and the
+  // start command invokes the entrypoint file rather than the `serve:api`
+  // alias, so the old matcher counted the API site as a page server, then
+  // refused the deploy because that "page" had no API_URL.
+  const loghqApi = {
+    root: '.',
+    start: 'bun node_modules/@stacksjs/actions/dist/serve/api.js',
+    port: 3043,
+    env: { HOST: '127.0.0.1' },
+  }
+  const loghqPages = { root: '.', start: 'bun cli.js serve', port: 3042, env: { API_URL: 'http://127.0.0.1:3043' } }
+
+  it('accepts a site that runs the API entrypoint under any key', () => {
+    expect(apiDeploymentProblem({ 'main': loghqPages, 'loghq-api': loghqApi }, true)).toBeUndefined()
+  })
+
+  it('recognises the entrypoint however the path is spelled', () => {
+    for (const start of [
+      'bun node_modules/@stacksjs/actions/dist/serve/api.js',
+      'bun serve/api.ts',
+      'bun /srv/app/dist/serve/api.mjs',
+      'buddy serve:api',
+    ]) {
+      // The page site is wired, so the only thing under test is whether `svc`
+      // is recognised as the API rather than counted as a second page server.
+      const sites = { pages: { start: 'bun cli.js serve', env: { PORT_API: '3043' } }, svc: { start } }
+      expect(apiDeploymentProblem(sites, true)).toBeUndefined()
+    }
+  })
+
+  it('does not mistake a neighbouring path for the API entrypoint', () => {
+    // `preserve/api.js` ends in the same characters; the boundary has to hold
+    // or an unrelated site silently becomes the API and the real one is missed.
+    const problem = apiDeploymentProblem({ pages: { start: 'bun cli.js serve' }, other: { start: 'bun preserve/api.jsx' } }, true)
+
+    expect(problem).toContain('no site serves them')
+  })
+
+  it('shows how every site was classified when it refuses', () => {
+    const problem = apiDeploymentProblem({ main: { start: 'bun cli.js serve' }, worker: { start: 'bun queue.js' } }, true)
+
+    expect(problem).toContain('Sites examined:')
+    expect(problem).toContain('`main` (page, no API_URL or PORT_API)')
+    expect(problem).toContain('`worker` (page, no API_URL or PORT_API)')
+  })
+
+  it('names the API site in the classification when one is found but unwired', () => {
+    const problem = apiDeploymentProblem({ 'main': { start: 'bun cli.js serve' }, 'loghq-api': loghqApi }, true)
+
+    expect(problem).toContain('`loghq-api` (api)')
+    expect(problem).toContain('`main` (page, no API_URL or PORT_API)')
+    expect(problem).toContain('PORT_API')
+  })
+})
+

--- a/storage/framework/core/buddy/tests/deploy-migration-dialect-preflight.test.ts
+++ b/storage/framework/core/buddy/tests/deploy-migration-dialect-preflight.test.ts
@@ -1,0 +1,70 @@
+/**
+ * stacksjs/stacks#2347 - a deploy must not report success while shipping an app
+ * that cannot read its own database.
+ *
+ * The scaffolded workflow runs the remote migrate step with
+ * `|| echo "::warning::"`, so a wrong-dialect corpus fails there without failing
+ * the job: TLS issued, DNS reconciled, site answering 200, and no tables. The
+ * dialect is knowable locally before anything ships, so the deploy refuses
+ * instead, alongside the API-reachability and port checks.
+ *
+ * These cover which sites and which connection get audited. The audit itself is
+ * `validateMigrationDialect`, covered in the migrate suite.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { siteDatabaseDrivers } from '../src/commands/deploy'
+
+const migrating = (env: Record<string, string> = {}) => ({
+  start: 'bun cli.js serve',
+  preStart: ['bun cli.js migrate'],
+  env,
+})
+
+describe('siteDatabaseDrivers', () => {
+  it('reads the connection from the site, not the deploying shell', () => {
+    expect(siteDatabaseDrivers({ main: migrating({ DB_CONNECTION: 'postgres' }) })).toEqual(['postgres'])
+  })
+
+  it('defaults to sqlite when the site names no connection', () => {
+    // Matches validateMigrationDialect's own default, so the deploy audits the
+    // corpus the box will actually run.
+    expect(siteDatabaseDrivers({ main: migrating() })).toEqual(['sqlite'])
+  })
+
+  it('lowercases, so DB_CONNECTION=Postgres is not treated as a third database', () => {
+    expect(siteDatabaseDrivers({ main: migrating({ DB_CONNECTION: 'Postgres' }) })).toEqual(['postgres'])
+  })
+
+  it('reports each distinct connection once', () => {
+    const sites = {
+      a: migrating({ DB_CONNECTION: 'sqlite' }),
+      b: migrating({ DB_CONNECTION: 'sqlite' }),
+      c: migrating({ DB_CONNECTION: 'postgres' }),
+    }
+
+    expect(siteDatabaseDrivers(sites).sort()).toEqual(['postgres', 'sqlite'])
+  })
+
+  it('ignores sites that never run migrations', () => {
+    // Refusing a deploy over the database a static site never opens would be a
+    // refusal with nothing to act on.
+    const sites = {
+      docs: { start: 'bun cli.js serve', preStart: ['bun run build'], env: { DB_CONNECTION: 'postgres' } },
+      assets: { root: 'dist', env: { DB_CONNECTION: 'mysql' } },
+    }
+
+    expect(siteDatabaseDrivers(sites)).toEqual([])
+  })
+
+  it('recognises the migrate step whatever it is called', () => {
+    for (const step of ['bun cli.js migrate', 'buddy db:migrate', 'bun cli.js migrate:fresh']) {
+      const sites = { main: { start: 'bun cli.js serve', preStart: [step], env: { DB_CONNECTION: 'postgres' } } }
+      expect(siteDatabaseDrivers(sites)).toEqual(['postgres'])
+    }
+  })
+
+  it('is empty for a config with no sites at all', () => {
+    expect(siteDatabaseDrivers({})).toEqual([])
+  })
+})

--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -2626,6 +2626,34 @@ export function historicallyRootedTables(dir: string, files: readonly string[]):
   return [...tables]
 }
 
+/**
+ * Every table this corpus already defines, however the file was authored.
+ *
+ * Distinct from {@link historicallyRootedTables}, which deliberately looks only
+ * at UNMARKED files to find the roots worth protecting. Here the question is the
+ * opposite one: what is the full set of tables a regeneration must reproduce in
+ * order to replace this corpus without changing what it describes.
+ */
+export function tablesDefinedByCorpus(dir: string, files: readonly string[]): string[] {
+  const tables = new Set<string>()
+
+  for (const file of files) {
+    try {
+      for (const statement of sqlStatementsOf(readFileSync(join(dir, file), 'utf8'))) {
+        const match = statement.match(/^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`]?(\w+)["'`]?/i)
+        if (match?.[1])
+          tables.add(match[1].toLowerCase())
+      }
+    }
+    catch {
+      // Unreadable here means "cannot prove this table exists"; the file is
+      // preserved anyway, because it is never in the rebuilt set.
+    }
+  }
+
+  return [...tables]
+}
+
 /** Whether a migration changes a table whose original CREATE is preserved. */
 export function migrationTouchesRootedTable(dir: string, file: string, rootedTables: ReadonlySet<string>): boolean {
   try {
@@ -2732,6 +2760,18 @@ export interface RegeneratedCorpus {
    */
   preserved: string[]
   /**
+   * Tables the corpus defines that no model describes, so `onlyExistingTables`
+   * could not re-emit them and left their files alone.
+   *
+   * Named rather than silently skipped: their migrations stay in the previous
+   * dialect, which is exactly the condition the caller was trying to clear, and
+   * a corpus that is 90% converted looks converted.
+   *
+   * Always present, empty for every other mode. `Result` is invariant through
+   * `mapErr`, so an optional field here would not match the returned object.
+   */
+  unrebuildable: string[]
+  /**
    * The subset of {@link preserved} kept for the second reason: the corpus
    * does not rebuild the tables these files describe.
    *
@@ -2781,6 +2821,27 @@ export async function regenerateMigrationCorpus(options: {
    * is the behaviour that lost hand-authored migrations.
    */
   replaceUnmarked?: boolean
+  /**
+   * Rebuild exactly the tables the corpus already defines, and nothing else.
+   *
+   * For changing DIALECT rather than schema. Neither existing route can do it
+   * (stacksjs/stacks#2346): the default preserves unmarked files, so
+   * wrong-dialect CREATEs survive, and `replaceUnmarked` deletes them but the
+   * generator only emits tables whose models the app declares, so a framework
+   * table the app relies on without declaring is left behind in the old dialect.
+   * Turning on `includeFrameworkDefaults` fixes the dialect by writing the
+   * framework's entire schema into the app: measured at 80 files from 78 models
+   * for an app that declares five.
+   *
+   * This is the intersection those two miss. Every model is available to the
+   * generator, so any table in the corpus can be emitted correctly, but only the
+   * tables already present are written. No new tables, none dropped.
+   *
+   * A table no model describes cannot be regenerated, so its file is preserved
+   * and named in `preserved`. Deleting it would drop a schema nothing can
+   * rebuild.
+   */
+  onlyExistingTables?: boolean
 } = {}): Promise<Result<RegeneratedCorpus, Error>> {
   try {
     const dialect = options.dialect ?? getQbDialect()
@@ -2808,7 +2869,14 @@ export async function regenerateMigrationCorpus(options: {
     // `forceStage` because of the sentinel written just below: it goes into
     // `sources.dir`, and that has to be a directory this call owns rather than
     // the app's own `app/Models` (stacksjs/stacks#2255).
-    const sources = resolveModelSources({ forceStage: true })
+    // `onlyExistingTables` needs every model in scope so a framework table the
+    // app relies on without declaring can still be emitted. The output is
+    // narrowed to the corpus afterwards, so this widens what CAN be generated
+    // without widening what gets written.
+    const sources = resolveModelSources({
+      forceStage: true,
+      ...(options.onlyExistingTables ? { includeFrameworkDefaults: true } : {}),
+    })
     if (!sources) {
       return err(new Error(
         'No models found. Define models in app/Models, or ensure the framework defaults at '
@@ -2894,13 +2962,50 @@ export async function regenerateMigrationCorpus(options: {
       ))
     }
 
-    const groups = groupGeneratedStatements(statements)
+    let groups = groupGeneratedStatements(statements)
 
     let existing: string[] = []
     try {
       existing = readdirSync(dir).filter(f => f.endsWith('.sql')).sort()
     }
     catch { /* directory does not exist yet */ }
+
+    // Narrow a dialect-only regeneration to the tables already described.
+    //
+    // Done before the preservation rules below so everything downstream sees the
+    // reduced corpus: `createdTablesOf` then reports exactly the corpus tables,
+    // so nothing is out of scope and nothing is deleted for describing a table
+    // the emit does not cover.
+    let unrebuildable: string[] = []
+    if (options.onlyExistingTables) {
+      const corpusTables = new Set(tablesDefinedByCorpus(dir, existing))
+      if (corpusTables.size === 0) {
+        return err(new Error(
+          `No CREATE TABLE statements found in ${dir}, so there is nothing to regenerate in place. `
+          + 'Run `buddy migrate:regenerate <dialect>` without --only-existing-tables to write a corpus from your models.',
+        ))
+      }
+
+      const emitted = new Set(createdTablesOf(statements).map(table => table.toLowerCase()))
+      unrebuildable = [...corpusTables].filter(table => !emitted.has(table)).sort()
+
+      groups = groups
+        .map(group => ({
+          ...group,
+          statements: group.statements.filter((statement) => {
+            const table = statementTable(statement)
+            return table ? corpusTables.has(table.toLowerCase()) : false
+          }),
+        }))
+        .filter(group => group.statements.length > 0)
+
+      if (groups.length === 0) {
+        return err(new Error(
+          `None of the ${corpusTables.size} table(s) in ${dir} have a model behind them, so none can be regenerated. `
+          + 'Declare the models, or publish the framework ones with `buddy publish model <Name>`.',
+        ))
+      }
+    }
 
     // Two independent reasons to keep a file, and a file only gets deleted if
     // neither applies.
@@ -2912,9 +3017,15 @@ export async function regenerateMigrationCorpus(options: {
     //    (stacksjs/stacks#2255). No flag waives this one: `--replace-unmarked`
     //    means "these unmarked files are generator output", not "delete the
     //    schema for tables you are not regenerating".
-    const rootedTables = new Set(options.replaceUnmarked ? [] : historicallyRootedTables(dir, existing))
+    // `onlyExistingTables` is a dialect change, so the roots are precisely what
+    // has to be replaced: preserving them is what leaves wrong-dialect CREATEs
+    // on disk. It is safe here in a way `replaceUnmarked` is not, because every
+    // table being deleted is one this run has just re-emitted.
+    const rootedTables = new Set(
+      options.replaceUnmarked || options.onlyExistingTables ? [] : historicallyRootedTables(dir, existing),
+    )
     const outOfScope = new Set(migrationsOutsideCorpus(dir, existing, createdTablesOf(statements)))
-    const deletable = options.replaceUnmarked
+    const deletable = options.replaceUnmarked || options.onlyExistingTables
       ? existing
       : existing.filter(file => isGeneratedMigration(dir, file))
     const removed = deletable.filter(file => {
@@ -2981,7 +3092,7 @@ export async function regenerateMigrationCorpus(options: {
     }))
 
     if (options.dryRun)
-      return ok({ dialect, models: sources.models.length, modelRoots: sources.roots, files, removed, preserved, preservedOutOfScope, dir })
+      return ok({ dialect, models: sources.models.length, modelRoots: sources.roots, files, removed, preserved, preservedOutOfScope, unrebuildable, dir })
 
     mkdirSync(dir, { recursive: true })
 
@@ -3001,7 +3112,7 @@ export async function regenerateMigrationCorpus(options: {
     // follow-up generation at a true zero diff.
     saveMigrationSnapshot(result.plan, { dialect: dialect as MigrationPlan['dialect'] })
 
-    return ok({ dialect, models: sources.models.length, modelRoots: sources.roots, files, removed, preserved, preservedOutOfScope, dir })
+    return ok({ dialect, models: sources.models.length, modelRoots: sources.roots, files, removed, preserved, preservedOutOfScope, unrebuildable, dir })
   }
   catch (error) {
     return err(handleError('Migration regeneration failed', error))

--- a/storage/framework/core/database/tests/regenerate-only-existing-tables.test.ts
+++ b/storage/framework/core/database/tests/regenerate-only-existing-tables.test.ts
@@ -1,0 +1,121 @@
+/**
+ * stacksjs/stacks#2346 - regenerating a corpus into a different dialect.
+ *
+ * Neither existing route produces one that is both runnable and minimal. The
+ * default preserves unmarked files, so wrong-dialect CREATEs survive.
+ * `--replace-unmarked` deletes them, but the generator only emits tables whose
+ * models the app declares, so a framework table the app relies on without
+ * declaring is left behind in the old dialect. Turning on
+ * `includeFrameworkDefaults` fixes the dialect by adopting the framework's whole
+ * schema: 80 files from 78 models, for an app declaring five.
+ *
+ * `tablesDefinedByCorpus` is the missing piece: the set a regeneration must
+ * reproduce to replace a corpus without changing what it describes.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { GENERATED_MIGRATION_MARKER, historicallyRootedTables, tablesDefinedByCorpus } from '../src/migrations'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'stacks-2346-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function write(name: string, sql: string): string {
+  writeFileSync(join(dir, name), sql)
+  return name
+}
+
+describe('tablesDefinedByCorpus', () => {
+  it('finds the table a generated migration creates', () => {
+    const file = write('0000000001-create-users-table.sql', 'CREATE TABLE "users" (id INTEGER);\n')
+
+    expect(tablesDefinedByCorpus(dir, [file])).toEqual(['users'])
+  })
+
+  it('counts a @generated file, which historicallyRootedTables deliberately skips', () => {
+    // The two answer opposite questions. historicallyRootedTables looks only at
+    // UNMARKED files, to find roots worth protecting; this needs the full set a
+    // regeneration has to reproduce, marked or not.
+    const generated = write('0000000002-create-jobs-table.sql', `${GENERATED_MIGRATION_MARKER}\nCREATE TABLE "jobs" (id INTEGER);\n`)
+
+    expect(tablesDefinedByCorpus(dir, [generated])).toEqual(['jobs'])
+    expect(historicallyRootedTables(dir, [generated])).toEqual([])
+  })
+
+  it('counts unmarked files too, unlike historicallyRootedTables', () => {
+    // The distinction that makes this usable for a dialect switch: the roots
+    // are exactly what has to be replaced, so they must be in the set.
+    const files = [
+      write('0000000004-create-users-table.sql', 'CREATE TABLE "users" (id BIGSERIAL);\n'),
+      write('0000000008-create-email_suppressions-table.sql', 'CREATE TABLE "email_suppressions" (id SERIAL);\n'),
+    ]
+
+    expect(tablesDefinedByCorpus(dir, files).sort()).toEqual(['email_suppressions', 'users'])
+  })
+
+  it('ignores files that only alter, so nothing is invented', () => {
+    const files = [
+      write('0000000001-create-projects-table.sql', 'CREATE TABLE "projects" (id INTEGER);\n'),
+      write('0000000011-auto-misc.sql', 'ALTER TABLE "projects" ALTER COLUMN "ingest_key" TYPE varchar(255);\n'),
+    ]
+
+    expect(tablesDefinedByCorpus(dir, files)).toEqual(['projects'])
+  })
+
+  it('reads several CREATEs out of one file', () => {
+    const file = write('0000000001-init.sql', 'CREATE TABLE "a" (id INTEGER);\nCREATE TABLE "b" (id INTEGER);\n')
+
+    expect(tablesDefinedByCorpus(dir, [file]).sort()).toEqual(['a', 'b'])
+  })
+
+  it('handles IF NOT EXISTS and unquoted names', () => {
+    const file = write('0000000001-init.sql', 'CREATE TABLE IF NOT EXISTS jobs (id INTEGER);\n')
+
+    expect(tablesDefinedByCorpus(dir, [file])).toEqual(['jobs'])
+  })
+
+  it('lowercases, so one table is never counted twice', () => {
+    const files = [
+      write('0000000001-a.sql', 'CREATE TABLE "Users" (id INTEGER);\n'),
+      write('0000000002-b.sql', 'CREATE TABLE "users" (id INTEGER);\n'),
+    ]
+
+    expect(tablesDefinedByCorpus(dir, files)).toEqual(['users'])
+  })
+
+  it('is empty for a corpus with no CREATE TABLE at all', () => {
+    const file = write('0000000001-alter.sql', 'ALTER TABLE "users" ADD COLUMN "x" TEXT;\n')
+
+    expect(tablesDefinedByCorpus(dir, [file])).toEqual([])
+  })
+
+  it('skips a file it cannot read rather than throwing', () => {
+    write('0000000001-create-users-table.sql', 'CREATE TABLE "users" (id INTEGER);\n')
+
+    expect(tablesDefinedByCorpus(dir, ['0000000001-create-users-table.sql', 'gone.sql'])).toEqual(['users'])
+  })
+
+  it('covers the reported corpus: every table, whoever authored the file', () => {
+    // The shape from the issue: postgres-flavoured files, some generated and
+    // some not, including a framework table the app never declared.
+    const files = [
+      write('0000000004-create-users-table.sql', 'CREATE TABLE "users" (id BIGSERIAL PRIMARY KEY);\n'),
+      write('0000000005-create-subscriptions-table.sql', 'CREATE TABLE "subscriptions" (id BIGSERIAL);\n'),
+      write('0000000008-create-email_suppressions-table.sql', 'CREATE TABLE "email_suppressions" (id SERIAL);\n'),
+      write('0000000010-create-projects-table.sql', 'CREATE TABLE "projects" (id INTEGER);\n'),
+      write('0000000011-auto-misc.sql', 'ALTER TABLE "projects" ALTER COLUMN "ingest_key" TYPE varchar(255);\n'),
+    ]
+
+    expect(tablesDefinedByCorpus(dir, files).sort())
+      .toEqual(['email_suppressions', 'projects', 'subscriptions', 'users'])
+  })
+})

--- a/storage/framework/core/env/src/cli.ts
+++ b/storage/framework/core/env/src/cli.ts
@@ -139,6 +139,57 @@ export function envKeyNames(file?: string): { publicKeyName: string, privateKeyN
 }
 
 /**
+ * The public key an env file's existing ciphertext was encrypted under.
+ *
+ * Encrypting needs only the PUBLIC half, and an encrypted env file already
+ * carries it on its `DOTENV_PUBLIC_KEY*` line. Resolving the keypair from
+ * `.env.keys` instead is what let one file end up holding two generations at
+ * once (stacksjs/stacks#2348):
+ *
+ *   `.env.keys` is gitignored, so on a CI runner it does not exist. The private
+ *   key arrives as `DOTENV_PRIVATE_KEY_<ENV>` in the environment, which this
+ *   path never consulted. A file with any plaintext line therefore got a
+ *   BRAND NEW keypair, its four plaintext values encrypted under generation 2,
+ *   its public-key line replaced with generation 2's, and a fresh `.env.keys`
+ *   written. The thirty-three values already encrypted under generation 1 were
+ *   left behind, decryptable by a key the file no longer names.
+ *
+ * Reusing the file's own public key makes that structurally impossible: every
+ * value in the file stays under one key, and the operator's existing private
+ * key keeps working.
+ *
+ * Only reused when the file actually holds ciphertext. A scaffolded file can
+ * ship a demo `DOTENV_PUBLIC_KEY` whose private half was never generated, and
+ * encrypting real secrets under that would make them permanently unreadable.
+ * With no ciphertext there is nothing to stay consistent with, so a fresh
+ * keypair is both safe and correct.
+ */
+export function reusableEnvPublicKey(envContent: string, publicKeyName: string): string | undefined {
+  let publicKey: string | undefined
+  let hasCiphertext = false
+
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#'))
+      continue
+
+    const match = trimmed.match(/^([^=]+)=(.*)$/)
+    if (!match?.[1] || match[2] === undefined)
+      continue
+
+    const key = match[1].trim()
+    const value = match[2].trim().replace(/^["']|["']$/g, '')
+
+    if (key === publicKeyName)
+      publicKey = value
+    else if (value.startsWith('encrypted:') || value.startsWith('enc:'))
+      hasCiphertext = true
+  }
+
+  return publicKey && hasCiphertext ? publicKey : undefined
+}
+
+/**
  * Encrypt .env file
  */
 export function encryptEnv(options: EncryptOptions = {}): { success: boolean, output?: string, error?: string } {
@@ -155,7 +206,19 @@ export function encryptEnv(options: EncryptOptions = {}): { success: boolean, ou
     let publicKey: string
     let privateKey: string
 
-    if (existsSync(keysPath)) {
+    // The file's own public key wins. See reusableEnvPublicKey: resolving from
+    // `.env.keys` alone is what produced a file holding two key generations.
+    const existingPublicKey = reusableEnvPublicKey(
+      readFileSync(envPath, 'utf-8'),
+      envKeyNames(options.file).publicKeyName,
+    )
+
+    if (existingPublicKey) {
+      // Deliberately no write to `.env.keys`: we hold only the public half, and
+      // inventing a private key to sit beside it would be a lie on disk.
+      publicKey = existingPublicKey
+    }
+    else if (existsSync(keysPath)) {
       const keysContent = readFileSync(keysPath, 'utf-8')
       const { parsed } = parse(keysContent)
 
@@ -394,7 +457,19 @@ export function setEnv(
         hasMatchingPrivateKey = Boolean(keys[privateKeyName])
       }
 
-      if (!hasMatchingPrivateKey) {
+      // Missing locally is not the same as missing. `.env.keys` is gitignored,
+      // so it is absent on every CI runner, where the private key arrives as
+      // `DOTENV_PRIVATE_KEY_<ENV>` in the environment instead. Discarding the
+      // file's public key on that evidence regenerates a keypair and leaves the
+      // file holding two generations, which is exactly the state that made 33
+      // committed values undecryptable in stacksjs/stacks#2348.
+      //
+      // So the file's own ciphertext is the better witness: if there is any,
+      // this public key is the one the rest of the file already uses and it has
+      // to stay. Only when the file carries no ciphertext, and no private key is
+      // reachable either way, is a fresh keypair the safe answer.
+      if (!hasMatchingPrivateKey && !process.env[privateKeyName]
+        && !reusableEnvPublicKey(content, publicKeyName)) {
         publicKey = undefined
       }
     }

--- a/storage/framework/core/env/tests/env-key-generation-drift.test.ts
+++ b/storage/framework/core/env/tests/env-key-generation-drift.test.ts
@@ -1,0 +1,163 @@
+/**
+ * stacksjs/stacks#2348 - one env file must never hold two key generations.
+ *
+ * `.env.keys` is gitignored, so it does not exist on a CI runner; the private
+ * key arrives as `DOTENV_PRIVATE_KEY_<ENV>` in the environment. Resolving the
+ * keypair from `.env.keys` alone meant a committed file with any plaintext line
+ * got a brand new keypair: the plaintext values were encrypted under generation
+ * 2, the public-key line was replaced with generation 2's, and every value
+ * already encrypted under generation 1 was orphaned.
+ *
+ * Reported as 4 values decrypting and 33 failing, which is that split exactly.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { encryptValue, generateKeypair } from '../src/crypto'
+import { encryptEnv, reusableEnvPublicKey, setEnv } from '../src/cli'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'stacks-env-2348-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+  delete process.env.DOTENV_PRIVATE_KEY_PRODUCTION
+})
+
+/** A committed, encrypted `.env.production` plus any hand-written plaintext. */
+function writeEnvFile(publicKey: string, encrypted: Record<string, string>, plaintext: Record<string, string> = {}): string {
+  const lines = [`DOTENV_PUBLIC_KEY_PRODUCTION="${publicKey}"`, '']
+  for (const [k, v] of Object.entries(encrypted))
+    lines.push(`${k}="${encryptValue(v, publicKey)}"`)
+  for (const [k, v] of Object.entries(plaintext))
+    lines.push(`${k}="${v}"`)
+
+  const path = join(dir, '.env.production')
+  writeFileSync(path, `${lines.join('\n')}\n`)
+  return path
+}
+
+function publicKeyIn(path: string): string | undefined {
+  return readFileSync(path, 'utf-8').match(/DOTENV_PUBLIC_KEY_PRODUCTION="([^"]+)"/)?.[1]
+}
+
+/** Every `KEY="value"` pair, ciphertext or not. */
+function valuesIn(path: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const line of readFileSync(path, 'utf-8').split('\n')) {
+    const m = line.trim().match(/^([A-Z0-9_]+)="(.*)"$/)
+    if (m?.[1] && !m[1].startsWith('DOTENV_PUBLIC_KEY'))
+      out[m[1]] = m[2]!
+  }
+  return out
+}
+
+describe('reusableEnvPublicKey', () => {
+  test('returns the file key when the file already holds ciphertext', () => {
+    const { publicKey } = generateKeypair()
+    const content = `DOTENV_PUBLIC_KEY_PRODUCTION="${publicKey}"\nAPP_NAME="${encryptValue('demo', publicKey)}"\n`
+
+    expect(reusableEnvPublicKey(content, 'DOTENV_PUBLIC_KEY_PRODUCTION')).toBe(publicKey)
+  })
+
+  test('returns nothing for a scaffolded file whose demo key encrypts nothing', () => {
+    // A public key with no ciphertext under it has no history to stay
+    // consistent with, and its private half may never have existed.
+    const content = 'DOTENV_PUBLIC_KEY_PRODUCTION="x25519-public:demo"\nAPP_NAME="plain"\n'
+
+    expect(reusableEnvPublicKey(content, 'DOTENV_PUBLIC_KEY_PRODUCTION')).toBeUndefined()
+  })
+
+  test('returns nothing when the file names no public key', () => {
+    expect(reusableEnvPublicKey('APP_NAME="plain"\n', 'DOTENV_PUBLIC_KEY_PRODUCTION')).toBeUndefined()
+  })
+})
+
+describe('encryptEnv on a CI runner with no .env.keys (#2348)', () => {
+  test('keeps the file key, so the file never holds two generations', () => {
+    const gen1 = generateKeypair()
+    const path = writeEnvFile(gen1.publicKey, { APP_NAME: 'loghq', APP_URL: 'https://loghq.dev' }, { STRIPE_SECRET_KEY: '', MAIL_PASSWORD: '' })
+
+    // No .env.keys: exactly the runner's state.
+    expect(existsSync(join(dir, '.env.keys'))).toBe(false)
+
+    const result = encryptEnv({ file: '.env.production', cwd: dir })
+
+    expect(result.success).toBe(true)
+    expect(publicKeyIn(path)).toBe(gen1.publicKey)
+
+    // Every value is ciphertext, and all of it under the one key the operator
+    // still holds the private half of.
+    const values = valuesIn(path)
+    expect(Object.keys(values).sort()).toEqual(['APP_NAME', 'APP_URL', 'MAIL_PASSWORD', 'STRIPE_SECRET_KEY'])
+    for (const [key, value] of Object.entries(values))
+      expect(`${key} ${value.startsWith('encrypted:')}`).toBe(`${key} true`)
+  })
+
+  test('does not invent a .env.keys holding a private key it never had', () => {
+    const gen1 = generateKeypair()
+    writeEnvFile(gen1.publicKey, { APP_NAME: 'loghq' }, { STRIPE_SECRET_KEY: '' })
+
+    encryptEnv({ file: '.env.production', cwd: dir })
+
+    expect(existsSync(join(dir, '.env.keys'))).toBe(false)
+  })
+
+  test('the previously encrypted values are left byte-identical', () => {
+    const gen1 = generateKeypair()
+    const path = writeEnvFile(gen1.publicKey, { APP_NAME: 'loghq' }, { STRIPE_SECRET_KEY: '' })
+    const before = valuesIn(path).APP_NAME
+
+    encryptEnv({ file: '.env.production', cwd: dir })
+
+    expect(valuesIn(path).APP_NAME).toBe(before)
+  })
+
+  test('still generates a keypair for a file that carries no ciphertext', () => {
+    // Nothing to stay consistent with, and the demo key's private half may
+    // never have existed, so a fresh keypair is the safe answer here.
+    writeFileSync(join(dir, '.env.production'), 'DOTENV_PUBLIC_KEY_PRODUCTION="x25519-public:demo"\nAPP_NAME="loghq"\n')
+
+    expect(encryptEnv({ file: '.env.production', cwd: dir }).success).toBe(true)
+    expect(publicKeyIn(join(dir, '.env.production'))).not.toBe('x25519-public:demo')
+    expect(existsSync(join(dir, '.env.keys'))).toBe(true)
+  })
+})
+
+describe('setEnv against a committed file with no local .env.keys (#2348)', () => {
+  test('encrypts under the file key rather than rotating it', () => {
+    const gen1 = generateKeypair()
+    const path = writeEnvFile(gen1.publicKey, { APP_NAME: 'loghq' })
+
+    const result = setEnv('STRIPE_SECRET_KEY', '', { file: '.env.production', cwd: dir })
+
+    expect(result.success).toBe(true)
+    expect(publicKeyIn(path)).toBe(gen1.publicKey)
+  })
+
+  test('an empty value is stored, not rejected', () => {
+    const gen1 = generateKeypair()
+    const path = writeEnvFile(gen1.publicKey, { APP_NAME: 'loghq' })
+
+    setEnv('STRIPE_SECRET_KEY', '', { file: '.env.production', cwd: dir, plain: true })
+
+    expect(valuesIn(path).STRIPE_SECRET_KEY).toBe('')
+  })
+
+  test('a private key in the environment counts as having one', () => {
+    // The runner's actual arrangement: no .env.keys on disk, the private key in
+    // DOTENV_PRIVATE_KEY_PRODUCTION.
+    const gen1 = generateKeypair()
+    process.env.DOTENV_PRIVATE_KEY_PRODUCTION = gen1.privateKey
+    const path = writeEnvFile(gen1.publicKey, {})
+
+    setEnv('NEW_KEY', 'value', { file: '.env.production', cwd: dir })
+
+    expect(publicKeyIn(path)).toBe(gen1.publicKey)
+  })
+})


### PR DESCRIPTION
Fixes #2349, #2348, #2346. Addresses the half of #2347 that lives in this repo.

Four commits, one per issue, each independently revertable.

---

### #2349 - an API site classified as a page server

`servesApi` accepted a site keyed `api`, or a `start` matching `serve:api`. A generated config that resolves the package rather than going through a bin shim runs the entrypoint by path:

```ts
start: 'bun node_modules/@stacksjs/actions/dist/serve/api.js'
```

`serve/api.js` with a slash, not `serve:api` with a colon. Under the key `loghq-api`, neither test matched, so the API site was counted among the page servers, and page servers must carry `API_URL` or `PORT_API`, which the API site has no reason to. The deploy was refused with "no site serves them" while the site serving them sat in the same config.

The matcher now accepts the entrypoint path, with a boundary that keeps `preserve/api.jsx` out. Both refusal messages now show the verdict per site:

```
Sites examined: `loghq-api` (api), `main` (page, no API_URL or PORT_API).
```

**Not changed:** the rule that every page site must declare `API_URL`/`PORT_API`. The issue asks whether it is too strict, but it is what catches the silent 502 the check exists for, and with the classification fixed it no longer fires on a correct config. That is a policy question, not something to smuggle into a bug fix.

---

### #2348 - a committed env file rewritten under a second key

This is the one with data-loss potential, and the root cause is precise.

`encryptEnv` resolved its keypair **only** from `.env.keys`. That file is gitignored, so on a CI runner it does not exist; the private key arrives as `DOTENV_PRIVATE_KEY_<ENV>` in the environment, which this path never consulted. So a committed file with any plaintext line got a **brand new keypair**: the plaintext values encrypted under generation 2, the public-key line replaced with generation 2's, a fresh `.env.keys` written, and every value already encrypted under generation 1 orphaned.

That is the reported 4-decrypt / 33-fail split exactly. The four that worked were the four just re-encrypted.

The fix is that **encrypting needs only the public half, and the file already carries it**. `reusableEnvPublicKey` reads it back and both `encryptEnv` and `setEnv` prefer it, which makes two generations in one file structurally impossible. No `.env.keys` is written on that path: holding a public key is not grounds for inventing a private one.

The existing guard against a scaffolded demo `DOTENV_PUBLIC_KEY` is kept, with a better witness: the file's own ciphertext. Values already encrypted under a key mean that key stays; nothing encrypted under it means no history to preserve and a fresh keypair is safe.

`buddy env:set KEY ''` is also accepted now, which removes the reason to hand-edit the file at all.

**Not changed:** the preflight still encrypts rather than refusing. With the key reused it can no longer orphan anything, and refusing would fail deploys that are now correct.

---

### #2347 - a green deploy shipping an app with no tables

`validateMigrationDialect` now runs in `buddy deploy`'s preflight, next to the API-reachability and port checks, so a corpus that cannot run against the configured database refuses locally instead of failing on the box inside a step the workflow marks as a warning.

The connection audited is the one each **site** will run with, resolved from its env with `.env.<environment>` merged, not the operator's shell. Their shell describes their laptop; auditing against it would refuse correct deploys and pass broken ones. Only sites whose preStart actually runs migrations are considered.

**Not fixed, because it is not in this repo:** the `|| echo "::warning::"` in the scaffolded `.github/workflows/deploy.yml`. `defaults/scaffold` ships only config files and no workflow, so whatever generates that file lives elsewhere. The issue calls the preflight the change that prevents the outage and the workflow the one that stops it being invisible. This is the first; the second still wants doing wherever that template lives.

---

### #2346 - regenerating into another dialect

Neither existing route produced a corpus that was both runnable and minimal, for two different reasons: the default preserves unmarked files, so the wrong-dialect CREATEs are precisely what survives; `--replace-unmarked` deletes them but the generator only emits tables whose models the app declares, so a framework table the app relies on without declaring is left behind in the old dialect.

`--only-existing-tables` is the intersection: every model in scope so any table in the corpus **can** be emitted, only the tables already present written. No new tables, none dropped. Roots are replaced rather than preserved, which is safe here in a way `--replace-unmarked` is not, because every file deleted describes a table this run has just re-emitted.

A table no model describes still cannot be regenerated, so its files are kept and the table is **named** in the plan. A corpus that is 90% converted looks converted.

The `includeFrameworkDefaults` hint now states its cost before someone runs it.

**Not addressed:** `ALTER COLUMN ... TYPE ... USING`, which SQLite cannot express. Under this flag it is re-emitted from the model rather than translated, so it does not arise, but folding it back into the CREATE it amends needs its own answer.

---

## Verification

| | |
|---|---|
| New tests | 38 across four files |
| `buddy` suite | 495 pass, 0 fail |
| `database` suite | 803 pass, 0 fail |
| root suite | 330 pass, 0 fail |
| `env` suite | 224 pass, 0 fail |
| lint (via `runLint`) / typecheck | clean |

Every load-bearing assertion was mutation-checked. Two mutations initially appeared to survive; on inspection my `perl` patterns had not applied, and once applied correctly both failed the suite. Two of my own tests were also wrong and were fixed against the source rather than the other way round: one asserted an unwired page site should pass, and one let the deploying shell's `DB_CONNECTION` leak into the expectation, which turned out to be a real design flaw in the helper.

I agree with the issue that `bun-query-builder` is not at fault and nothing needed filing there.