### PR TITLE
fix(migrate): give the schema diff a baseline that survives a release (#2351)

### DIFF
--- a/docs/guide/buddy/migrate.md
+++ b/docs/guide/buddy/migrate.md
@@ -344,6 +344,36 @@ buddy migrate
 buddy migrate --diff
 ```
 
+## The snapshot is the baseline
+
+`buddy migrate` works out what changed by diffing your models against a snapshot
+of the last known schema:
+
+```
+storage/framework/database/model-snapshot.<dialect>.json
+```
+
+Without that file there is no baseline, so the same change is derived again on
+every run. Applying it fixes exactly one run, and the next one proposes it back.
+
+That path sits inside the project, which is right for a checkout and wrong for a
+release-directory deploy. Capistrano-style layouts put every deploy in a fresh
+`releases/<sha>`, so the snapshot is never there, and a schema that is already
+correct keeps reporting a pending change.
+
+Point `DB_SNAPSHOT_PATH` at a directory that outlives the release:
+
+```bash
+# absolute, or relative to the release directory
+DB_SNAPSHOT_PATH=/srv/app/shared/db
+DB_SNAPSHOT_PATH=../../shared/db
+```
+
+The directory must be writable: migrate writes the new snapshot back after a
+successful run, and a read-only one leaves you where you started. When a
+destructive change is proposed and no snapshot exists, migrate now names the
+directory it looked in rather than leaving you to guess.
+
 ## Related Commands
 
 - [buddy seed](/guide/buddy/seed) - Seed database with test data

--- a/storage/framework/core/buddy/src/commands/migrate.ts
+++ b/storage/framework/core/buddy/src/commands/migrate.ts
@@ -332,13 +332,49 @@ function describeOp(op: MigrationOpLike): string {
     case 'modify_column':
       return `change type of "${op.table}"."${op.column}" (possible data loss)`
     case 'rebuild_table':
-      return `rebuild table "${op.table}" (type/constraint change)`
+      // Deliberately not "(type/constraint change)". SQLite rebuilds a table for
+      // several reasons — a changed column type, a changed foreign key, or the
+      // removal of a constrained column — and nothing here computed which one it
+      // was. Asserting the wrong one sent an operator looking for a type change
+      // that did not exist, against SQL that rebuilt the table byte-identically
+      // (stacksjs/stacks#2351). Name the operation, not a guess at its cause.
+      return `rebuild table "${op.table}" (SQLite rebuilds in place; compare the SQL below against the live schema)`
     case 'rename_column':
       return `rename "${op.table}"."${op.from}" → "${op.to}"`
     case 'rename_table':
       return `rename table "${op.from}" → "${op.to}"`
     default:
       return `${op.kind} on "${op.table}"${op.column ? `."${op.column}"` : ''}`
+  }
+}
+
+/**
+ * Explain a proposed change when there is no baseline to have proposed it from.
+ *
+ * The differ compares models against `<snapshotDir>/model-snapshot.<dialect>.json`.
+ * With that file absent it re-derives the baseline every run, so the same change
+ * is proposed on every deploy and applying it fixes exactly one release. On a
+ * Capistrano-style layout the snapshot is absent by construction: each deploy is a
+ * fresh `releases/<sha>` directory and the default path lives inside it.
+ *
+ * Nothing named the file, so the failure looked like a schema that would not
+ * converge rather than a baseline that was never there (stacksjs/stacks#2351).
+ */
+async function missingBaselineNote(): Promise<string | undefined> {
+  try {
+    const { resolveSnapshotDirectory, snapshotDirectoryIsShared } = await import('@stacksjs/database')
+    const dir = resolveSnapshotDirectory()
+    if (existsSync(dir) && readdirSync(dir).some(f => /^model-snapshot\.\w+\.json$/.test(f)))
+      return undefined
+
+    return `No model snapshot in ${dir}, so this change was derived without a baseline and will be `
+      + `proposed again on the next run.${snapshotDirectoryIsShared()
+        ? ' DB_SNAPSHOT_PATH points there; check the directory exists and is writable.'
+        : ' If each deploy runs from a new directory, point DB_SNAPSHOT_PATH at a shared one that survives the release.'}`
+  }
+  catch (error) {
+    log.debug(`[migrate] baseline check skipped: ${error instanceof Error ? error.message : String(error)}`)
+    return undefined
   }
 }
 
@@ -372,6 +408,10 @@ async function confirmDestructiveMigrations(opts: { force?: boolean, fromDb?: bo
   log.warn(`This migration includes ${destructive.length} potentially destructive change${destructive.length === 1 ? '' : 's'}:`)
   for (const op of destructive)
     log.warn(`  • ${describeOp(op)}`)
+
+  const baseline = await missingBaselineNote()
+  if (baseline)
+    log.warn(baseline)
 
   if (opts.force)
     return true

--- a/storage/framework/core/database/src/database.ts
+++ b/storage/framework/core/database/src/database.ts
@@ -7,7 +7,7 @@
  */
 
 import { isVitessSharded, toQueryBuilderDialect } from './dialect'
-import { QB_SNAPSHOT_DIR } from './utils'
+import { qbSnapshotDir } from './utils'
 import type { QueryBuilderConfig, StacksDialect } from '@stacksjs/query-builder'
 import { createQueryBuilder, setConfig } from '@stacksjs/query-builder'
 import { env as stacksEnv } from '@stacksjs/env'
@@ -142,9 +142,9 @@ export class Database {
 
     // Configure bun-query-builder
     setConfig({
-      // See QB_SNAPSHOT_DIR: setConfig replaces the config wholesale, so
+      // See qbSnapshotDir: setConfig replaces the config wholesale, so
       // every call site has to carry this or `.qb` returns to the root.
-      snapshotDir: QB_SNAPSHOT_DIR,
+      snapshotDir: qbSnapshotDir(),
       // Collapsed, not passed through: Stacks accepts dialects the query
       // builder has no renderer for (they diverge only in DDL), and handing
       // one of those down verbatim makes it fall back to its default

--- a/storage/framework/core/database/src/migration-path.ts
+++ b/storage/framework/core/database/src/migration-path.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
-import { isAbsolute, join } from 'node:path'
+import { isAbsolute, join, relative } from 'node:path'
 import process from 'node:process'
 
 const DEFAULT_MIGRATION_DIR = 'database/migrations'
@@ -106,4 +106,41 @@ function wireOf(dialect: string): 'postgres' | 'mysql' {
 export function relativeMigrationDirectory(directory: string, cwd = process.cwd()): string {
   const prefix = `${cwd}/`
   return directory.startsWith(prefix) ? directory.slice(prefix.length) : directory
+}
+
+/**
+ * Where the model snapshot lives, as an absolute path.
+ *
+ * `buddy migrate` diffs models against `<snapshotDir>/model-snapshot.<dialect>.json`.
+ * The default sits inside the project, which is correct for a checkout and wrong
+ * for a Capistrano-style deploy: every release is a fresh `releases/<sha>`
+ * directory, so the snapshot is absent on every deploy, the differ re-derives the
+ * baseline from scratch, and the same change is proposed forever. Applying it by
+ * hand fixes exactly one release (stacksjs/stacks#2351).
+ *
+ * `DB_SNAPSHOT_PATH` points it at a shared directory that survives the release
+ * flip, mirroring `DB_MIGRATIONS_PATH` above. Absolute paths are honoured.
+ */
+export function resolveSnapshotDirectory(cwd = process.cwd()): string {
+  const configured = process.env.DB_SNAPSHOT_PATH || DEFAULT_SNAPSHOT_DIR
+  return isAbsolute(configured) ? configured : join(cwd, configured)
+}
+
+/**
+ * The same directory, expressed the way bun-query-builder wants it.
+ *
+ * It resolves `snapshotDir` as `join(workspaceRoot, snapshotDir)`, and `join`
+ * does not honour an absolute second segment — `join('/app/current', '/srv/shared')`
+ * is `/app/current/srv/shared`. So an absolute `DB_SNAPSHOT_PATH` handed down
+ * verbatim would silently write back inside the release directory, which is the
+ * exact failure this is meant to remove. Relativising it first makes the library's
+ * own join land where the operator asked, including via `..`.
+ */
+export function snapshotDirForQueryBuilder(cwd = process.cwd()): string {
+  return relative(cwd, resolveSnapshotDirectory(cwd)) || '.'
+}
+
+/** True when the snapshot directory is not the in-project default. */
+export function snapshotDirectoryIsShared(): boolean {
+  return Boolean(process.env.DB_SNAPSHOT_PATH)
 }

--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -7,7 +7,7 @@
 
 import type { Result } from '@stacksjs/error-handling'
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
-import { dirname, isAbsolute, join } from 'node:path'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { log as _log } from '@stacksjs/logging'
 
 // Defensive log wrapper to handle cases where log methods might not be initialized.
@@ -34,7 +34,7 @@ import {
   saveMigrationSnapshot,
   setConfig,
 } from '@stacksjs/query-builder'
-import { db, QB_SNAPSHOT_DIR, resetDatabaseConnection } from './utils'
+import { db, qbSnapshotDir, resetDatabaseConnection } from './utils'
 import {
   classifyConnectionError,
   createDatabase,
@@ -146,7 +146,7 @@ function getQbDialect(): 'sqlite' | 'mysql' | 'singlestore' | 'vitess' | 'postgr
 function migrationDirectory(dialect: string = getQbDialect()): string {
   return resolveMigrationDirectory(dialect, {
     configured: (qbConfig as { migrationDir?: string }).migrationDir,
-    snapshotDir: QB_SNAPSHOT_DIR,
+    snapshotDir: qbSnapshotDir(),
   })
 }
 
@@ -179,7 +179,7 @@ function configureQueryBuilder(
     // dot-directory in every Stacks app holding something the app never chose
     // to place there. `storage/framework` is where generated framework state
     // already lives, so it belongs there.
-    snapshotDir: QB_SNAPSHOT_DIR,
+    snapshotDir: qbSnapshotDir(),
     migrationDir: relativeMigrationDirectory(migrationDirectory(targetDialect)),
     database: {
       database: connectionConfig?.name || connectionConfig?.database || 'stacks',
@@ -1875,11 +1875,16 @@ export async function previewPendingMigrations(options: GenerateMigrationsOption
  * generated framework state out of the project root.
  */
 function snapshotDirLabel(): string {
-  return (qbConfig as { snapshotDir?: string } | undefined)?.snapshotDir || QB_SNAPSHOT_DIR
+  return (qbConfig as { snapshotDir?: string } | undefined)?.snapshotDir || qbSnapshotDir()
 }
 
 function resolveSnapshotDir(): string {
-  return join(process.cwd(), snapshotDirLabel())
+  const label = snapshotDirLabel()
+  // `snapshotDirLabel()` is whatever was handed to `setConfig`, which is already
+  // relativised for the library's own `join`. Resolving it the same way keeps
+  // reads and writes on the same directory even when it lives outside the
+  // release, which is the point of DB_SNAPSHOT_PATH (stacksjs/stacks#2351).
+  return isAbsolute(label) ? label : resolve(process.cwd(), label)
 }
 
 function snapshotPathFor(dialect: string): string {

--- a/storage/framework/core/database/src/utils.ts
+++ b/storage/framework/core/database/src/utils.ts
@@ -19,7 +19,7 @@ import type { FrameworkSchema } from './framework-schema'
 import type { PoolConfig, ReadPolicyConfig, ReplicaConfig } from './driver-config'
 import { getConnectionDefaults } from './defaults'
 import { isMysqlWire, isVitessSharded, toQueryBuilderDialect } from './dialect'
-import { relativeMigrationDirectory, resolveMigrationDirectory } from './migration-path'
+import { relativeMigrationDirectory, resolveMigrationDirectory, snapshotDirForQueryBuilder } from './migration-path'
 import { contextInTransaction, markContextWrote, resolveReplicaConnection, selectReplica, shouldRouteToReplica, withTransactionContext } from './replicas'
 import { aggregateFunctions } from './types'
 
@@ -266,6 +266,18 @@ function getDbConfig(): { database: string, username?: string, password?: string
 export const QB_SNAPSHOT_DIR = 'storage/framework/database'
 
 /**
+ * The snapshot directory to hand to `setConfig`, resolved at call time.
+ *
+ * Read fresh on every call rather than frozen into a module constant: on a
+ * Capistrano-style deploy `DB_SNAPSHOT_PATH` points at a shared directory that
+ * outlives the release, and a value captured at import time would miss an env
+ * loaded after this module (stacksjs/stacks#2351).
+ */
+export function qbSnapshotDir(): string {
+  return snapshotDirForQueryBuilder()
+}
+
+/**
  * Process-wide query-builder soft-delete filtering must stay disabled.
  *
  * The raw query builder has no model definition, so it cannot know whether
@@ -398,8 +410,8 @@ function updateQueryBuilderConfig(): void {
     // wholesale, so omitting this here silently reverts the snapshot to the
     // library default and writes a second copy to `.qb` in the project root -
     // the exact directory moving it was meant to remove.
-    snapshotDir: QB_SNAPSHOT_DIR,
-    migrationDir: relativeMigrationDirectory(resolveMigrationDirectory(toQueryBuilderDialect(dialect), { snapshotDir: QB_SNAPSHOT_DIR })),
+    snapshotDir: qbSnapshotDir(),
+    migrationDir: relativeMigrationDirectory(resolveMigrationDirectory(toQueryBuilderDialect(dialect), { snapshotDir: qbSnapshotDir() })),
     timestamps: {
       createdAt: 'created_at',
       updatedAt: 'updated_at',

--- a/storage/framework/core/database/tests/snapshot-directory.test.ts
+++ b/storage/framework/core/database/tests/snapshot-directory.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { join } from 'node:path'
+import process from 'node:process'
+import { resolveSnapshotDirectory, snapshotDirectoryIsShared, snapshotDirForQueryBuilder } from '../src/migration-path'
+
+const ORIGINAL = process.env.DB_SNAPSHOT_PATH
+
+afterEach(() => {
+  if (ORIGINAL === undefined)
+    delete process.env.DB_SNAPSHOT_PATH
+  else
+    process.env.DB_SNAPSHOT_PATH = ORIGINAL
+})
+
+// stacksjs/stacks#2351 — the model snapshot is the migration baseline. When it
+// lives inside the release directory a Capistrano-style deploy never sees one,
+// so the differ re-derives from scratch and proposes the same change forever.
+describe('snapshot directory resolution', () => {
+  const cwd = '/srv/app/releases/abc123'
+
+  it('defaults to the in-project path', () => {
+    delete process.env.DB_SNAPSHOT_PATH
+    expect(resolveSnapshotDirectory(cwd)).toBe(join(cwd, 'storage/framework/database'))
+    expect(snapshotDirectoryIsShared()).toBe(false)
+  })
+
+  it('resolves a relative override against the project root', () => {
+    process.env.DB_SNAPSHOT_PATH = '../../shared/db'
+    expect(resolveSnapshotDirectory(cwd)).toBe('/srv/app/shared/db')
+    expect(snapshotDirectoryIsShared()).toBe(true)
+  })
+
+  it('honours an absolute override instead of nesting it under the release', () => {
+    process.env.DB_SNAPSHOT_PATH = '/srv/app/shared/db'
+    expect(resolveSnapshotDirectory(cwd)).toBe('/srv/app/shared/db')
+    // The bug this guards: join(cwd, '/srv/app/shared/db') would be
+    // '/srv/app/releases/abc123/srv/app/shared/db', back inside the release.
+    expect(resolveSnapshotDirectory(cwd).startsWith(cwd)).toBe(false)
+  })
+
+  // bun-query-builder resolves its own snapshotDir as join(workspaceRoot, value),
+  // and join ignores nothing about an absolute second segment. Handing it an
+  // absolute path writes back inside the release, so the value it receives must
+  // be relative and must round-trip to the directory the operator asked for.
+  it('hands the query builder a value its own join resolves back to the same directory', () => {
+    for (const configured of ['/srv/app/shared/db', '../../shared/db', 'storage/framework/database']) {
+      process.env.DB_SNAPSHOT_PATH = configured
+      const forQb = snapshotDirForQueryBuilder(cwd)
+      expect(forQb.startsWith('/')).toBe(false)
+      expect(join(cwd, forQb)).toBe(resolveSnapshotDirectory(cwd))
+    }
+  })
+
+  it('never returns an empty string for the query builder', () => {
+    process.env.DB_SNAPSHOT_PATH = cwd
+    expect(snapshotDirForQueryBuilder(cwd)).toBe('.')
+    expect(join(cwd, snapshotDirForQueryBuilder(cwd))).toBe(cwd)
+  })
+})


### PR DESCRIPTION
Fixes the first defect in #2351, and the message half of the second.

## 1. The baseline was release-local

`buddy migrate` diffs models against `<snapshotDir>/model-snapshot.<dialect>.json`. That path was a hardcoded relative literal:

```ts
export const QB_SNAPSHOT_DIR = 'storage/framework/database'
function resolveSnapshotDir(): string {
  return join(process.cwd(), snapshotDirLabel())
}
```

There was no override, so on a Capistrano-style layout it always resolved inside `releases/<sha>`. Every deploy is a new directory, so the snapshot was absent every time, the differ re-derived the baseline from scratch, and the same change was proposed forever. Applying it fixed exactly one release, which is what the timeline in the issue shows: the database never changed between the two diffs, only the release directory did.

`DB_SNAPSHOT_PATH` now points it at a directory that outlives the release, mirroring the existing `DB_MIGRATIONS_PATH`:

```bash
DB_SNAPSHOT_PATH=/srv/app/shared/db      # absolute
DB_SNAPSHOT_PATH=../../shared/db          # or relative to the release
```

### The part that would have silently not worked

bun-query-builder resolves its own `snapshotDir` as `join(workspaceRoot, value)`, and `join` does not honour an absolute second segment:

```
join('/srv/app/releases/abc123', '/srv/app/shared/db')
  === '/srv/app/releases/abc123/srv/app/shared/db'
```

So an absolute `DB_SNAPSHOT_PATH` passed down verbatim would have written the snapshot back inside the release: the config would look right, the operator would believe it was shared, and the symptom would not change. The value handed to the library is relativised first, and a test round-trips it back through that same `join` for the absolute, the `../`, and the default case.

`resolveSnapshotDir()` uses `resolve()` rather than `join()` for the same reason on the read side.

Read fresh per call rather than frozen into a module constant, so an env loaded after this module still counts.

## 2. The message asserted a cause it never computed

```ts
case 'rebuild_table':
  return `rebuild table "${op.table}" (type/constraint change)`
```

Nothing in that path compares types or constraints. SQLite rebuilds a table for several reasons (a changed column type, a changed foreign key, the removal of a constrained column) and the label named one of them as fact. The issue is precise about the cost: the generated `CREATE TABLE` matched `sqlite_master` byte for byte while the output insisted the types had changed, so the search went looking for a difference that was not there.

It now names the operation and points at the SQL, which is the thing that can actually be compared.

## 3. A missing baseline now says so

A destructive change proposed with no snapshot on disk prints the directory that was searched, and whether `DB_SNAPSHOT_PATH` is what put it there:

```
No model snapshot in /srv/app/releases/abc123/storage/framework/database, so this
change was derived without a baseline and will be proposed again on the next run.
If each deploy runs from a new directory, point DB_SNAPSHOT_PATH at a shared one
that survives the release.
```

Nothing named that file before, which is why this read as a schema tool that could not converge rather than a baseline that was never there.

## What this does not fix

**The false rebuild itself (issue section 2).** The differ still decides a rebuild is needed, and still marks it destructive, for a table that renders identically. In bun-query-builder:

```js
const needsRebuild = modifiedCols.length > 0 || fkChangedCols.length > 0 || removedCols.some(...)
const typeChanged = modifiedCols.some(n => prevCols[n].type !== currCols[n].type)
operations.push({ kind: 'rebuild_table', destructive: removedCols.length > 0 || typeChanged, ... })
```

`destructive` requires `typeChanged`, so the comparison did believe a type changed. With no snapshot the `prev` side is re-derived rather than read back, and SQLite's renderer maps several distinct declared types onto the same storage class, so a column can compare unequal and still render identically. That is consistent with everything in the report, and it is a bun-query-builder change, not one here. Giving it a real baseline removes the trigger in practice; the underlying comparison should still be tightened upstream.

**The duplicate index names (issue section 3).** `qualifiedIndexName` in bun-query-builder 0.2.45 already guards this:

```js
const qualified = indexName.startsWith(prefix) ? indexName : `${prefix}${indexName}`
```

So `projects_projects_ingest_key_unique` was written by an older version and is legacy drift sitting in the live database, not something the current generator would emit. Nothing cleans it up or ignores it, which is worth its own issue; `buddy doctor`'s unique-index audit already matches by column set rather than name for exactly this reason.

## Verification

- New `snapshot-directory.test.ts`, 5 tests, including the `join` round-trip that pins the absolute-path trap
- `bun test ./storage/framework/core/database/tests/` 808 pass, 0 fail
- `bun test ./storage/framework/core/buddy/tests/` 495 pass, 0 fail
- `runLint` (SDK) clean on every touched file
- `bun run typecheck` unchanged from main; no error in any touched file
