### PR TITLE
fix(migrations): gate data statements, not just DDL

### DIFF
--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -1142,21 +1142,84 @@ async function hideDisabledFeatureMigrations(): Promise<Array<{ original: string
  * Only the forms the generator emits are recognised; anything unrecognised
  * comes back null and is therefore kept, which is the safe direction.
  */
+/**
+ * Drop the leading `WITH ... AS (...)` list so the statement's real verb is
+ * first.
+ *
+ * A common table expression pushes the verb past the CTE body, so a pattern
+ * anchored at the start of the statement sees `WITH` and nothing it
+ * recognises. `0000000133-normalize-tag-uniques.sql` is written that way, and
+ * it is why the gate let it through (stacksjs/stacks#2323).
+ */
+function afterCommonTableExpressions(statement: string): string {
+  if (!/^\s*WITH\b/i.test(statement))
+    return statement
+
+  let depth = 0
+  for (let index = 0; index < statement.length; index++) {
+    const char = statement[index]
+    if (char === '(') {
+      depth++
+      continue
+    }
+    if (char !== ')')
+      continue
+
+    depth--
+    if (depth !== 0)
+      continue
+
+    const rest = statement.slice(index + 1)
+    // A comma means another CTE follows; keep walking to the next body.
+    if (/^\s*,/.test(rest))
+      continue
+    return rest
+  }
+
+  return statement
+}
+
+/**
+ * The table a statement acts on, or null when it acts on none we can name.
+ *
+ * DDL was the whole list here, which meant a `UPDATE tags` read as "no table"
+ * and was kept by every caller that filters on this. Data statements are the
+ * ones a feature gate most needs to see: a disabled feature's CREATE is
+ * hidden, so anything that later writes to that table has nothing to write to.
+ */
 export function statementTable(statement: string): string | null {
+  const body = afterCommonTableExpressions(statement)
   const patterns = [
     /^\s*ALTER\s+TABLE\s+["`]?([a-z0-9_]+)["`]?/i,
     /^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["`]?([a-z0-9_]+)["`]?/i,
     /^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?["`]?([a-z0-9_]+)["`]?/i,
     /^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?["`]?[a-z0-9_]+["`]?\s+ON\s+["`]?([a-z0-9_]+)["`]?/i,
+    /^\s*UPDATE\s+["`]?([a-z0-9_]+)["`]?/i,
+    /^\s*INSERT\s+(?:OR\s+\w+\s+)?INTO\s+["`]?([a-z0-9_]+)["`]?/i,
+    /^\s*DELETE\s+FROM\s+["`]?([a-z0-9_]+)["`]?/i,
   ]
 
   for (const pattern of patterns) {
-    const match = pattern.exec(statement)
+    const match = pattern.exec(body)
     if (match)
       return match[1]!.toLowerCase()
   }
 
   return null
+}
+
+/**
+ * Whether a statement names a table anywhere, not just as its target.
+ *
+ * The target alone is not enough. `0000000133` reads `FROM tags` inside a CTE
+ * before updating it, and a statement that reads a table which was never
+ * created fails exactly as loudly as one that writes to it. There is no case
+ * where naming a missing table succeeds, so matching a reference anywhere is
+ * the conservative direction.
+ */
+export function statementReferencesTable(statement: string, table: string): boolean {
+  const escaped = table.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`\\b(?:FROM|JOIN|UPDATE|INTO)\\s+["\`\\[]?${escaped}["\`\\]]?\\b`, 'i').test(statement)
 }
 
 /**
@@ -1177,8 +1240,16 @@ export function withoutGatedStatements(sql: string, gated: ReadonlySet<string>):
   const statements = sql.split(';').map(s => s.trim()).filter(Boolean)
   const kept = statements.filter((statement) => {
     const table = statementTable(statement)
+    if (table && gated.has(table))
+      return false
 
-    return !table || !gated.has(table)
+    // Not only the target: a gated table read in a subquery is just as absent.
+    for (const candidate of gated) {
+      if (statementReferencesTable(statement, candidate))
+        return false
+    }
+
+    return true
   })
 
   if (kept.length === statements.length)

--- a/storage/framework/core/database/tests/gated-dml-statements.test.ts
+++ b/storage/framework/core/database/tests/gated-dml-statements.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test'
+import { statementReferencesTable, statementTable, withoutGatedStatements } from '../src/migrations'
+
+// Verbatim from `0000000133-normalize-tag-uniques.sql`, the statement that
+// failed a `migrate:fresh` on a `--minimal` scaffold with `no such table: tags`.
+const CTE_UPDATE = `WITH duplicate_names AS (
+  SELECT id
+  FROM (
+    SELECT id, ROW_NUMBER() OVER (PARTITION BY name ORDER BY id) AS duplicate_rank
+    FROM tags
+  )
+  WHERE duplicate_rank > 1
+)
+UPDATE tags
+SET name = SUBSTR(name, 1, 40) || '-' || id
+WHERE id IN (SELECT id FROM duplicate_names)`
+
+describe('statementTable', () => {
+  it('still reads the DDL forms it always did', () => {
+    expect(statementTable('ALTER TABLE tags ADD COLUMN color TEXT')).toBe('tags')
+    expect(statementTable('CREATE TABLE IF NOT EXISTS "tags" (id INTEGER)')).toBe('tags')
+    expect(statementTable('DROP TABLE IF EXISTS tags')).toBe('tags')
+    expect(statementTable('CREATE UNIQUE INDEX tags_slug ON tags (slug)')).toBe('tags')
+  })
+
+  it('reads data statements, which it used to call untabled', () => {
+    // These returned null, so every caller filtering on this kept them.
+    expect(statementTable('UPDATE coupons SET is_active = 1')).toBe('coupons')
+    expect(statementTable('INSERT INTO tags (name) VALUES (\'x\')')).toBe('tags')
+    expect(statementTable('INSERT OR IGNORE INTO tags (name) VALUES (\'x\')')).toBe('tags')
+    expect(statementTable('DELETE FROM tags WHERE id = 1')).toBe('tags')
+  })
+
+  it('sees past a common table expression to the verb', () => {
+    expect(statementTable(CTE_UPDATE)).toBe('tags')
+  })
+
+  it('sees past several chained common table expressions', () => {
+    const chained = `WITH a AS (SELECT 1), b AS (SELECT 2) UPDATE tags SET name = 'x'`
+    expect(statementTable(chained)).toBe('tags')
+  })
+
+  it('returns null for a statement naming no table it can identify', () => {
+    expect(statementTable('PRAGMA foreign_keys = ON')).toBeNull()
+  })
+})
+
+describe('statementReferencesTable', () => {
+  it('finds a table read inside a subquery, not just the target', () => {
+    expect(statementReferencesTable(CTE_UPDATE, 'tags')).toBe(true)
+  })
+
+  it('does not match a table whose name merely contains another', () => {
+    expect(statementReferencesTable('SELECT 1 FROM taggables', 'tags')).toBe(false)
+    expect(statementReferencesTable('UPDATE tag_groups SET x = 1', 'tags')).toBe(false)
+  })
+})
+
+describe('withoutGatedStatements', () => {
+  it('drops a CTE-led UPDATE against a gated table', () => {
+    // The #2323 failure. CMS off means `0000000100-create-tags-table.sql` is
+    // hidden and `tags` never exists, but this statement was kept and ran,
+    // so `migrate:fresh` exited 1 on a freshly scaffolded app.
+    const out = withoutGatedStatements(`${CTE_UPDATE};`, new Set(['tags']))
+
+    expect(out).toBe('')
+  })
+
+  it('keeps the statements whose tables are not gated', () => {
+    const sql = `UPDATE tags SET name = 'a';\nUPDATE users SET name = 'b';`
+    const out = withoutGatedStatements(sql, new Set(['tags']))
+
+    expect(out).toContain('UPDATE users')
+    expect(out).not.toContain('UPDATE tags')
+  })
+
+  it('leaves a file alone when nothing in it is gated', () => {
+    const sql = `UPDATE users SET name = 'b';`
+    expect(withoutGatedStatements(sql, new Set(['tags']))).toBe(sql)
+  })
+
+  it('is a no-op when nothing is gated at all', () => {
+    const sql = `UPDATE tags SET name = 'a';`
+    expect(withoutGatedStatements(sql, new Set())).toBe(sql)
+  })
+})


### PR DESCRIPTION
Fixes #2323.

## Reproduced

`buddy new --minimal`, `bun install`, then the documented reset, on stacks **0.72.86**:

```
$ ./buddy migrate            # exit 0, tree clean
$ ./buddy migrate:fresh --force
EXIT=1
Migration failed: no such table: tags
```

The runner jumps `0000000098 → 0000000101`, so `0000000100-create-tags-table.sql` never ran, and `0000000133-normalize-tag-uniques.sql` then failed against a table that does not exist.

## Why

The feature gate hides migrations belonging to disabled features and collects the tables they would have created, so that later statements against those tables can be stripped for the run. A `--minimal` scaffold has CMS off:

```
[migration] Skipping 169 migration(s) for disabled features
  (commerce: 92, dashboard: 19, marketing: 8, cms: 24, monitoring: 2, queue: 4, forms: 3, realtime: 1, mixed: 16)
```

The hiding works. The stripping does not, for two compounding reasons:

**`statementTable` knew only DDL.** `ALTER TABLE`, `CREATE TABLE`, `DROP TABLE`, `CREATE INDEX ... ON`. A `UPDATE tags` reported "no table", and every caller filtering on it therefore kept the statement.

**Its patterns anchor at the start of the statement**, and `0000000133` opens with a common table expression, so the verb is not where they look:

```sql
WITH duplicate_names AS ( ... FROM tags ) UPDATE tags SET ...
```

Run against the real file with the tables a minimal scaffold gates:

```
statements in file:  5
OLD gate keeps:      5   <- four target tables that do not exist
NEW gate keeps:      1
```

The four the old gate kept: two CTE-led `UPDATE tags`, one `UPDATE coupons`, one `UPDATE authors`.

## The change

- `statementTable` skips a leading CTE list before matching, and recognises `UPDATE`, `INSERT INTO` (including `INSERT OR IGNORE INTO`) and `DELETE FROM`
- `withoutGatedStatements` also drops a statement that names a gated table **anywhere**, not only as its target. `0000000133` reads `FROM tags` inside its CTE, and a statement reading a table that was never created fails exactly as loudly as one writing to it. There is no case where naming a missing table succeeds, so that is the conservative direction.

Word boundaries are respected, so `tags` does not match `taggables` or `tag_groups`.

## Testing

11 tests, including the failing statement verbatim from the corpus, chained CTEs, the DDL forms that must keep working, and the near-miss table names.

- database suite: 865 pass, 0 fail
- `bun test ./tests`: 365 pass, 0 fail
- `./buddy lint`: 3198 files, 0 errors, 0 warnings
- `./buddy typecheck`: clean

## Correction to #2373

That PR fixed the duplicate-file half of #2323, and its description says the crash "looks already fixed by `d2e67ae5a4`". That was inference from a commit date, and it was wrong. `d2e67ae5a4` bootstraps `notifications` and `notification_deliveries` specifically, which is why the reporter's error named one of them. The failure just moves to the next gated table. This PR is the actual cause.

I should have scaffolded and run it before writing that, rather than reasoning from the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)