### PR TITLE
fix(queue): stop the redis batch test poisoning every other queue test

### DIFF
--- a/storage/framework/core/queue/tests/batch-redis-lifecycle.test.ts
+++ b/storage/framework/core/queue/tests/batch-redis-lifecycle.test.ts
@@ -1,24 +1,25 @@
-import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { RedisClient } from 'bun'
+import { env } from '@stacksjs/env'
+import { queue as queueConfig } from '@stacksjs/config'
 
 const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379/0'
 
-mock.module('@stacksjs/logging', () => ({
-  log: {
-    debug() {},
-    error() {},
-    info() {},
-    warn() {},
-  },
-}))
-mock.module('@stacksjs/env', () => ({ env: { QUEUE_DRIVER: 'redis' } }))
-mock.module('@stacksjs/config', () => ({
-  queue: {
-    connections: {
-      redis: { redis: { url: redisUrl } },
-    },
-  },
-}))
+// Deliberately NOT `mock.module('@stacksjs/env', ...)`.
+//
+// Bun loads every test file before running any of them, and `src/batch.ts` binds
+// `envVars` from `@stacksjs/env` at import time. A module mock applied at the top
+// of this file therefore replaces the module for the ONE cached `batch.ts`
+// instance that every other queue test shares, so `getQueueDriver()` returned
+// 'redis' repo-wide and the seven `batch-add-races` cases failed with
+// "Batch batch-2282 not found" — reading Redis instead of their own database.
+// `mock.restore()` does not undo `mock.module`, so the afterAll here could not
+// have saved it either.
+//
+// `getQueueDriver()` and `batchRedisUrl()` both read their values at call time,
+// so overriding the live objects inside beforeAll/afterAll gets the same effect
+// scoped to this file's own run.
+const original: { driver: unknown, redis: unknown } = { driver: undefined, redis: undefined }
 
 const redis = new RedisClient(redisUrl)
 const batchId = `batch-redis-lifecycle-${process.pid}`
@@ -27,13 +28,26 @@ const key = `stacks:batch:${batchId}`
 const { recordBatchJobCompletion } = await import('../src/batch')
 
 beforeAll(async () => {
+  original.driver = (env as Record<string, unknown>).QUEUE_DRIVER
+  ;(env as Record<string, unknown>).QUEUE_DRIVER = 'redis'
+
+  const connections = (queueConfig as { connections?: Record<string, unknown> })?.connections
+  if (connections) {
+    original.redis = connections.redis
+    connections.redis = { redis: { url: redisUrl } }
+  }
+
   await redis.connect()
 })
 
 afterAll(async () => {
   await redis.del(key)
   redis.close()
-  mock.restore()
+
+  ;(env as Record<string, unknown>).QUEUE_DRIVER = original.driver
+  const connections = (queueConfig as { connections?: Record<string, unknown> })?.connections
+  if (connections && original.redis !== undefined)
+    connections.redis = original.redis
 })
 
 describe('Redis batch lifecycle accounting (#2354)', () => {


### PR DESCRIPTION
`main`'s `test` job has been red since #2357 landed. Every run since is failing, and it is not intermittent.

## Bisected

| run | head | test |
|---|---|---|
| 32741433541 | `1e79346f85` (#2358) | pass |
| 32751811425 | `4c288d6e2d` (#2357) | **fail** |

Same seven failures in every run since, all in `batch-add-races.test.ts`:

```
(fail) DispatchedBatch.add - atomic counter growth (#2282) > the uncontended add still grows the counters and dispatches the jobs
...7 total
error: Batch batch-2282 not found
```

They pass when that file is run alone. Removing `batch-redis-lifecycle.test.ts` and re-running the suite gives 320 pass / 0 fail, which isolates it to that one file.

## Cause

`batch-redis-lifecycle.test.ts` forced the driver with a top-level module mock:

```ts
mock.module('@stacksjs/env', () => ({ env: { QUEUE_DRIVER: 'redis' } }))
```

Bun loads every test file before running any of them, and `src/batch.ts` binds `envVars` from `@stacksjs/env` at import time:

```ts
function getQueueDriver(): string {
  return envVars.QUEUE_DRIVER || 'sync'
}
```

There is one cached `batch.ts` instance shared by every queue test. The mock replaced the module behind it during the load phase, so `getQueueDriver()` returned `'redis'` repo-wide and the races tests looked for their fixtures in Redis instead of their own database. Hence "not found" rather than an assertion mismatch.

The file did call `mock.restore()` in `afterAll`, which cannot help twice over: `mock.restore()` does not undo `mock.module`, and the damage was already done during load, before any hook ran.

## Fix

`getQueueDriver()` and `batchRedisUrl()` both read their values at call time, so the override does not need to be a module mock at all. It moves into `beforeAll` and is undone in `afterAll`, scoped to this file's own run:

```ts
beforeAll(async () => {
  original.driver = env.QUEUE_DRIVER
  env.QUEUE_DRIVER = 'redis'
  ...
})

afterAll(async () => {
  env.QUEUE_DRIVER = original.driver
  ...
})
```

The `@stacksjs/config` queue connection is swapped and restored the same way. The `@stacksjs/logging` mock is dropped; it was only silencing output.

## Verification

- `bun test ./storage/framework/core/queue/tests/` **322 pass / 0 fail**, from 315 / 7
- Both redis lifecycle tests still pass, including the one that requires the redis path to reject (`rejects.toThrow(/integer/i)`), so this does not paper over the coverage by falling back to the SQL path
- `bun test` (root) 365 pass / 0 fail

## Note for future test files

Any test that needs a different `QUEUE_DRIVER` has to do it this way. A top-level `mock.module` of a module that `src/` binds at import time is process-global in Bun and there is no way to take it back, so it silently reconfigures every other file that shares the importer.
