### PR TITLE
fix(payments): make constructEvent async, so the obvious export is the working one (#2355)

### DIFF
--- a/docs/bootcamp/saas/payments.md
+++ b/docs/bootcamp/saas/payments.md
@@ -224,7 +224,7 @@ router.post('/webhooks/stripe', webhookHandler)
 ```ts
 // app/Events/StripeWebhook.ts
 import type Stripe from 'stripe'
-import { stripe } from '@stacksjs/payments'
+import { constructEvent } from '@stacksjs/payments'
 
 export async function handleWebhook(request: Request) {
   const sig = request.headers.get('stripe-signature')
@@ -233,13 +233,17 @@ export async function handleWebhook(request: Request) {
   let event: Stripe.Event
 
   try {
-    event = stripe.webhooks.constructEvent(
+    // Always await this. Verification is async on every runtime, because Bun
+    // resolves Stripe's crypto provider to WebCrypto, which has no sync path.
+    event = await constructEvent(
       body,
       sig!,
       process.env.STRIPE_WEBHOOK_SECRET!
     )
   } catch (err) {
-    console.error('Webhook signature verification failed')
+    // Log the real reason. A generic message here is how a verification bug
+    // hides: every delivery fails the same way and the cause never reaches you.
+    console.error('Webhook signature verification failed:', err)
     return new Response('Webhook Error', { status: 400 })
   }
 

--- a/storage/framework/core/payments/src/billable/webhook.ts
+++ b/storage/framework/core/payments/src/billable/webhook.ts
@@ -66,33 +66,32 @@ export function registerWebhookHandlers(handlerMap: Record<WebhookEventType, Web
 /**
  * Construct and verify a webhook event from the raw request.
  *
+ * Async on every runtime, deliberately. Bun resolves the Stripe SDK's crypto
+ * provider to WebCrypto's `SubtleCrypto`, which is async-only, so the SDK's
+ * synchronous `constructEvent` throws "SubtleCryptoProvider cannot be used in a
+ * synchronous context" there. This package used to wrap that sync call under
+ * this name and offer the working one as `constructEventAsync`, which made the
+ * shorter and more obvious export the one that could never work on the
+ * framework's own default runtime.
+ *
+ * It failed where it hurt most. Verification lives inside the caller's
+ * try/catch, so the throw surfaced as a 401 on every genuine Stripe delivery:
+ * Stripe retried, every retry 401'd, and local subscription state silently
+ * stopped tracking reality. Tests that call the handler directly rather than
+ * POSTing a signed body never touch verification at all, so nothing caught it
+ * (stacksjs/stacks#2355).
+ *
+ * There is one name now, and it works on Node and Bun alike. A caller that
+ * genuinely needs the synchronous path on Node can still reach
+ * `stripe.webhooks.constructEvent` through the exported client.
+ *
  * `tolerance` (in seconds) controls how much clock skew between Stripe and
  * this server is acceptable before signatures are rejected. Stripe's SDK
  * default is 300s; tightening this is recommended in production but the
  * previous code dropped the value entirely, so a configured tolerance was
  * silently ignored.
  */
-export function constructEvent(
-  payload: string | Buffer,
-  signature: string,
-  secret: string,
-  tolerance?: number,
-): Stripe.Event {
-  if (tolerance != null && Number.isFinite(tolerance) && tolerance > 0) {
-    return stripe.webhooks.constructEvent(payload, signature, secret, tolerance)
-  }
-  return stripe.webhooks.constructEvent(payload, signature, secret)
-}
-
-/**
- * Async variant of {@link constructEvent}. Some runtimes (notably Bun) resolve
- * the Stripe SDK's crypto provider to WebCrypto's `SubtleCrypto`, which is
- * async-only — the synchronous `constructEvent` then throws
- * "SubtleCryptoProvider cannot be used in a synchronous context". Verifying via
- * `constructEventAsync` works across Node and Bun, so webhook processing uses
- * this path.
- */
-export async function constructEventAsync(
+export async function constructEvent(
   payload: string | Buffer,
   signature: string,
   secret: string,
@@ -102,6 +101,22 @@ export async function constructEventAsync(
     return await stripe.webhooks.constructEventAsync(payload, signature, secret, tolerance)
   }
   return await stripe.webhooks.constructEventAsync(payload, signature, secret)
+}
+
+/**
+ * Alias of {@link constructEvent}, kept so callers that adopted this name while
+ * `constructEvent` could not work on Bun keep compiling unchanged.
+ *
+ * @deprecated Use {@link constructEvent}. It is async on every runtime as of
+ * stacksjs/stacks#2355, so the two are the same function and one name is enough.
+ */
+export async function constructEventAsync(
+  payload: string | Buffer,
+  signature: string,
+  secret: string,
+  tolerance?: number,
+): Promise<Stripe.Event> {
+  return await constructEvent(payload, signature, secret, tolerance)
 }
 
 /**

--- a/storage/framework/core/payments/tests/webhook-construct-event.test.ts
+++ b/storage/framework/core/payments/tests/webhook-construct-event.test.ts
@@ -1,0 +1,106 @@
+import { createHmac } from 'node:crypto'
+import { beforeAll, describe, expect, it } from 'bun:test'
+import { services } from '@stacksjs/config'
+
+// stacksjs/stacks#2355 — `constructEvent` used to wrap the Stripe SDK's
+// synchronous verification, which cannot run under Bun's resolution of the SDK:
+// the `worker` export condition ships a crypto provider backed by WebCrypto's
+// SubtleCrypto, which is async-only, so the sync call throws
+// "SubtleCryptoProvider cannot be used in a synchronous context".
+//
+// It surfaced as a 401 on every genuine Stripe delivery, because verification
+// runs inside the caller's try/catch. Stripe retried, every retry 401'd, and
+// local subscription state silently stopped tracking reality.
+//
+// Two things hid it, and both are why these tests verify real signatures rather
+// than assert shapes. Tests that call handlers directly never verify at all.
+// And a vendored checkout resolves `stripe` to the `node` build, whose provider
+// has a sync path, so even a verifying test can pass locally against a build
+// the deployed app never loads. Asserting "the sync path throws" would pin the
+// test runner's resolution, not the product; asserting that our export is async
+// and verifies correctly holds either way.
+
+const SECRET = 'whsec_test_2355'
+
+function sign(body: string, secret = SECRET, at = Math.floor(Date.now() / 1000)): string {
+  const mac = createHmac('sha256', secret).update(`${at}.${body}`).digest('hex')
+  return `t=${at},v1=${mac}`
+}
+
+function eventBody(type = 'charge.succeeded'): string {
+  return JSON.stringify({ id: 'evt_2355', object: 'event', type, data: { object: {} } })
+}
+
+let constructEvent: typeof import('../src/billable/webhook').constructEvent
+let constructEventAsync: typeof import('../src/billable/webhook').constructEventAsync
+let manageWebhook: typeof import('../src/billable/webhook').manageWebhook
+
+beforeAll(async () => {
+  // The Stripe client is a lazy proxy that demands a key on first property
+  // access. Verification never calls the API, so any well-formed test key does.
+  ;(services as any).stripe = { ...(services as any).stripe, secretKey: 'sk_test_2355' }
+  const mod = await import('../src/billable/webhook')
+  constructEvent = mod.constructEvent
+  constructEventAsync = mod.constructEventAsync
+  manageWebhook = mod.manageWebhook
+})
+
+describe('constructEvent', () => {
+  it('is async, so it can never take the sync-only crypto path', () => {
+    expect(constructEvent.constructor.name).toBe('AsyncFunction')
+    expect(constructEventAsync.constructor.name).toBe('AsyncFunction')
+  })
+
+  it('is what the manageWebhook facade exposes', () => {
+    expect(manageWebhook.constructEvent).toBe(constructEvent)
+    expect(manageWebhook.constructEventAsync).toBe(constructEventAsync)
+  })
+
+  it('verifies a correctly signed payload', async () => {
+    const body = eventBody()
+    const event = await constructEvent(body, sign(body), SECRET)
+    expect(event.id).toBe('evt_2355')
+    expect(event.type).toBe('charge.succeeded')
+  })
+
+  it('rejects a payload that was altered after signing', async () => {
+    const body = eventBody()
+    const header = sign(body)
+    await expect(constructEvent(body.replace('succeeded', 'failed'), header, SECRET)).rejects.toThrow()
+  })
+
+  it('rejects a signature made with a different secret', async () => {
+    const body = eventBody()
+    await expect(constructEvent(body, sign(body, 'whsec_wrong'), SECRET)).rejects.toThrow()
+  })
+
+  it('rejects rather than throwing synchronously, so an unawaited call cannot escape a try/catch', () => {
+    let threwSynchronously = false
+    try {
+      void constructEvent('{}', 'bad', SECRET).catch(() => undefined)
+    }
+    catch {
+      threwSynchronously = true
+    }
+    expect(threwSynchronously).toBe(false)
+  })
+
+  // The docblock notes a configured tolerance used to be dropped on the floor.
+  it('honours a tolerance, rejecting a signature older than it allows', async () => {
+    const body = eventBody()
+    const old = Math.floor(Date.now() / 1000) - 600
+    await expect(constructEvent(body, sign(body, SECRET, old), SECRET, 60)).rejects.toThrow()
+    // Same stale signature passes when the tolerance is wide enough, proving
+    // the rejection above is the tolerance and not the signature.
+    const event = await constructEvent(body, sign(body, SECRET, old), SECRET, 3600)
+    expect(event.id).toBe('evt_2355')
+  })
+})
+
+describe('constructEventAsync', () => {
+  it('still verifies, so callers on the old name keep working', async () => {
+    const body = eventBody()
+    const event = await constructEventAsync(body, sign(body), SECRET)
+    expect(event.id).toBe('evt_2355')
+  })
+})


### PR DESCRIPTION
Fixes #2355 with suggestion 1, which also removes the need for 2 and 3: there is no broken path left to throw a pointed error from, and only one name to reach for.

## The cause is narrower than "Bun is async-only"

Bun does not have one Stripe build. The SDK ships several, and which one loads decides whether the sync API works at all:

```
node_modules/stripe/cjs/stripe.cjs.worker.js   → SubtleCrypto provider, no sync path
pantry/stripe/cjs/stripe.cjs.node.js           → Node crypto provider, sync works
```

Bun resolves the `worker` condition, so a deployed app gets a provider with no synchronous path and `constructEvent` throws every time. That matches the report exactly.

It also explains why this was invisible, which the issue notes but attributes only to handler-level tests. A vendored checkout resolves `stripe` to the `node` build, so **even a test that verifies a real signature passes locally against a build the deployed app never loads.** Verified both ways in this repo:

```
require.resolve('stripe') from repo root          → node_modules/.../stripe.cjs.worker.js   → sync THROWS
require.resolve('stripe') from the payments pkg   → pantry/.../stripe.cjs.node.js           → sync OK
```

That is why the tests here verify signatures through the exported function rather than asserting that the sync call throws. An assertion on the throw would pin the test runner's module resolution, not the product, and would flip depending on whether pantry is present.

## The change

`constructEvent` is now async on every runtime and delegates to the SDK's async verification:

```ts
export async function constructEvent(
  payload: string | Buffer,
  signature: string,
  secret: string,
  tolerance?: number,
): Promise<Stripe.Event>
```

`constructEventAsync` is kept as a `@deprecated` alias so callers that adopted it while `constructEvent` could not work keep compiling unchanged. Nothing in the framework called the sync variant, so the only affected code is app-level.

**This is a breaking signature change**, deliberately a typechecked one rather than a silent one: a caller that did `const event: Stripe.Event = constructEvent(...)` now gets `Promise<Stripe.Event>` and fails to compile. A caller who needs the raw synchronous path on Node can still reach `stripe.webhooks.constructEvent` through the exported client.

## The docs were teaching the bug

`docs/bootcamp/saas/payments.md` demonstrated the failing pattern verbatim: the raw sync SDK call, wrapped in a catch that logged `'Webhook signature verification failed'` with no `err`. That is the same generic 401 that kept the real message from reaching you. It now awaits the package export and logs the error.

## Tests

New `webhook-construct-event.test.ts`, 8 tests, driving the real export end to end with HMAC-signed payloads (the lazy Stripe proxy is given a test key; verification never calls the API):

- `constructEvent` and `constructEventAsync` are both `AsyncFunction` — the direct regression guard against a revert to sync
- the `manageWebhook` facade exposes the same functions
- a correctly signed payload verifies
- a payload altered after signing is rejected
- a signature made with a different secret is rejected
- an unawaited call rejects rather than throwing synchronously
- a stale signature is rejected under a 60s tolerance and accepted under 3600s, so the rejection is provably the tolerance and not the signature. That one also covers the `tolerance` parameter the docblock records as previously dropped, which had no test at all.

## Verification

- `bun test ./storage/framework/core/payments/tests/` 130 pass, 0 fail
- `runLint` (SDK) clean on every touched file
- `bun run typecheck` green in CI

A local `bun run typecheck` reports 14 errors here, including an API-version mismatch in `drivers/stripe.ts`. Those are the same resolution artifact described above, not a repo baseline: `pantry/` is gitignored and absent from CI, and its stripe is 21.0.1 against the declared 22.3.2, so the pinned `LatestApiVersion` does not match the types that get resolved locally. CI has no pantry and is green. Worth knowing before treating a local error count as the baseline.
