### PR TITLE
fix(migrations): match a generated CREATE on its table, not its formatting

### DIFF
--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -3149,6 +3149,64 @@ export async function regenerateMigrationCorpus(options: {
   }
 }
 
+/**
+ * The table a `CREATE TABLE` statement creates, lowercased, or undefined.
+ *
+ * Quoting varies by dialect and by whoever wrote the committed file, so all
+ * four spellings have to reach the same name.
+ */
+export function createdTableName(statement: string): string | undefined {
+  const match = /^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["'`[]?([\w$]+)["'`\]]?/i.exec(statement)
+  return match?.[1]?.toLowerCase()
+}
+
+export interface CommittedMigrationIndex {
+  /** Every committed statement, whitespace-normalized, for exact matching. */
+  sql: string
+  /** Tables the committed corpus already creates. */
+  createdTables: Set<string>
+}
+
+export function indexCommittedMigrations(fileContents: readonly string[]): CommittedMigrationIndex {
+  const createdTables = new Set<string>()
+  for (const contents of fileContents) {
+    for (const statement of contents.split(';')) {
+      const table = createdTableName(statement)
+      if (table)
+        createdTables.add(table)
+    }
+  }
+  return { sql: normalizeSqlForComparison(fileContents.join('\n')), createdTables }
+}
+
+function normalizeSqlForComparison(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Whether a generated statement is already represented in the committed corpus.
+ *
+ * Text matching alone is too weak for `CREATE TABLE`. The generator's
+ * formatting does not have to agree with whatever wrote the committed file - a
+ * hand-authored migration, an older generator, one of the guarantee helpers -
+ * and a single differing space means the statement reads as new. The result is
+ * a SECOND `CREATE TABLE notification_deliveries` written next to the one the
+ * corpus already had, which is what `migrate:fresh` was leaving behind on a
+ * freshly scaffolded app: a failed migration, a half-built database, and
+ * fifteen untracked files to notice and delete (stacksjs/stacks#2323).
+ *
+ * So a `CREATE TABLE` is matched on the table it creates rather than on how it
+ * is written. Everything else still compares text, because an `ALTER` or an
+ * `UPDATE` is only redundant if it is genuinely the same statement.
+ */
+export function generatedStatementIsRedundant(statement: string, index: CommittedMigrationIndex): boolean {
+  const table = createdTableName(statement)
+  if (table)
+    return index.createdTables.has(table)
+
+  return index.sql.includes(normalizeSqlForComparison(statement))
+}
+
 function persistGeneratedMigrations(sqlStatements: string[]): number {
   if (!sqlStatements?.length)
     return 0
@@ -3160,21 +3218,30 @@ function persistGeneratedMigrations(sqlStatements: string[]): number {
   // Skip statements already represented in committed migrations. The qb
   // diff will sometimes restate things after the snapshot gets rewritten,
   // and we'd rather no-op than create a duplicate file.
-  let existingSql = ''
+  const committed: string[] = []
   try {
     for (const f of readdirSync(migrationsDir).filter(f => f.endsWith('.sql')))
-      existingSql += `\n${readFileSync(join(migrationsDir, f), 'utf8')}`
+      committed.push(readFileSync(join(migrationsDir, f), 'utf8'))
   }
   catch { /* nothing committed yet */ }
-  const normalize = (s: string): string => s.replace(/\s+/g, ' ').trim()
-  const haystack = normalize(existingSql)
+  const index = indexCommittedMigrations(committed)
 
   const groups = groupGeneratedStatements(sqlStatements)
   let written = 0
   let cursor = nextMigrationNumber(migrationsDir)
 
   for (const group of groups) {
-    const fresh = group.statements.filter(stmt => !haystack.includes(normalize(stmt)))
+    const fresh = group.statements.filter((stmt) => {
+      if (!generatedStatementIsRedundant(stmt, index))
+        return true
+      // Named rather than dropped in silence: if the corpus creates a table
+      // whose shape has since moved on, this line is the breadcrumb, and
+      // `migrate:regenerate` is the command that rebuilds it properly.
+      const table = createdTableName(stmt)
+      if (table)
+        log.debug(`[migration] Skipping generated CREATE for "${table}" - the committed corpus already creates it.`)
+      return false
+    })
     if (fresh.length === 0)
       continue
 

--- a/storage/framework/core/database/tests/generated-create-dedup.test.ts
+++ b/storage/framework/core/database/tests/generated-create-dedup.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test'
+import { createdTableName, generatedStatementIsRedundant, indexCommittedMigrations } from '../src/migrations'
+
+describe('createdTableName', () => {
+  it('reads the table out of every spelling a corpus uses', () => {
+    expect(createdTableName('CREATE TABLE notification_deliveries (id INTEGER)')).toBe('notification_deliveries')
+    expect(createdTableName('CREATE TABLE IF NOT EXISTS "notifications" (id INTEGER)')).toBe('notifications')
+    expect(createdTableName('  create table `team_members` (id INTEGER)')).toBe('team_members')
+    expect(createdTableName('CREATE TABLE [releases] (id INTEGER)')).toBe('releases')
+  })
+
+  it('is not fooled by a statement that merely mentions a table', () => {
+    expect(createdTableName('ALTER TABLE releases ADD COLUMN tag TEXT')).toBeUndefined()
+    expect(createdTableName('UPDATE notification_deliveries SET channel = \'email\'')).toBeUndefined()
+    expect(createdTableName('CREATE INDEX idx_releases_tag ON releases (tag)')).toBeUndefined()
+  })
+})
+
+describe('generatedStatementIsRedundant', () => {
+  it('skips a CREATE for a table the corpus already creates, however it is written', () => {
+    // The #2323 case. The committed file and the generator do not have to
+    // agree on whitespace, quoting, or column order for the table to already
+    // exist, and a textual comparison wrote a second CREATE whenever they
+    // differed by so much as a space.
+    const index = indexCommittedMigrations([
+      `CREATE TABLE notification_deliveries (\n  id INTEGER PRIMARY KEY,\n  channel TEXT\n);`,
+    ])
+
+    expect(generatedStatementIsRedundant(
+      `CREATE TABLE IF NOT EXISTS "notification_deliveries" (id INTEGER PRIMARY KEY, channel TEXT, status TEXT)`,
+      index,
+    )).toBe(true)
+  })
+
+  it('still writes a CREATE for a table nothing has created', () => {
+    const index = indexCommittedMigrations(['CREATE TABLE users (id INTEGER);'])
+
+    expect(generatedStatementIsRedundant('CREATE TABLE teams (id INTEGER)', index)).toBe(false)
+  })
+
+  it('compares non-CREATE statements on their text, not their table', () => {
+    // An ALTER or an UPDATE is only redundant if it is the same statement.
+    // Matching those on the table name would drop every later change to a
+    // table the corpus happens to create.
+    const index = indexCommittedMigrations([
+      'CREATE TABLE releases (id INTEGER);\nALTER TABLE releases ADD COLUMN tag TEXT;',
+    ])
+
+    expect(generatedStatementIsRedundant('ALTER TABLE releases ADD COLUMN tag TEXT', index)).toBe(true)
+    expect(generatedStatementIsRedundant('ALTER TABLE releases ADD COLUMN channel TEXT', index)).toBe(false)
+  })
+
+  it('ignores whitespace differences on the statements it matches textually', () => {
+    const index = indexCommittedMigrations(['ALTER TABLE  releases   ADD COLUMN tag TEXT;'])
+
+    expect(generatedStatementIsRedundant('ALTER TABLE releases ADD COLUMN tag TEXT', index)).toBe(true)
+  })
+
+  it('treats an empty corpus as creating nothing', () => {
+    const index = indexCommittedMigrations([])
+
+    expect(index.createdTables.size).toBe(0)
+    expect(generatedStatementIsRedundant('CREATE TABLE users (id INTEGER)', index)).toBe(false)
+  })
+
+  it('indexes every CREATE in a multi-statement file', () => {
+    const index = indexCommittedMigrations([
+      'CREATE TABLE a (id INTEGER);\nCREATE TABLE IF NOT EXISTS b (id INTEGER);\nALTER TABLE a ADD COLUMN x TEXT;',
+    ])
+
+    expect([...index.createdTables].sort()).toEqual(['a', 'b'])
+  })
+})


### PR DESCRIPTION
Refs #2323. Fixes the duplicate-file half of it; see the note at the bottom on the crash.

## The defect

`persistGeneratedMigrations` decided whether a generated statement was already committed by concatenating every `.sql` in the corpus, normalizing whitespace, and asking whether the statement appeared in it:

```ts
const haystack = normalize(existingSql)
const fresh = group.statements.filter(stmt => !haystack.includes(normalize(stmt)))
```

For a `CREATE TABLE` that is too weak. The generator's output does not have to agree character for character with whatever wrote the committed file, whether that was a hand-authored migration, an older generator, or one of the guarantee helpers. Any difference at all reads as a new statement.

The reporter's exact case, checked against the old comparison:

```
committed:  CREATE TABLE notification_deliveries (
              id INTEGER PRIMARY KEY,
              channel TEXT
            );
generated:  CREATE TABLE IF NOT EXISTS "notification_deliveries" (id INTEGER PRIMARY KEY, channel TEXT, status TEXT)

old textual dedup says redundant: false
```

So `migrate:fresh` wrote a second `CREATE TABLE notification_deliveries` next to the one already in the corpus, and fourteen more like it: fifteen untracked files to notice and delete on a tree that was clean a moment earlier.

It also explains the non-determinism the issue notes. The comparison is against text that shifts as the snapshot is rewritten, so which statements look new shifts with it.

## The change

A `CREATE TABLE` is matched on the **table it creates**, across the four quoting styles a corpus uses (bare, `"`, backtick, `[`). Everything else still compares text, because an `ALTER` or an `UPDATE` is only redundant if it is genuinely the same statement, and matching those on their table would drop every later change to a table the corpus happens to create.

A skipped CREATE is logged with the table name rather than dropped in silence, so a corpus whose shape has since moved on leaves a breadcrumb pointing at `migrate:regenerate`.

## Testing

`createdTableName`, `indexCommittedMigrations` and `generatedStatementIsRedundant` are exported and tested directly: eight tests covering the quoting styles, statements that merely mention a table (`ALTER`, `UPDATE`, `CREATE INDEX`), the text path, and an empty corpus.

- database suite: 854 pass, 0 fail
- `bun test ./tests`: 365 pass, 0 fail
- `./buddy lint`: 3198 files, 0 errors, 0 warnings
- `./buddy typecheck`: clean

## On the crash in that issue

The `no such table: notification_deliveries` failure looks already addressed on main. `d2e67ae5a4` (2026-08-16) added a bootstrap to `migrate/fresh.ts` that creates `notifications` and `notification_deliveries` before the corpus replays, precisely so the historical normalization migrations that write to them can run:

```ts
const notificationBootstrap = await migrateNotificationTables({ tables: ['notifications', 'notification_deliveries'] })
```

The issue was filed against `v0.70.371`, tagged 2026-08-13, three days earlier.

I could **not** re-verify that end to end. `buddy new` downloads a pinned template rather than building from the working tree, so a scaffold on this branch does not exercise this code. Calling that out rather than claiming the crash is fixed: this PR is scoped to the pollution, which is independently reproducible and independently wrong. The issue is worth leaving open until someone can run the original repro against a current scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)