### PR TITLE
fix(serve): stop the production server preferring an untracked stx copy

### DIFF
--- a/storage/framework/core/buddy/src/production-server.ts
+++ b/storage/framework/core/buddy/src/production-server.ts
@@ -1,11 +1,12 @@
 import type { RequestContextSnapshot } from '@stacksjs/config'
 import { existsSync } from 'node:fs'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
 import { installRequestContext, parseCookieHeader } from '@stacksjs/config'
 import { log } from '@stacksjs/logging'
 import { siteConfigPath } from '@stacksjs/path'
+import { ExitCode } from '@stacksjs/types'
+import { resolveStxSource } from './stx-source'
 
 /**
  * Request-scoped context (query string + parsed cookies) for `<script
@@ -225,26 +226,44 @@ export async function startProductionServer(options?: { port?: string | number, 
   const { stxPageAuthMiddleware } = await import('@stacksjs/auth')
   await injectGlobalAutoImports()
 
-      // Resolve the stx `serve` implementation: local STX worktree first
-      // (dev machines), then the project's pantry-vendored copy, then the
-      // installed npm package.
+      // Resolve the stx `serve` implementation.
+      //
+      // The installed dependency, unless someone asked for a different copy by
+      // name. This used to check a hardcoded STX worktree in `~/Code` and the
+      // project's `pantry/` directory FIRST, and take either one silently.
+      //
+      // That made an untracked directory outrank the declared dependency in
+      // the production server. It is how stacksjs/stacks#2369 happened: an app
+      // on `bun-plugin-stx@0.2.231` served every page through a
+      // `pantry/bun-plugin-stx@0.2.76` copy left over from July, which predates
+      // the page-response read-back (added in 0.2.219). So `notFound()` and
+      // `definePageMeta({ status })` recorded a 404 that nothing read, and a
+      // deleted status page answered 200 with its own not-found body - to a
+      // crawler, a cache, and a customer's uptime monitor.
+      //
+      // Nothing about that was visible: no log said which copy had loaded.
+      // A stale checkout is now something you opt into, by path, and the
+      // server says what it loaded either way.
       let stxServe: any
-      const serveCandidates = [
-        join(homedir(), 'Code/Tools/stx/packages/bun-plugin/dist/serve.js'),
-        join(process.cwd(), 'pantry/bun-plugin-stx/dist/serve.js'),
-      ]
-      for (const entry of serveCandidates) {
-        try {
-          if (existsSync(entry)) {
-            ;({ serve: stxServe } = await import(entry))
-            break
-          }
-        }
-        catch { /* try next */ }
+      const serveSource = resolveStxSource({ value: process.env.BUN_PLUGIN_STX_SRC })
+      if (serveSource.kind === 'missing') {
+        // `log.exit`, not `log.error` + `process.exit`: the error write is
+        // async and `process.exit` does not wait for it, so the one line
+        // explaining the refusal is dropped on the way out.
+        await log.exit(
+          `BUN_PLUGIN_STX_SRC points at ${serveSource.path}, which does not exist. `
+          + `Unset it to use the installed bun-plugin-stx.`,
+          ExitCode.FatalError,
+        )
       }
