### PR TITLE
fix(payments): ask the database whether a subscription is valid (#2361)

### DIFF
--- a/storage/framework/core/payments/src/billable/subscription.ts
+++ b/storage/framework/core/payments/src/billable/subscription.ts
@@ -20,6 +20,17 @@ export interface SubscriptionManager {
   isIncomplete: (user: UserModel, type: string) => Promise<boolean>
 }
 
+/**
+ * The provider statuses that mean the customer currently has what they paid for.
+ *
+ * Kept as one list because `isValid` is the question every entitlement check
+ * ultimately asks, and the answer has to be the same everywhere it is asked.
+ */
+export const ENTITLING_STATUSES = ['active', 'trialing'] as const
+
+/** Statuses meaning payment was started but never completed. */
+export const INCOMPLETE_STATUSES = ['incomplete'] as const
+
 export const manageSubscription: SubscriptionManager = (() => {
   async function create(
     user: UserModel,
@@ -177,25 +188,41 @@ export const manageSubscription: SubscriptionManager = (() => {
     return (subscription as Record<string, unknown>).provider_status === 'trialing'
   }
 
+  /**
+   * Does this user hold a subscription of `type` in any of `statuses`?
+   *
+   * Asked of the database rather than answered in memory, because a user can
+   * legitimately have several rows for one `type`. The webhook path upserts on
+   * `provider_id`, and Stripe issues a new id per subscription, so a cancelled
+   * row stays behind with `provider_status: 'canceled'` and resubscribing adds
+   * another. Fetching one row with `executeTakeFirst()` and no `ORDER BY` then
+   * inspects whichever row the planner happened to return, and told a paying
+   * customer they were not paying (stacksjs/stacks#2361).
+   *
+   * There is no ordering to fall back on either: `Subscription` carries no
+   * `useTimestamps`, so there is no `created_at` and `id` is the only proxy for
+   * recency. Matching on status avoids needing one, and stays correct however
+   * many historical rows accumulate.
+   */
+  async function hasSubscriptionInStatus(user: UserModel, type: string, statuses: readonly string[]): Promise<boolean> {
+    const match = await db
+      .selectFrom('subscriptions')
+      .where('user_id', '=', user.id)
+      .where('type', '=', type)
+      .whereIn('provider_status', [...statuses])
+      .select(['id'])
+      .limit(1)
+      .executeTakeFirst()
+
+    return Boolean(match)
+  }
+
   async function isIncomplete(user: UserModel, type: string): Promise<boolean> {
-    const subscription = await db.selectFrom('subscriptions').where('user_id', '=', user.id).where('type', '=', type).selectAll().executeTakeFirst()
-
-    if (!subscription)
-      return false
-
-    return (subscription as Record<string, unknown>).provider_status === 'incomplete'
+    return await hasSubscriptionInStatus(user, type, INCOMPLETE_STATUSES)
   }
 
   async function isValid(user: UserModel, type: string): Promise<boolean> {
-    const subscription = await db.selectFrom('subscriptions').where('user_id', '=', user.id).where('type', '=', type).selectAll().executeTakeFirst()
-
-    if (!subscription)
-      return false
-
-    const active = await isActive(subscription as unknown as SubscriptionsTable)
-    const trial = await isTrial(subscription as unknown as SubscriptionsTable)
-
-    return active || trial
+    return await hasSubscriptionInStatus(user, type, ENTITLING_STATUSES)
   }
 
   async function storeSubscription(user: UserModel, type: string, _lookupKey: string, options: Stripe.Subscription): Promise<SubscriptionsTable | undefined> {

--- a/storage/framework/core/payments/tests/subscription-is-valid.test.ts
+++ b/storage/framework/core/payments/tests/subscription-is-valid.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+// stacksjs/stacks#2361 — `isValid()` fetched one subscription row with
+// `executeTakeFirst()` and no ORDER BY, then inspected that row's status. A user
+// who cancels and resubscribes has several rows for the same `type` (the webhook
+// upserts on `provider_id`, and Stripe issues a new id per subscription), so the
+// planner was free to hand back the cancelled one and the app told a paying
+// customer they were not paying.
+//
+// These drive the query through a fake builder that honours the filters, so the
+// old shape fails them: without the status filter the canceled-first ordering
+// returns the wrong row, and row order must not matter either way.
+
+interface Row { id: number, user_id: number, type: string, provider_status: string }
+
+const table: { rows: Row[] } = { rows: [] }
+let lastQuery: { wheres: [string, unknown][], ins: [string, unknown[]][], limit?: number } = { wheres: [], ins: [] }
+
+function fakeDb() {
+  return {
+    selectFrom(_t: string) {
+      lastQuery = { wheres: [], ins: [] }
+      const chain: any = {
+        where(col: string, _op: string, val: unknown) {
+          lastQuery.wheres.push([col, val])
+          return chain
+        },
+        whereIn(col: string, vals: unknown[]) {
+          lastQuery.ins.push([col, vals])
+          return chain
+        },
+        select(_cols: string[]) { return chain },
+        selectAll() { return chain },
+        limit(n: number) {
+          lastQuery.limit = n
+          return chain
+        },
+        async executeTakeFirst() {
+          const matched = table.rows.filter((row) => {
+            for (const [col, val] of lastQuery.wheres) {
+              if ((row as any)[col] !== val)
+                return false
+            }
+            for (const [col, vals] of lastQuery.ins) {
+              if (!vals.includes((row as any)[col]))
+                return false
+            }
+            return true
+          })
+          return matched[0]
+        },
+      }
+      return chain
+    },
+  }
+}
+
+// Override only `db`. Replacing a module wholesale drops the rest of its
+// surface, and anything else importing it then fails to load.
+const realDatabase = await import('@stacksjs/database')
+mock.module('@stacksjs/database', () => ({ ...realDatabase, db: fakeDb() }))
+
+const { manageSubscription, ENTITLING_STATUSES, INCOMPLETE_STATUSES } = await import('../src/billable/subscription')
+
+const user = { id: 7 } as any
+
+beforeEach(() => {
+  table.rows = []
+})
+
+describe('manageSubscription.isValid', () => {
+  it('says no when the user has never subscribed', async () => {
+    expect(await manageSubscription.isValid(user, 'default')).toBe(false)
+  })
+
+  it('says yes for a single active subscription', async () => {
+    table.rows = [{ id: 1, user_id: 7, type: 'default', provider_status: 'active' }]
+    expect(await manageSubscription.isValid(user, 'default')).toBe(true)
+  })
+
+  it('says yes during a trial', async () => {
+    table.rows = [{ id: 1, user_id: 7, type: 'default', provider_status: 'trialing' }]
+    expect(await manageSubscription.isValid(user, 'default')).toBe(true)
+  })
+
+  // The reported failure: cancelled row first, active row second.
+  it('says yes for a resubscribed customer whose cancelled row is returned first', async () => {
+    table.rows = [
+      { id: 1, user_id: 7, type: 'default', provider_status: 'canceled' },
+      { id: 2, user_id: 7, type: 'default', provider_status: 'active' },
+    ]
+    expect(await manageSubscription.isValid(user, 'default')).toBe(true)
+  })
+
+  // Undefined order means the planner may return either first, so both must hold.
+  it('gives the same answer whichever row the planner returns first', async () => {
+    const canceled = { id: 1, user_id: 7, type: 'default', provider_status: 'canceled' }
+    const active = { id: 2, user_id: 7, type: 'default', provider_status: 'active' }
+
+    table.rows = [canceled, active]
+    const canceledFirst = await manageSubscription.isValid(user, 'default')
+    table.rows = [active, canceled]
+    const activeFirst = await manageSubscription.isValid(user, 'default')
+
+    expect(canceledFirst).toBe(activeFirst)
+    expect(canceledFirst).toBe(true)
+  })
+
+  it('says no when every row is cancelled', async () => {
+    table.rows = [
+      { id: 1, user_id: 7, type: 'default', provider_status: 'canceled' },
+      { id: 2, user_id: 7, type: 'default', provider_status: 'canceled' },
+    ]
+    expect(await manageSubscription.isValid(user, 'default')).toBe(false)
+  })
+
+  it('does not read another type as entitlement', async () => {
+    table.rows = [{ id: 1, user_id: 7, type: 'addon', provider_status: 'active' }]
+    expect(await manageSubscription.isValid(user, 'default')).toBe(false)
+  })
+
+  it('does not read another user as entitlement', async () => {
+    table.rows = [{ id: 1, user_id: 8, type: 'default', provider_status: 'active' }]
+    expect(await manageSubscription.isValid(user, 'default')).toBe(false)
+  })
+
+  it('asks the database for the status rather than filtering in memory', async () => {
+    table.rows = [{ id: 1, user_id: 7, type: 'default', provider_status: 'active' }]
+    await manageSubscription.isValid(user, 'default')
+
+    expect(lastQuery.ins).toEqual([['provider_status', [...ENTITLING_STATUSES]]])
+    expect(lastQuery.limit).toBe(1)
+  })
+})
+
+// Same defect, same file, not mentioned in the issue: it fetched one unordered
+// row and inspected it, so a stale row could mask a genuinely incomplete one.
+describe('manageSubscription.isIncomplete', () => {
+  it('finds an incomplete row behind a cancelled one', async () => {
+    table.rows = [
+      { id: 1, user_id: 7, type: 'default', provider_status: 'canceled' },
+      { id: 2, user_id: 7, type: 'default', provider_status: 'incomplete' },
+    ]
+    expect(await manageSubscription.isIncomplete(user, 'default')).toBe(true)
+  })
+
+  it('says no when nothing is incomplete', async () => {
+    table.rows = [{ id: 1, user_id: 7, type: 'default', provider_status: 'active' }]
+    expect(await manageSubscription.isIncomplete(user, 'default')).toBe(false)
+  })
+
+  it('queries the incomplete vocabulary', async () => {
+    table.rows = []
+    await manageSubscription.isIncomplete(user, 'default')
+    expect(lastQuery.ins).toEqual([['provider_status', [...INCOMPLETE_STATUSES]]])
+  })
+})


### PR DESCRIPTION
Fixes #2361, taking the shape you proposed.

## The change

The status filter moves into the query, so the answer no longer depends on which row the planner returns or how many historical rows exist:

```ts
async function hasSubscriptionInStatus(user, type, statuses: readonly string[]): Promise<boolean> {
  const match = await db
    .selectFrom('subscriptions')
    .where('user_id', '=', user.id)
    .where('type', '=', type)
    .whereIn('provider_status', [...statuses])
    .select(['id'])
    .limit(1)
    .executeTakeFirst()

  return Boolean(match)
}
```

`ENTITLING_STATUSES` (`active`, `trialing`) and `INCOMPLETE_STATUSES` are named and exported, because `isValid` is the question every entitlement check ultimately asks and the answer has to be the same everywhere it is asked.

## `isIncomplete` had the same defect

Not mentioned in the issue, same file, same shape:

```ts
const subscription = await db.selectFrom('subscriptions')
  .where('user_id', '=', user.id).where('type', '=', type)
  .selectAll().executeTakeFirst()          // no ORDER BY
...
return subscription.provider_status === 'incomplete'
```

A stale row masks a genuinely incomplete one exactly the same way, so it is fixed alongside.

## On the timestamps

You are right that there is nothing to order by: `Subscription` carries no `useTimestamps`, so there is no `created_at` and `id` is the only proxy for recency. Matching on status avoids needing an ordering at all, which is why this is the better fix rather than adding an `ORDER BY id DESC`.

Adding `useTimestamps` is still worth doing, but it is a migration against a table that already exists in every deployed app, so it wants its own change rather than riding along here.

## Tests

12 new tests in `subscription-is-valid.test.ts`, driving the query through a fake builder that honours `where`/`whereIn`/`limit`, so the assertions are about behaviour rather than about the shape of the call.

**Three of them fail against the previous implementation**, which is the point:

- `says yes for a resubscribed customer whose cancelled row is returned first`
- `gives the same answer whichever row the planner returns first` (the same two rows in both orders, since undefined order means either may come back)
- `asks the database for the status rather than filtering in memory`

The rest cover the trivial cases and the boundaries that must keep holding: no subscription, single active, trialing, all-cancelled, another `type`, another `user_id`, plus the `isIncomplete` pair.

## Verification

- `bun test ./storage/framework/core/payments/tests/` 142 pass, 0 fail
- `runLint` (SDK) clean on the touched file
- `bun run typecheck` diffed against `main`: **zero new errors**
