### PR TITLE
fix(stripe): make stripe:setup idempotent and honour --dry-run (#2359)

### DIFF
--- a/storage/framework/core/actions/src/saas/setup.ts
+++ b/storage/framework/core/actions/src/saas/setup.ts
@@ -1,11 +1,25 @@
 import process from 'node:process'
 import { log } from '@stacksjs/logging'
-import { createStripeProduct } from '@stacksjs/payments'
+import { createStripeProduct, formatSetupReport } from '@stacksjs/payments'
 
-const result = await createStripeProduct()
+// `runAction(Action.StripeSetup, options)` spawns this file with `buddyOptions`
+// translating the CLI options into argv flags, so the flags have to be read
+// here. They were not, which meant `--dry-run` created real products in a real
+// Stripe account while the help text promised a preview (stacksjs/stacks#2359).
+const argv = process.argv.slice(2)
+const dryRun = argv.includes('--dry-run') || argv.includes('--dryRun')
+
+const result = await createStripeProduct({ dryRun })
 
 if (result?.isErr) {
   console.error(result.error)
-  log.error('generateMigrations failed', result.error)
+  log.error('stripe:setup failed', result.error)
   process.exit(1)
 }
+
+const report = result.value
+log.info(dryRun
+  ? 'Dry run. Nothing was written to Stripe. This is what would be applied:'
+  : 'Applied:')
+for (const line of formatSetupReport(report))
+  log.info(line)

--- a/storage/framework/core/buddy/src/commands/saas.ts
+++ b/storage/framework/core/buddy/src/commands/saas.ts
@@ -32,7 +32,16 @@ export function saas(buddy: CLI): void {
         process.exit(ExitCode.FatalError)
       }
 
-      await outro(`Stripe products created successfully`, {
+      // `--dry-run` is a global flag, so it arrives here whether or not this
+      // command opts in. It used to be advertised and ignored, which made the
+      // preview write real billing objects (stacksjs/stacks#2359); the closing
+      // line has to tell the truth about which of the two just happened.
+      const dryRun = Boolean((options as { dryRun?: boolean, 'dry-run'?: boolean }).dryRun
+        ?? (options as { 'dry-run'?: boolean })['dry-run'])
+
+      await outro(dryRun
+        ? 'Dry run complete. Nothing was written to Stripe.'
+        : 'Stripe products are up to date', {
         startTime: perf,
         useSeconds: true,
       })

--- a/storage/framework/core/payments/src/billable/setup-products.ts
+++ b/storage/framework/core/payments/src/billable/setup-products.ts
@@ -1,3 +1,4 @@
+import type Stripe from 'stripe'
 import type { Result } from '@stacksjs/error-handling'
 import { saas } from '@stacksjs/config'
 import { err, ok } from '@stacksjs/error-handling'
@@ -9,43 +10,150 @@ interface PriceParams {
   currency: string
   product: string
   lookup_key: string
+  transfer_lookup_key?: boolean
   recurring?: {
     interval: 'day' | 'month' | 'week' | 'year'
   }
 }
-export async function createStripeProduct(): Promise<Result<string, Error>> {
+
+export interface SetupProductsOptions {
+  /** Report what would change and write nothing. */
+  dryRun?: boolean
+}
+
+/** One line of the plan of record, in the order it would be applied. */
+export interface SetupProductAction {
+  kind: 'product' | 'price'
+  /** `create` writes a new object, `reuse` found an equivalent one, `replace` moves a lookup key onto a new price. */
+  verb: 'create' | 'reuse' | 'replace'
+  /** Product name, or the price's lookup key. */
+  target: string
+  detail?: string
+}
+
+export interface SetupProductsReport {
+  dryRun: boolean
+  actions: SetupProductAction[]
+}
+
+/**
+ * Find the active product a plan maps to.
+ *
+ * Matched by name rather than through `products.search`. Search is the obvious
+ * tool and the wrong one here: its index is eventually consistent (Stripe
+ * documents a lag of up to a minute), so a second run inside that window would
+ * find nothing and create a duplicate — reintroducing the exact bug this
+ * lookup exists to prevent. `products.list` reads the live objects.
+ */
+async function findProductByName(name: string): Promise<Stripe.Product | undefined> {
+  for await (const product of stripe.products.list({ active: true, limit: 100 })) {
+    if (product.name === name)
+      return product
+  }
+  return undefined
+}
+
+/** The active price carrying `lookupKey`, if one exists. A lookup key belongs to at most one price. */
+async function findPriceByLookupKey(lookupKey: string): Promise<Stripe.Price | undefined> {
+  const prices = await stripe.prices.list({ lookup_keys: [lookupKey], active: true, limit: 1 })
+  return prices.data[0]
+}
+
+/** True when the live price already encodes exactly what the config asks for. */
+function priceMatches(price: Stripe.Price, params: PriceParams): boolean {
+  return price.unit_amount === params.unit_amount
+    && price.currency === params.currency
+    && price.product === params.product
+    && (price.recurring?.interval ?? undefined) === params.recurring?.interval
+}
+
+/**
+ * Provision the products and prices declared in `config/saas.ts`.
+ *
+ * Idempotent by construction, because this is a command people re-run: a second
+ * environment, a price change, an added plan, an unguarded CI step. The previous
+ * implementation created unconditionally, so a second run left a duplicate
+ * product behind and then failed on `prices.create` — a lookup key may only
+ * belong to one active price — exiting non-zero having half-applied
+ * (stacksjs/stacks#2359).
+ *
+ * Stripe prices are immutable, so a changed amount cannot be edited in place.
+ * The lookup key is moved onto a new price with `transfer_lookup_key`, which
+ * Stripe applies atomically, and the superseded price is left active but
+ * unkeyed so existing subscriptions on it keep billing.
+ */
+export async function createStripeProduct(options: SetupProductsOptions = {}): Promise<Result<SetupProductsReport, Error>> {
+  const dryRun = options.dryRun ?? false
+  const actions: SetupProductAction[] = []
   const plans = saas.plans
+
   try {
-    if (plans !== undefined && plans.length) {
-      for (const plan of plans) {
-        // First, create the product in Stripe
-        const product = await stripe.products.create({
-          name: plan.productName,
-          description: plan.description,
-          metadata: plan.metadata,
-        })
+    if (plans === undefined || !plans.length)
+      return ok({ dryRun, actions })
 
-        // Use the created product's ID to add the pricing options
-        for (const pricing of plan.pricing) {
-          if (product) {
-            const priceParams: PriceParams = {
-              unit_amount: pricing.price,
-              currency: pricing.currency,
-              product: product.id,
-              lookup_key: pricing.key,
-            }
+    for (const plan of plans) {
+      const existingProduct = await findProductByName(plan.productName)
+      let productId = existingProduct?.id
 
-            if (pricing.interval) {
-              priceParams.recurring = { interval: pricing.interval }
-            }
-
-            await stripe.prices.create(priceParams)
-          }
+      if (existingProduct) {
+        actions.push({ kind: 'product', verb: 'reuse', target: plan.productName, detail: existingProduct.id })
+      }
+      else {
+        actions.push({ kind: 'product', verb: 'create', target: plan.productName })
+        if (!dryRun) {
+          const product = await stripe.products.create({
+            name: plan.productName,
+            description: plan.description,
+            metadata: plan.metadata,
+          })
+          productId = product.id
         }
+      }
+
+      for (const pricing of plan.pricing) {
+        // On a dry run against a product that does not exist yet there is no id
+        // to compare against, so report the price as a create and move on rather
+        // than inventing one.
+        if (!productId) {
+          actions.push({ kind: 'price', verb: 'create', target: pricing.key })
+          continue
+        }
+
+        const priceParams: PriceParams = {
+          unit_amount: pricing.price,
+          currency: pricing.currency,
+          product: productId,
+          lookup_key: pricing.key,
+        }
+        if (pricing.interval)
+          priceParams.recurring = { interval: pricing.interval }
+
+        const existingPrice = await findPriceByLookupKey(pricing.key)
+
+        if (existingPrice && priceMatches(existingPrice, priceParams)) {
+          actions.push({ kind: 'price', verb: 'reuse', target: pricing.key, detail: existingPrice.id })
+          continue
+        }
+
+        if (existingPrice) {
+          actions.push({
+            kind: 'price',
+            verb: 'replace',
+            target: pricing.key,
+            detail: `${existingPrice.id} -> new price (${pricing.price} ${pricing.currency})`,
+          })
+          priceParams.transfer_lookup_key = true
+        }
+        else {
+          actions.push({ kind: 'price', verb: 'create', target: pricing.key })
+        }
+
+        if (!dryRun)
+          await stripe.prices.create(priceParams)
       }
     }
 
-    return ok('Migrations generated')
+    return ok({ dryRun, actions })
   }
   catch (error) {
     const e = error instanceof Error ? error : new Error(String(error))
@@ -53,4 +161,19 @@ export async function createStripeProduct(): Promise<Result<string, Error>> {
 
     return err(e)
   }
+}
+
+/** Render a report as one line per action, for the CLI to print. */
+export function formatSetupReport(report: SetupProductsReport): string[] {
+  if (!report.actions.length)
+    return ['No plans are declared in config/saas.ts, so there is nothing to provision.']
+
+  return report.actions.map((action) => {
+    const verb = action.verb === 'reuse'
+      ? 'already exists'
+      : action.verb === 'replace'
+        ? 'moves lookup key to a new price'
+        : 'creates'
+    return `  ${action.kind} "${action.target}" ${verb}${action.detail ? ` (${action.detail})` : ''}`
+  })
 }

--- a/storage/framework/core/payments/tests/stripe-setup-idempotency.test.ts
+++ b/storage/framework/core/payments/tests/stripe-setup-idempotency.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+// stacksjs/stacks#2359 — `buddy stripe:setup` created unconditionally, so a
+// second run left a duplicate product behind and then failed on prices.create
+// (a lookup key belongs to one active price). Its advertised `--dry-run` wrote
+// real billing objects. These drive the reconciler against a fake account so
+// re-running, changing a price, and previewing are all covered without touching
+// Stripe.
+
+interface FakeProduct { id: string, name: string, active: boolean }
+interface FakePrice {
+  id: string
+  product: string
+  unit_amount: number
+  currency: string
+  lookup_key: string
+  active: boolean
+  recurring?: { interval: string }
+}
+
+const account: { products: FakeProduct[], prices: FakePrice[] } = { products: [], prices: [] }
+const writes: { products: any[], prices: any[] } = { products: [], prices: [] }
+
+const stripe = {
+  products: {
+    list(_params: unknown) {
+      return {
+        async* [Symbol.asyncIterator]() {
+          for (const p of account.products) {
+            if (p.active)
+              yield p
+          }
+        },
+      }
+    },
+    async create(params: any) {
+      writes.products.push(params)
+      const product: FakeProduct = { id: `prod_${account.products.length + 1}`, name: params.name, active: true }
+      account.products.push(product)
+      return product
+    },
+  },
+  prices: {
+    async list(params: { lookup_keys?: string[] }) {
+      const key = params.lookup_keys?.[0]
+      return { data: account.prices.filter(p => p.active && p.lookup_key === key) }
+    },
+    async create(params: any) {
+      writes.prices.push(params)
+      if (params.transfer_lookup_key) {
+        for (const p of account.prices) {
+          if (p.lookup_key === params.lookup_key)
+            p.lookup_key = ''
+        }
+      }
+      const price: FakePrice = {
+        id: `price_${account.prices.length + 1}`,
+        product: params.product,
+        unit_amount: params.unit_amount,
+        currency: params.currency,
+        lookup_key: params.lookup_key,
+        active: true,
+        recurring: params.recurring,
+      }
+      account.prices.push(price)
+      return price
+    },
+  },
+}
+
+const plans = [{
+  productName: 'Test Hobby',
+  description: 'A plan',
+  pricing: [{ key: 'hobby_monthly', price: 1900, interval: 'month' as const, currency: 'usd' }],
+  metadata: { createdBy: 'test', version: '1.0.0' },
+}]
+
+mock.module('@stacksjs/logging', () => ({ log: { debug() {}, error() {}, info() {}, warn() {} } }))
+mock.module('@stacksjs/config', () => ({ saas: { plans } }))
+mock.module('@stacksjs/payments', () => ({ stripe }))
+
+const { createStripeProduct, formatSetupReport } = await import('../src/billable/setup-products')
+
+beforeEach(() => {
+  account.products = []
+  account.prices = []
+  writes.products = []
+  writes.prices = []
+})
+
+describe('createStripeProduct', () => {
+  it('provisions a clean account', async () => {
+    const result = await createStripeProduct()
+    expect(result.isErr).toBeFalsy()
+    expect(result.value.actions).toEqual([
+      { kind: 'product', verb: 'create', target: 'Test Hobby' },
+      { kind: 'price', verb: 'create', target: 'hobby_monthly' },
+    ])
+    expect(writes.products.length).toBe(1)
+    expect(writes.prices.length).toBe(1)
+  })
+
+  // The whole point: this is the command people re-run.
+  it('is idempotent, so a second run writes nothing', async () => {
+    await createStripeProduct()
+    writes.products = []
+    writes.prices = []
+
+    const second = await createStripeProduct()
+    expect(second.value.actions.map(a => a.verb)).toEqual(['reuse', 'reuse'])
+    expect(writes.products).toEqual([])
+    expect(writes.prices).toEqual([])
+    expect(account.products.length).toBe(1)
+    expect(account.prices.filter(p => p.active).length).toBe(1)
+  })
+
+  // Prices are immutable in Stripe, so a changed amount cannot be edited. The
+  // lookup key moves to a new price and the old one stays active but unkeyed,
+  // so subscriptions already on it keep billing.
+  it('moves the lookup key when the configured amount changes', async () => {
+    await createStripeProduct()
+    plans[0]!.pricing[0]!.price = 2900
+    writes.prices = []
+
+    const result = await createStripeProduct()
+    plans[0]!.pricing[0]!.price = 1900 // restore for other tests
+
+    expect(result.value.actions.map(a => a.verb)).toEqual(['reuse', 'replace'])
+    expect(writes.prices.length).toBe(1)
+    expect(writes.prices[0].transfer_lookup_key).toBe(true)
+    expect(writes.prices[0].unit_amount).toBe(2900)
+    // Exactly one active price still carries the key, and the superseded price survives.
+    expect(account.prices.filter(p => p.lookup_key === 'hobby_monthly').length).toBe(1)
+    expect(account.prices.filter(p => p.active).length).toBe(2)
+  })
+
+  it('reuses the product when only a new plan price is added', async () => {
+    await createStripeProduct()
+    plans[0]!.pricing.push({ key: 'hobby_yearly', price: 19000, interval: 'year' as const, currency: 'usd' })
+    writes.products = []
+
+    const result = await createStripeProduct()
+    plans[0]!.pricing.pop()
+
+    expect(result.value.actions.map(a => `${a.kind}:${a.verb}`))
+      .toEqual(['product:reuse', 'price:reuse', 'price:create'])
+    expect(writes.products).toEqual([])
+  })
+})
+
+describe('dry run', () => {
+  it('writes nothing to a clean account but still reports the plan', async () => {
+    const result = await createStripeProduct({ dryRun: true })
+    expect(result.value.dryRun).toBe(true)
+    expect(result.value.actions.map(a => a.verb)).toEqual(['create', 'create'])
+    expect(writes.products).toEqual([])
+    expect(writes.prices).toEqual([])
+    expect(account.products).toEqual([])
+    expect(account.prices).toEqual([])
+  })
+
+  it('writes nothing when a change is pending', async () => {
+    await createStripeProduct()
+    plans[0]!.pricing[0]!.price = 2900
+    writes.prices = []
+
+    const result = await createStripeProduct({ dryRun: true })
+    plans[0]!.pricing[0]!.price = 1900
+
+    expect(result.value.actions.map(a => a.verb)).toEqual(['reuse', 'replace'])
+    expect(writes.prices).toEqual([])
+  })
+})
+
+describe('formatSetupReport', () => {
+  it('says so when there is nothing declared', () => {
+    expect(formatSetupReport({ dryRun: true, actions: [] })[0]).toContain('nothing to provision')
+  })
+
+  it('renders one line per action', () => {
+    const lines = formatSetupReport({
+      dryRun: false,
+      actions: [
+        { kind: 'product', verb: 'reuse', target: 'Test Hobby', detail: 'prod_1' },
+        { kind: 'price', verb: 'replace', target: 'hobby_monthly' },
+      ],
+    })
+    expect(lines[0]).toContain('already exists')
+    expect(lines[1]).toContain('moves lookup key')
+  })
+})

--- a/storage/framework/defaults/ai/skills/stacks-payments/SKILL.md
+++ b/storage/framework/defaults/ai/skills/stacks-payments/SKILL.md
@@ -276,14 +276,31 @@ Supported webhook event types: `payment_intent.succeeded`, `payment_intent.payme
 
 ### Setup Products from SaaS Config
 
-```typescript
-import { createStripeProduct } from '@stacksjs/payments'
+Prefer the command; it is what an app author can discover:
 
-const result = await createStripeProduct()
-// Creates Stripe products and prices from config/saas.ts plans
+```bash
+buddy stripe:setup --dry-run   # report the plan of record, write nothing
+buddy stripe:setup             # apply it
 ```
 
-This iterates `saas.plans`, creates a Stripe product per plan, then creates prices for each pricing option using `lookup_key` from the `key` field.
+```typescript
+import { createStripeProduct, formatSetupReport } from '@stacksjs/payments'
+
+const result = await createStripeProduct({ dryRun: true })
+if (!result.isErr)
+  console.log(formatSetupReport(result.value).join('\n'))
+```
+
+This iterates `saas.plans` and reconciles each one against the live account: a
+product is matched by name and reused, and each pricing option is matched by its
+`lookup_key` (from the `key` field). Prices are immutable in Stripe, so a changed
+amount is applied by creating a new price with `transfer_lookup_key: true`, which
+moves the key atomically and leaves the superseded price active so existing
+subscriptions keep billing.
+
+Re-running is safe and converges. It does not use `products.search` on purpose:
+that index is eventually consistent, so a second run inside the lag window would
+find nothing and create a duplicate.
 
 ### Utility Functions
 


### PR DESCRIPTION
Fixes #2359. Items 1, 2 and the minor message bug. Item 3 does not reproduce; detail at the bottom.

## 1. Idempotency

The reconciler now matches before it writes:

- **Products** by `productName`, reused when found.
- **Prices** by `lookup_key`, reused when the live price already encodes the configured amount, currency, product and interval.
- **Changed amounts**: Stripe prices are immutable, so the amount cannot be edited. A new price is created with `transfer_lookup_key: true`, which Stripe applies atomically, and the superseded price is left **active but unkeyed** so subscriptions already billing on it are unaffected.

### Why not `products.search`

Search is the obvious tool and the wrong one. Its index is eventually consistent, so a second run inside the lag window finds nothing and creates the duplicate this change exists to prevent. `products.list` reads live objects.

### The lookup_key claim, confirmed

You flagged that the uniqueness behaviour came from the docs rather than observation. It is confirmed by the vendored SDK's own types, which describe `transfer_lookup_key` as:

> If set to true, will atomically remove the lookup key from the existing price, and assign it to this price.

A key can only be attached to one price, so the original `prices.create` on a second run would indeed have failed. `prices.list` accepts a `lookup_keys` filter, which is what the lookup uses.

## 2. `--dry-run`

Actions are spawned with `buddyOptions` translating CLI options into argv flags, so the action has to read them, and did not. It now parses `--dry-run` (and the camelCase form `buddyOptions` emits) and threads `dryRun` into the reconciler, which reports the plan of record and writes nothing:

```
Dry run. Nothing was written to Stripe. This is what would be applied:
  product "Stacks Hobby" already exists (prod_123)
  price "stacks_hobby_monthly" moves lookup key to a new price (price_abc -> new price (2900 usd))
```

The command's closing line now reports which of the two actually happened rather than always claiming products were created.

Agreed this was the one to fix first. A preview flag that writes billing objects is worse than no flag.

## Minor

`ok('Migrations generated')` and `log.error('generateMigrations failed')` were copy-paste from the migration action. Both corrected.

## 3. Missing from `buddy --help` — could not reproduce

On current main it lists, under a `stripe:` group:

```
  stripe:
    stripe:setup                    Sets up stripe products in the dashboard
```

`getCommandsToLoad` returns the whole registry for `--help`, and `loadCommands` dedupes `saas` and `stripe:setup` to one module load, which still registers the command.

Worth knowing what I hit on the way there, because it is a better explanation than the code: my `buddy --help` was crashing outright with `SyntaxError: Export named 'createTypedRouter' not found`, because installed `@stacksjs/bun-router` was **0.0.22** against a lockfile pinning **0.1.7**. A node_modules behind the lockfile takes down the entire help path, not one command. Given the report was against 0.72.8 through a consuming app, that seems more likely than a registry gap. Happy to reopen that item if it still reproduces on a synced install.

`--project` is left declared. It is inert here, but it is declared the same way on a dozen other commands, so removing it only from this one would be inconsistent rather than a fix.

## Verification

- New `stripe-setup-idempotency.test.ts`, 8 tests, driving the reconciler against a fake Stripe account: clean provision, **second run writes nothing**, changed amount transfers the key and leaves the old price active, added price reuses the product, and both dry-run paths write nothing while still reporting.
- `bun test ./storage/framework/core/payments/tests/` 138 pass, 0 fail
- `runLint` (SDK) clean on every touched file
- `bun run typecheck` no error in any touched file, count unchanged from main