-      if (!stxServe) {
+      if (serveSource.kind === 'override') {
+        ;({ serve: stxServe } = await import(serveSource.path))
+        log.warn(`Serving views through ${serveSource.path} instead of the installed bun-plugin-stx.`)
+      }
+      else {
         ;({ serve: stxServe } = await import('bun-plugin-stx/serve'))
       }
+      log.debug(`stx serve implementation: ${serveSource.kind === 'override' ? serveSource.path : 'bun-plugin-stx/serve'}`)
 
       // Pre-resolve the vendored stx module + site/i18n config so `{t:…}`
       // translation tokens and the lang picker render in production exactly
@@ -504,21 +523,30 @@ export async function startProductionServer(options?: { port?: string | number, 
   log.success(`Production server listening on http://0.0.0.0:${port}`)
 }
 
+/**
+ * The stx module used to render `{t:…}` tokens and the lang picker.
+ *
+ * The installed dependency, unless `STACKS_STX_SRC` names another copy. Same
+ * reasoning as the `serve` resolution above: a hardcoded `~/Code` worktree and
+ * the project's `pantry/` used to win silently over the declared dependency,
+ * which meant a directory nobody tracks decided what the production server
+ * ran. See stacksjs/stacks#2369 for what that cost.
+ */
 async function resolveVendoredStxModule(): Promise<any | undefined> {
-  const candidates = [
-    join(homedir(), 'Code/Tools/stx/packages/stx/dist/index.js'),
-    join(process.cwd(), 'pantry/@stacksjs/stx/dist/index.js'),
-  ]
-  for (const entry of candidates) {
-    try {
-      if (existsSync(entry))
-        return await import(entry)
-    }
-    catch { /* try next */ }
+  const source = resolveStxSource({ value: process.env.STACKS_STX_SRC })
+  if (source.kind === 'missing') {
+    // See the BUN_PLUGIN_STX_SRC branch above: `log.error` then
+    // `process.exit` prints nothing, because the write never lands.
+    await log.exit(
+      `STACKS_STX_SRC points at ${source.path}, which does not exist. Unset it to use the installed @stacksjs/stx.`,
+      ExitCode.FatalError,
+    )
   }
-  // Production fallback: the installed npm package (resolved from node_modules).
-  // On a deployed server there is no dev worktree or `pantry/` dir — deps are
-  // installed via `bun install`, so this is the path that actually resolves.
+  if (source.kind === 'override') {
+    log.warn(`Rendering through ${source.path} instead of the installed @stacksjs/stx.`)
+    return await import(source.path)
+  }
+
   try {
     return await import('@stacksjs/stx')
   }
@@ -538,36 +566,24 @@ function fallbackI18nFromSite(site: any) {
   }
 }
 
+/**
+ * `resolveI18n` from whichever stx copy this server renders through, so
+ * `{t:…}` tokens and the lang picker behave the same as the pages around them.
+ *
+ * Shares `resolveVendoredStxModule`'s resolution rather than repeating a
+ * candidate list: two lists that were supposed to agree is how one of them
+ * ends up pointing somewhere the other does not.
+ */
 async function resolveSiteI18n(site: any): Promise<any> {
-  const resolverPaths = [
-    join(homedir(), 'Code/Tools/stx/packages/stx/src/site-builder/i18n.ts'),
-    join(homedir(), 'Code/Tools/stx/packages/stx/dist/index.js'),
-    join(process.cwd(), 'pantry/@stacksjs/stx/dist/index.js'),
-  ]
-  for (const resolverPath of resolverPaths) {
-    try {
-      if (!existsSync(resolverPath))
-        continue
-      const resolved = await import(resolverPath)
-      if (typeof resolved.resolveI18n !== 'function')
-        continue
-      const i18n = resolved.resolveI18n(site, process.cwd())
-      if (i18n)
-        return i18n
-    }
-    catch { /* try next */ }
-  }
-  // Production fallback: resolve `resolveI18n` from the installed npm package so
-  // `{t:…}` tokens render on a deployed server (no dev worktree / pantry dir).
   try {
-    const resolved = await import('@stacksjs/stx')
-    if (typeof (resolved as any).resolveI18n === 'function') {
+    const resolved = await resolveVendoredStxModule()
+    if (typeof (resolved as any)?.resolveI18n === 'function') {
       const i18n = (resolved as any).resolveI18n(site, process.cwd())
       if (i18n)
         return i18n
     }
   }
-  catch { /* not installed */ }
+  catch { /* fall back to the site config below */ }
   return fallbackI18nFromSite(site)
 }
 

--- a/storage/framework/core/buddy/src/stx-source.ts
+++ b/storage/framework/core/buddy/src/stx-source.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'node:fs'
+
+/**
+ * Which copy of stx the production server should render through.
+ *
+ * The answer is "the installed dependency" unless an operator names another
+ * one by path. It used to be "a hardcoded worktree under `~/Code`, else the
+ * project's `pantry/` directory, else the installed dependency", chosen
+ * silently and in that order.
+ *
+ * That inverted the thing a deployment depends on: an untracked directory
+ * outranked the declared dependency in the server that answers real traffic.
+ * stacksjs/stacks#2369 is what it cost - an app on `bun-plugin-stx@0.2.231`
+ * served every page through a `pantry/bun-plugin-stx@0.2.76` copy from four
+ * months earlier, which predates the page-response read-back added in 0.2.219.
+ * Pages calling `notFound()` recorded a 404 that nothing read, so deleted
+ * pages answered 200 with their own not-found body.
+ *
+ * Kept in its own module so the rule can be tested without binding a port.
+ */
+export type StxSource =
+  /** Use the package resolved from `node_modules`. */
+  | { kind: 'installed' }
+  /** Use the file the operator named, which is present. */
+  | { kind: 'override', path: string }
+  /** The operator named a file that is not there. Refuse rather than guess. */
+  | { kind: 'missing', path: string }
+
+export interface ResolveStxSourceOptions {
+  /** Raw environment value, if any. */
+  value: string | undefined
+  /** Injected for tests. */
+  exists?: (path: string) => boolean
+}
+
+export function resolveStxSource(options: ResolveStxSourceOptions): StxSource {
+  const exists = options.exists ?? existsSync
+  // An empty or whitespace-only value is an unset variable that went through a
+  // shell, not a request for a copy at the path `''`.
+  const path = options.value?.trim()
+  if (!path)
+    return { kind: 'installed' }
+
+  return exists(path) ? { kind: 'override', path } : { kind: 'missing', path }
+}

--- a/storage/framework/core/buddy/tests/stx-source.test.ts
+++ b/storage/framework/core/buddy/tests/stx-source.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { resolveStxSource } from '../src/stx-source'
+
+describe('resolveStxSource', () => {
+  const missing = () => false
+  const present = () => true
+
+  it('uses the installed dependency when nothing is named', () => {
+    expect(resolveStxSource({ value: undefined, exists: present })).toEqual({ kind: 'installed' })
+  })
+
+  it('treats an empty or whitespace value as unset', () => {
+    // `BUN_PLUGIN_STX_SRC= buddy serve` is an operator clearing the variable,
+    // not asking for a copy at the path ''.
+    expect(resolveStxSource({ value: '', exists: present })).toEqual({ kind: 'installed' })
+    expect(resolveStxSource({ value: '   ', exists: present })).toEqual({ kind: 'installed' })
+  })
+
+  it('uses a named copy that is present', () => {
+    expect(resolveStxSource({ value: '/srv/stx/serve.js', exists: present }))
+      .toEqual({ kind: 'override', path: '/srv/stx/serve.js' })
+  })
+
+  it('refuses a named copy that is absent rather than falling back silently', () => {
+    // Falling back would answer a request for a specific build by serving a
+    // different one, which is the confusion this whole module exists to end.
+    expect(resolveStxSource({ value: '/gone/serve.js', exists: missing }))
+      .toEqual({ kind: 'missing', path: '/gone/serve.js' })
+  })
+})
+
+describe('the production server does not prefer untracked local copies (#2369)', () => {
+  const source = readFileSync(
+    join(import.meta.dir, '../src/production-server.ts'),
+    'utf8',
+  )
+  // Comments explain the history and name both, so only look at real code.
+  const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter(line => !line.trim().startsWith('//'))
+    .join('\n')
+
+  it('never resolves stx out of the project pantry directory', () => {
+    // An app on bun-plugin-stx 0.2.231 rendered every page through a
+    // pantry copy of 0.2.76, which predates the page-response read-back, so
+    // `notFound()` recorded a 404 that nothing read and deleted pages
+    // answered 200. The declared dependency has to win.
+    expect(code).not.toContain('pantry/')
+  })
+
+  it('never resolves stx out of a hardcoded home directory path', () => {
+    expect(code).not.toContain('Code/Tools/stx')
+    expect(code).not.toContain('homedir(')
+  })
+
+  it('reaches the installed packages by name', () => {
+    expect(code).toContain('bun-plugin-stx/serve')
+    expect(code).toContain('@stacksjs/stx')
+  })
+})


### PR DESCRIPTION
Closes #2369.

## The read-back is not missing

The issue's diagnosis was that `buddy serve` never calls `readResponseStatus`, and grepping `@stacksjs/buddy/dist` for it does come back empty. But buddy does not render pages itself: it delegates to `bun-plugin-stx`'s `serve`, which **has** done the read-back since **0.2.219**. Buddy inherits it.

I could not reproduce the bug on this repo. A probe page identical to the issue's returned:

```
HTTP/1.1 404 Not Found
X-Probe-Header: reached
```

So the question was not "why does no host implement the contract" but "which copy of `bun-plugin-stx` was that app running".

## Which copy

`production-server.ts` resolved stx by checking, in order:

```
~/Code/Tools/stx/packages/bun-plugin/dist/serve.js
<cwd>/pantry/bun-plugin-stx/dist/serve.js
bun-plugin-stx/serve
```

An **untracked directory outranked the declared dependency** in the process that answers production traffic, and nothing logged which one won.

The reporting app has `bun-plugin-stx@0.2.231` in `node_modules` and a `pantry/bun-plugin-stx@0.2.76` copy dated July 3. The pantry copy is 155 versions behind and predates the read-back entirely (`grep -c readResponseStatus` on its `dist/serve.js`: **0**), so every page it rendered recorded a status that nothing read.

I confirmed the version boundary by unpacking releases: the read-back is absent through 0.2.218 and present from 0.2.220.

## Reproduced both directions

Rather than infer it, I copied that exact 0.2.76 pantry directory into this repo and ran the same probe page:

| condition | result |
|---|---|
| stale pantry copy present | `200 OK`, no probe header |
| stale pantry copy removed | `404`, `X-Probe-Header: reached` |
| **after this change**, stale copy still on disk | `404`, `X-Probe-Header: reached` |

## What changed

The same shadowing pattern appeared **three times** in this file: the `serve` implementation, the stx module used for `{t:…}` tokens, and a third candidate list inside `resolveSiteI18n`. All three now resolve the installed package by name. The i18n one shares the module resolver instead of repeating a candidate list, because two lists that are supposed to agree are how one ends up pointing somewhere the other does not.

Running a local build is still supported, but it is now something you **opt into by naming the path**:

- `BUN_PLUGIN_STX_SRC` for the serve implementation, already the spelling `dev/dashboard.ts` uses
- `STACKS_STX_SRC` for the module

The server warns which copy it loaded, and a path that does not exist refuses to boot rather than silently falling back to a different build than the one asked for. Both refusals use `log.exit`, since `log.error` followed by `process.exit` prints nothing (the write is async and the exit does not wait for it) - the first draft refused to start while explaining why to nobody.

## Testing

- `resolveStxSource` is its own module so the rule is testable without binding a port: unset, empty, whitespace, present-override, absent-override
- a guard test asserting `production-server.ts` contains no `pantry/`, no `Code/Tools/stx` and no `homedir(` in real code, stripping comments first since the comments explain the history and name both. I verified the guard fails when a pantry candidate is reintroduced rather than assuming it would
- buddy suite: 550 pass, 0 fail
- `bun test ./tests`: 365 pass, 0 fail
- `./buddy lint`: 3198 files, 0 errors, 0 warnings
- `./buddy typecheck`: clean

## For the reporting app

No framework release is needed to unblock it: deleting `pantry/` from that app, or upgrading the copy in it, fixes the soft 404s immediately. This change is what stops it happening again, and makes it visible when it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)