### PR TITLE
fix(orm): resolve the route generator from the package, and say when a generated route is skipped (#2364)

### DIFF
--- a/storage/framework/core/orm/src/auto-crud.ts
+++ b/storage/framework/core/orm/src/auto-crud.ts
@@ -476,6 +476,32 @@ export function validateWriteBody(
  * The parameter's NAME is the app's business. The shape is what decides whether
  * this URL is already claimed.
  */
+/** The subset of a registered route this matching needs. */
+export interface RegisteredRouteLike {
+  method?: string
+  path?: unknown
+}
+
+/**
+ * The already-registered route that would shadow a generated `method` + `path`,
+ * or undefined when the generated route is free to register.
+ *
+ * Pure, and separate from the logging wrapper in `../routes.ts`, so the rule can
+ * be tested without booting a router. The rule itself is the whole of
+ * stacksjs/stacks#2364: match on SHAPE, because a hand-written
+ * `/api/sites/{siteId}` and a generated `/api/sites/{id}` address the same URLs
+ * and a literal comparison sees two different strings, registers both, and lets
+ * the generated handler answer without the hand-written one's authorization.
+ */
+export function findShadowingRoute<T extends RegisteredRouteLike>(
+  routes: readonly T[],
+  method: string,
+  path: string,
+): T | undefined {
+  const shape = routeShape(path)
+  return routes.find(r => r.method === method && routeShape(String(r.path ?? '')) === shape)
+}
+
 export function routeShape(path: string): string {
   // Both spellings the router accepts, so `/sites/:siteId` matches too.
   return path.replace(/\{[^}]*\}/g, '{}').replace(/:[^/]+/g, '{}')

--- a/storage/framework/core/orm/src/routes.ts
+++ b/storage/framework/core/orm/src/routes.ts
@@ -2,7 +2,19 @@
  * ORM-generated routes
  *
  * Auto-generates CRUD REST API routes based on model `useApi` trait definitions.
- * User-defined routes in ./routes/ are loaded first and always take priority.
+ *
+ * User-defined routes in `./routes/` are loaded first and take priority: every
+ * generated route is registered only if no user route already answers that
+ * method and path SHAPE, so a hand-written `/api/sites/{siteId}` claims the
+ * endpoint a generated `/api/sites/{id}` would otherwise take. Each skip is
+ * logged, naming the route that won.
+ *
+ * That contract holds for the generator in this file. It does NOT hold for a
+ * vendored `storage/framework/orm/routes.ts` old enough to compare paths
+ * literally, which sees two different strings and registers alongside the
+ * hand-written route (stacksjs/stacks#2364). Nothing re-vendors that file, so
+ * every loader resolves this package first and falls back to the vendored copy
+ * only when the package is unreachable.
  */
 
 import type { EnhancedRequest } from '@stacksjs/bun-router'
@@ -12,7 +24,7 @@ import { projectPath, storagePath } from '@stacksjs/path'
 import { createQueryBuilder, defaultConfig, setConfig } from '@stacksjs/query-builder'
 import { HttpError } from '@stacksjs/error-handling'
 import { log } from '@stacksjs/logging'
-import { apiBasePath, applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, getWritableFields, mapWriteError, resolveApiMiddleware, resolveIndexPageArgs, routeShape, stampOwnership, stripHidden, teamOwnershipField, toSnakeCase, toSnakeCaseKeys, validateWriteBody } from './auto-crud'
+import { apiBasePath, applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, findShadowingRoute, getWritableFields, mapWriteError, resolveApiMiddleware, resolveIndexPageArgs, stampOwnership, stripHidden, teamOwnershipField, toSnakeCase, toSnakeCaseKeys, validateWriteBody } from './auto-crud'
 import { loadModelRegistry } from './model-registry'
 
 // Initialize the query builder config from the project's optional
@@ -71,11 +83,32 @@ const models = await loadModelRegistry({
 const db = createQueryBuilder()
 
 // Helper: check if a route is already registered (user-defined routes take priority)
+/**
+ * Is a user route already serving this method and path shape?
+ *
+ * Compared by shape, not by literal path, because a hand-written
+ * `/api/sites/{siteId}` and a generated `/api/sites/{id}` address the same URLs
+ * and differ only in the parameter's name. A literal comparison sees two
+ * different strings, registers the generated route anyway, and whichever won
+ * registration serves: the hand-written handler's authorization check simply
+ * stops running (stacksjs/stacks#2364).
+ *
+ * The skip is logged. Silence previously meant both "skipped correctly" and
+ * "compared literally and skipped nothing", and those are indistinguishable
+ * from outside the process. Naming the route that won also surfaces the
+ * parameter-name mismatch that makes this confusing in the first place.
+ */
 function routeExists(method: string, path: string): boolean {
-  const shape = routeShape(path)
-  return route.routes.some(
-    (r: any) => r.method === method && routeShape(String(r.path ?? '')) === shape,
+  const existing = findShadowingRoute(route.routes as any[], method, path)
+  if (!existing)
+    return false
+
+  const existingPath = String((existing as any).path ?? '')
+  log.info(
+    `[orm] Skipping generated ${method} ${path} - already defined`
+    + `${existingPath && existingPath !== path ? ` as ${existingPath}` : ''}.`,
   )
+  return true
 }
 
 // Helper: get hidden attribute names from a model

--- a/storage/framework/core/orm/tests/auto-crud.test.ts
+++ b/storage/framework/core/orm/tests/auto-crud.test.ts
@@ -26,7 +26,7 @@
 import { describe, expect, it } from 'bun:test'
 import { Database } from 'bun:sqlite'
 import { snakeCase } from '@stacksjs/strings'
-import { apiBasePath, applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, getWritableFields, INDEX_DEFAULT_PER_PAGE, INDEX_MAX_PER_PAGE, isUniqueViolation, mapWriteError, normalizeValidationValue, resolveApiMiddleware, resolveIndexPageArgs, routeShape, stampOwnership, stripHidden, teamOwnershipField, toSnakeCase, toSnakeCaseKeys } from '../src/auto-crud'
+import { apiBasePath, applyCasts, applySorting, buildIndexMeta, buildIndexPaginator, buildReadColumnMap, dropHiddenInputs, filterFillable, findShadowingRoute, getWritableFields, INDEX_DEFAULT_PER_PAGE, INDEX_MAX_PER_PAGE, isUniqueViolation, mapWriteError, normalizeValidationValue, resolveApiMiddleware, resolveIndexPageArgs, routeShape, stampOwnership, stripHidden, teamOwnershipField, toSnakeCase, toSnakeCaseKeys } from '../src/auto-crud'
 import { toPaginator } from '../src/paginator'
 
 describe('toSnakeCaseKeys (write-path column mapping)', () => {
@@ -766,5 +766,65 @@ describe('buildIndexPaginator (flat Laravel index shape)', () => {
     expect(p.from).toBe(expected.from)
     expect(p.to).toBe(expected.to)
     expect(p.has_more_pages).toBe(expected.has_more_pages)
+  })
+})
+
+// stacksjs/stacks#2364 — the shape rule from #2224 was correct in this package
+// and absent from the vendored `storage/framework/orm/routes.ts` an app actually
+// ran, so a generated PATCH registered alongside a hand-written one and answered
+// without its authorization check. The rule lives here, pure, so it can be
+// asserted directly rather than inferred from the generator's source.
+describe('findShadowingRoute (which generated routes must not register) (#2364)', () => {
+  const userRoutes = [
+    { method: 'GET', path: '/api/sites' },
+    { method: 'PATCH', path: '/api/sites/{siteId}' },
+    { method: 'DELETE', path: '/api/sites/:siteId' },
+    { method: 'GET', path: '/api/sites/{siteId}/stats' },
+  ]
+
+  it('finds a hand-written route whose parameter is named differently', () => {
+    expect(findShadowingRoute(userRoutes, 'PATCH', '/api/sites/{id}')?.path)
+      .toBe('/api/sites/{siteId}')
+  })
+
+  // The reported blast radius was wider than PATCH: DELETE collided too, and a
+  // probe asserting only "not 200" could not tell a 403 guard from the generated
+  // handler's 400.
+  it('covers every item-level verb, not just the one that was noticed', () => {
+    expect(findShadowingRoute(userRoutes, 'DELETE', '/api/sites/{id}')).toBeDefined()
+  })
+
+  it('matches the colon spelling the router also accepts', () => {
+    expect(findShadowingRoute([{ method: 'PUT', path: '/api/sites/:siteId' }], 'PUT', '/api/sites/{id}'))
+      .toBeDefined()
+  })
+
+  it('matches a collection route, which literal comparison also got right', () => {
+    expect(findShadowingRoute(userRoutes, 'GET', '/api/sites')?.path).toBe('/api/sites')
+  })
+
+  it('does not treat a different verb on the same path as a collision', () => {
+    expect(findShadowingRoute(userRoutes, 'POST', '/api/sites/{id}')).toBeUndefined()
+  })
+
+  it('does not treat a longer path as a collision', () => {
+    // `/api/sites/{siteId}/stats` has one more segment, so the item route is free.
+    expect(findShadowingRoute(
+      [{ method: 'GET', path: '/api/sites/{siteId}/stats' }],
+      'GET',
+      '/api/sites/{id}',
+    )).toBeUndefined()
+  })
+
+  it('does not treat a different resource as a collision', () => {
+    expect(findShadowingRoute(userRoutes, 'PATCH', '/api/users/{id}')).toBeUndefined()
+  })
+
+  it('returns nothing when the app registered no routes at all', () => {
+    expect(findShadowingRoute([], 'PATCH', '/api/sites/{id}')).toBeUndefined()
+  })
+
+  it('tolerates a route whose path is missing rather than throwing', () => {
+    expect(findShadowingRoute([{ method: 'PATCH' }], 'PATCH', '/api/sites/{id}')).toBeUndefined()
   })
 })

--- a/storage/framework/core/router/src/stacks-router.ts
+++ b/storage/framework/core/router/src/stacks-router.ts
@@ -3944,23 +3944,56 @@ export function createStacksRouter(config: StacksRouterConfig = {}): StacksRoute
         throw error
       }
 
-      // Load ORM-generated API routes. The generator writes a project-local
-      // routes file; we accept both locations:
-      //   - `storage/framework/orm/routes.ts` (canonical, outside the core
-      //     package so it survives when @stacksjs/orm is npm-installed)
-      //   - `storage/framework/core/orm/routes.ts` (legacy, inside the core
-      //     workspace package)
+      // Load ORM-generated API routes.
+      //
+      // The PACKAGE is tried first, and that ordering is load-bearing. The
+      // vendored `storage/framework/orm/routes.ts` is copied into an app once
+      // and nothing re-vendors it: `@stacksjs/orm` publishes `dist/routes.js`
+      // and no `routes.ts`, so an app that upgrades the package keeps running
+      // whatever generator its vendored copy froze at. One app was serving a
+      // copy old enough to compare route paths literally, so a generated
+      // `PATCH /api/sites/{id}` did not recognise a hand-written
+      // `/api/sites/{siteId}` as the same endpoint, registered alongside it,
+      // and the hand-written handler's authorization check stopped running
+      // (stacksjs/stacks#2364).
+      //
+      // `core/server/src/start.ts` and `core/api/src/generate-openapi.ts`
+      // already resolve it package-first; this path and `defaults/bootstrap.ts`
+      // were the two that did not, which is why the same app could be correct
+      // under one entrypoint and shadowed under another.
+      //
+      // The vendored paths remain as fallbacks for a checkout with no built
+      // package behind the specifier.
       log.debug('[router] Loading ORM routes...')
-      const ormRoutesCandidates = [
-        p.frameworkPath('orm/routes.ts'),
-        p.frameworkPath('core/orm/routes.ts'),
-      ]
+      // Held in a variable so the specifier resolves at runtime: a literal one
+      // is resolved while transpiling, and an unresolvable literal fails the
+      // module rather than throwing where it can be caught.
+      const ormRoutesPackage = '@stacksjs/orm/routes'
       let ormRoutesLoaded = false
+      try {
+        await import(ormRoutesPackage)
+        ormRoutesLoaded = true
+        log.debug(`[router] ORM routes loaded from ${ormRoutesPackage}`)
+      }
+      catch (error) {
+        log.debug('[router] ORM routes not available from the package, trying the vendored copy\n', error)
+      }
+
+      const ormRoutesCandidates = ormRoutesLoaded
+        ? []
+        : [
+            p.frameworkPath('orm/routes.ts'),
+            p.frameworkPath('core/orm/routes.ts'),
+          ]
       for (const candidate of ormRoutesCandidates) {
         try {
           if (await Bun.file(candidate).exists()) {
             await import(candidate)
             ormRoutesLoaded = true
+            // Which generator is running is the one fact that made #2364
+            // undiagnosable from outside, so say it rather than debug it.
+            log.info(`[router] ORM routes loaded from the vendored copy at ${candidate}. `
+              + `This file is not refreshed by upgrading @stacksjs/orm - delete it to use the package.`)
             break
           }
         }
@@ -3974,25 +4007,10 @@ export function createStacksRouter(config: StacksRouterConfig = {}): StacksRoute
           log.warn(`[router] ORM routes candidate failed to load, falling back to next: ${candidate}\n`, error)
         }
       }
-      // Last resort: the package itself. An app scaffolded before the vendored
-      // shim was fixed still has one that re-exports `../core/orm/routes`, a
-      // directory that exists in this repository and nowhere else — so both
-      // file candidates above fail and the app serves no model endpoints at
-      // all. `@stacksjs/orm/routes` is the same generator, resolved the way an
-      // installed app can actually reach it.
-      if (!ormRoutesLoaded) {
-        try {
-          // Variable, not a literal — see generate-openapi.ts: a literal
-          // specifier that cannot resolve fails this module at transpile time
-          // rather than throwing where it can be caught.
-          const ormRoutesPackage = '@stacksjs/orm/routes'
-          await import(ormRoutesPackage)
-          ormRoutesLoaded = true
-        }
-        catch (error) {
-          log.warn('[router] ORM routes could not be loaded from @stacksjs/orm either\n', error)
-        }
-      }
+      // The package was already tried first, above: an app scaffolded before the
+      // vendored shim was fixed carries one that re-exports `../core/orm/routes`,
+      // a directory that exists in this repository and nowhere else, and the
+      // package is what it can actually reach.
 
       if (!ormRoutesLoaded)
         log.warn('[router] No ORM routes candidate loaded - model useApi endpoints are unavailable.')

--- a/storage/framework/defaults/bootstrap.ts
+++ b/storage/framework/defaults/bootstrap.ts
@@ -134,7 +134,27 @@ if (mounts('dashboard', feature('dashboard'))) {
   await route.register(frameworkPath('defaults/routes/dashboard-api.ts'))
   // The dev dashboard boots through this file rather than the application
   // router's importRoutes() path, so load model-declared useApi routes here too.
-  await import(frameworkPath('orm/routes.ts'))
+  //
+  // Package first, vendored second, matching importRoutes() and start.ts. This
+  // line used to import the vendored copy only, and nothing re-vendors that
+  // file: `@stacksjs/orm` publishes `dist/routes.js` and no `routes.ts`, so an
+  // app kept whatever generator its copy froze at however often it upgraded.
+  // An old enough copy compares route paths literally, so a generated
+  // `PATCH /api/sites/{id}` does not recognise a hand-written
+  // `/api/sites/{siteId}` as the same endpoint and registers alongside it,
+  // and the hand-written handler's authorization check stops running
+  // (stacksjs/stacks#2364).
+  //
+  // Held in a variable so the specifier resolves at runtime rather than while
+  // transpiling, where an unresolvable literal would fail this module instead
+  // of throwing where it can be caught.
+  const ormRoutesPackage = '@stacksjs/orm/routes'
+  try {
+    await import(ormRoutesPackage)
+  }
+  catch {
+    await import(frameworkPath('orm/routes.ts'))
+  }
 }
 
 // Email webhook + unsubscribe routes (stacksjs/stacks#1881, #1880).


### PR DESCRIPTION
Fixes the reachable half of #2364: suggestions 1 and 2, plus the packaging cause underneath them. Suggestion 3 is deliberately left out, reasoning at the bottom.

## The guard was already correct. It was not running.

Shape matching landed as **#2224**, in this package. The app ran a different copy.

Two loaders resolved the vendored `storage/framework/orm/routes.ts` first:

- `importRoutes()` in `core/router/src/stacks-router.ts` (vendored, then legacy, then package as a last resort)
- `defaults/bootstrap.ts:137`, which imported the vendored file **with no fallback at all**

Meanwhile `core/server/src/start.ts` and `core/api/src/generate-openapi.ts` already resolve it package-first. That split is why the same app could be correct under one entrypoint and shadowed under another. Both remaining loaders now match the two that were already right, so this is making the codebase consistent with itself rather than introducing a new policy.

The vendored paths stay as a fallback for a checkout with no built package behind the specifier, and the vendored file is now named in the log when it is what loaded.

## Why the vendored copy is the real problem

Nothing re-vendors it. `@stacksjs/orm` publishes `dist/routes.js` and no `routes.ts`, so the file `bootstrap.ts` imports cannot be refreshed by upgrading the package. An app keeps whatever generator its copy froze at, indefinitely.

I checked the registry while writing this: `@stacksjs/orm@0.72.63`'s `dist/routes.js` **already contains the shape guard** (`replace(/\{[^}]*\}/g,"{}")` survives minification). So the fix has been published and shipping and unreachable. An app could upgrade to a version that fixes this and stay broken, with nothing in the output to say why.

## Suggestion 2, which turned out to be the important one

Every skip is now logged, naming the route that won:

```
[orm] Skipping generated PATCH /api/sites/{id} - already defined as /api/sites/{siteId}.
```

Silence previously meant both "skipped correctly" and "compared literally and skipped nothing". From outside the process those are identical, which is why this needed a long diagnosis **twice** for what is the same underlying rule as #2224. The loader also says which generator it loaded, so "which copy am I running" is answerable from the log rather than by reading a vendored file.

## Suggestion 1

The file header claimed a contract it could not keep. It now states the rule precisely (match on shape, log the skip) and says where it does *not* hold, so the next person reading it is not misled the way this issue was.

## Tests

The matching rule moves into `auto-crud.ts` as `findShadowingRoute` - the module that exists to be unit-tested without booting a router - and `routeExists` becomes a thin logging wrapper around it. That keeps the rule assertable directly rather than inferred from generator source, which matters given your point that a source-level test cannot see an unreachable route.

Nine tests. **Three fail against the literal comparison**, verified by reverting it:

- parameter named differently (`{siteId}` vs `{id}`)
- **DELETE**, which your correction called and the original probe missed, because asserting "not 200" cannot tell a 403 guard from the generated handler's 400
- the `:siteId` colon spelling

The rest pin the boundaries that must keep holding: collection routes, a different verb, a longer path, a different resource, an empty route table, and a route with no `path` (tolerated rather than thrown on).

## Not included: suggestion 3

`resolveOwnership` returning `{enforced: false}` for a model with neither `ownership` nor `team_id` is real and reproduces exactly as you describe. I have left it alone because failing closed there would stop generating mutating routes for every model that declares nothing, which is a breaking change to published behaviour and a product decision rather than a bug fix. Same for generated reads being public by default. Both deserve their own issue and an explicit call, not a quiet change inside a routing fix.

## Verification

- `bun test ./storage/framework/core/orm/tests/` 1818 pass, 0 fail
- `bun test ./storage/framework/core/router/tests/` 431 pass, 0 fail
- `bun test` (root) 365 pass, 0 fail
- `runLint` (SDK) clean on every touched file
- `bun run typecheck` no error in any touched file
