### PR TITLE
fix(deploy): stop counting headless sites as page servers

### DIFF
--- a/storage/framework/core/buddy/src/commands/deploy.ts
+++ b/storage/framework/core/buddy/src/commands/deploy.ts
@@ -1434,6 +1434,24 @@ function servesApi(name: string, site: any): boolean {
 }
 
 /**
+ * Whether a site can receive an HTTP request at all.
+ *
+ * A server app is only reachable if something routes to it: its own listening
+ * port, or a domain the gateway sends traffic to. `bun buddy queue:work` and
+ * `bun buddy schedule:run` have neither - they are long-running processes with
+ * no listener, so nothing can request `/api/**` from them and nothing can 502.
+ *
+ * The classifier used to treat any site with a `start` string as a page
+ * server, which refused whole deploys over a proxy relationship a headless
+ * worker cannot have (stacksjs/stacks#2367). Note that the API site itself is
+ * deliberately domain-less, loopback-only on its own port, so a port alone has
+ * to count.
+ */
+function servesHttp(site: any): boolean {
+  return Boolean(site?.port || site?.domain)
+}
+
+/**
  * How each site was classified, for the error message.
  *
  * The old messages asserted a conclusion the operator could see was false ("no
@@ -1448,6 +1466,8 @@ function describeSiteClassification(sites: Record<string, any>): string {
     .map(([name, site]) => {
       if (servesApi(name, site))
         return `\`${name}\` (api)`
+      if (!servesHttp(site))
+        return `\`${name}\` (headless, no HTTP surface)`
       const env = (site?.env ?? {}) as Record<string, unknown>
       const wiring = env.API_URL ? 'API_URL set' : env.PORT_API ? 'PORT_API set' : 'no API_URL or PORT_API'
       return `\`${name}\` (page, ${wiring})`
@@ -1507,7 +1527,13 @@ export function apiDeploymentProblem(sites: Record<string, any>, hasApiRoutes: b
   // not `routes/api.ts`. Holding it to "must proxy to the project's API" asks
   // it to wire up routes it does not serve, and refuses every deploy of a box
   // that has a dashboard on it.
-  const pages = appSites.filter(([name, site]) => !servesApi(name, site) && !isDashboardSite(name))
+  //
+  // And not a headless process. A site with no port and no domain has no HTTP
+  // surface to proxy from, so requiring it to declare `PORT_API` records a
+  // relationship that does not exist and refuses deploys that were correct
+  // (stacksjs/stacks#2367).
+  const pages = appSites.filter(([name, site]) =>
+    !servesApi(name, site) && !isDashboardSite(name) && servesHttp(site))
 
   // Somebody has pointed the proxy somewhere explicitly. That is intent, and
   // it covers the API living on another host entirely.

--- a/storage/framework/core/buddy/tests/deploy-api-reachable.test.ts
+++ b/storage/framework/core/buddy/tests/deploy-api-reachable.test.ts
@@ -107,13 +107,13 @@ describe('apiDeploymentProblem: classifying the API site (#2349)', () => {
   it('does not mistake a neighbouring path for the API entrypoint', () => {
     // `preserve/api.js` ends in the same characters; the boundary has to hold
     // or an unrelated site silently becomes the API and the real one is missed.
-    const problem = apiDeploymentProblem({ pages: { start: 'bun cli.js serve' }, other: { start: 'bun preserve/api.jsx' } }, true)
+    const problem = apiDeploymentProblem({ pages: { start: 'bun cli.js serve', port: 3000 }, other: { start: 'bun preserve/api.jsx', port: 3050 } }, true)
 
     expect(problem).toContain('no site serves them')
   })
 
   it('shows how every site was classified when it refuses', () => {
-    const problem = apiDeploymentProblem({ main: { start: 'bun cli.js serve' }, worker: { start: 'bun queue.js' } }, true)
+    const problem = apiDeploymentProblem({ main: { start: 'bun cli.js serve', port: 3000 }, worker: { start: 'bun queue.js', port: 3099 } }, true)
 
     expect(problem).toContain('Sites examined:')
     expect(problem).toContain('`main` (page, no API_URL or PORT_API)')
@@ -121,7 +121,7 @@ describe('apiDeploymentProblem: classifying the API site (#2349)', () => {
   })
 
   it('names the API site in the classification when one is found but unwired', () => {
-    const problem = apiDeploymentProblem({ 'main': { start: 'bun cli.js serve' }, 'loghq-api': loghqApi }, true)
+    const problem = apiDeploymentProblem({ 'main': { start: 'bun cli.js serve', port: 3000 }, 'loghq-api': loghqApi }, true)
 
     expect(problem).toContain('`loghq-api` (api)')
     expect(problem).toContain('`main` (page, no API_URL or PORT_API)')
@@ -170,5 +170,50 @@ describe('apiDeploymentProblem and the ts-cloud dashboard', () => {
 
     expect(problem).toContain('`main`')
     expect(problem).not.toContain('dashboard-stacksjs-com` will not proxy')
+  })
+})
+
+describe('apiDeploymentProblem: headless sites (#2367)', () => {
+  // `bun buddy queue:work` and `bun buddy schedule:run`, verbatim in shape:
+  // a `start` command, an environment, and no listener of any kind.
+  const worker = { root: '.', start: 'bun buddy queue:work', preStart: ['bun install'], env: { APP_ENV: 'production' } }
+  const scheduler = { root: '.', start: 'bun buddy schedule:run', preStart: ['bun install'], env: { APP_ENV: 'production' } }
+
+  it('does not require a headless worker to proxy to the API', () => {
+    // The reported failure: a valid config refused before anything uploaded,
+    // over an `/api/**` surface these processes never expose.
+    expect(apiDeploymentProblem({
+      main: { ...pageSite, env: { PORT_API: '3008' } },
+      api: apiSite,
+      worker,
+      scheduler,
+    }, true)).toBeUndefined()
+  })
+
+  it('does not claim the API is unserved when the site set is one headless worker', () => {
+    // The second branch of the same misclassification, and the more dangerous
+    // one: a role-specific deploy whose set has no API site because the
+    // primary owns it. This workflow only runs when its own config changes, so
+    // it stayed broken quietly.
+    expect(apiDeploymentProblem({ checksWorker: worker }, true)).toBeUndefined()
+  })
+
+  it('reports a headless site as headless rather than as an unwired page', () => {
+    const problem = apiDeploymentProblem({ main: pageSite, api: apiSite, worker }, true)
+
+    expect(problem).toContain('`main` (page, no API_URL or PORT_API)')
+    expect(problem).toContain('`worker` (headless, no HTTP surface)')
+  })
+
+  it('still holds a page server to the check when it declares only a domain', () => {
+    // Reachable through the gateway without declaring a port, so it does proxy
+    // `/api/**` and does need to say where.
+    const problem = apiDeploymentProblem({
+      main: { start: 'bun cli.js serve', domain: 'example.com' },
+      api: apiSite,
+    }, true)
+
+    expect(problem).toContain('`main`')
+    expect(problem).toContain('PORT_API')
   })
 })


### PR DESCRIPTION
Closes #2367.

`apiDeploymentProblem` classified every site with a `start` string as a page server, then refused the deploy because those "pages" declared no `PORT_API`:

```js
const appSites = entries.filter(([, site]) => typeof site?.start === 'string')
const pages = appSites.filter(([name, site]) => !servesApi(name, site) && !isDashboardSite(name))
```

`bun buddy queue:work` and `bun buddy schedule:run` have no port, no domain and no listener of any kind. Nothing can request `/api/**` from them, so nothing can 502. The deploy was refused before anything uploaded, over a proxy relationship those processes cannot have.

The second branch of the same misclassification is worse: a role-specific deploy whose site set is one headless worker reported *"This project declares API routes and no site serves them"*, because the primary owns the API and that set was never meant to have one. That workflow only runs when its own config file changes, so it stayed broken quietly rather than failing loudly.

## The predicate

A site is now only held to the check if it can receive an HTTP request at all:

```ts
function servesHttp(site: any): boolean {
  return Boolean(site?.port || site?.domain)
}
```

Neither means no gateway entry (rpx skips domain-less sites, which is exactly why the `api` site omits one) and no declared listener. A port alone has to count, because the API site is deliberately domain-less and loopback-only on its own port.

`describeSiteClassification` now reports these as `(headless, no HTTP surface)` instead of `(page, no API_URL or PORT_API)`, so the line reporting a refusal no longer asserts something the operator can see is false.

## The check still does its job

The original failure it was added for is untouched: reviewos.org shipped a public page site returning 200 while every `/api` request 502'd. A public page site necessarily has a domain or a port, so it still lands in `pages`. There is a test for the domain-only case.

Three existing fixtures omitted `port` as test shorthand while actually testing API-site detection (#2349). They now declare the port a real page server has. Calling that out explicitly since it is a test change riding along with a behaviour change.

## Testing

Four new tests, two of which reproduce the reported failures verbatim in shape. I verified those two fail against the old classification rather than assuming they would.

- buddy suite: 554 pass, 0 fail
- `bun test ./tests`: 365 pass, 0 fail
- `./buddy lint`: 3198 files, 0 errors, 0 warnings
- `./buddy typecheck`: clean

## Workaround until this lands

Setting `PORT_API` on the headless sites satisfies the check and unblocks the deploy. As the issue notes, it records a proxy relationship that does not exist, so it is worth removing once this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)