### PR TITLE
fix(router): say at boot which root-mounted routes can never be reached

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -133,6 +133,7 @@
         "@stacksjs/logging": "workspace:*",
         "@stacksjs/path": "workspace:*",
         "@stacksjs/security": "workspace:*",
+        "@stacksjs/server": "workspace:*",
         "@stacksjs/sites": "workspace:*",
         "@stacksjs/storage": "workspace:*",
         "@stacksjs/strings": "workspace:*",

--- a/storage/framework/core/actions/package.json
+++ b/storage/framework/core/actions/package.json
@@ -83,6 +83,7 @@
     "@stacksjs/logging": "workspace:*",
     "@stacksjs/path": "workspace:*",
     "@stacksjs/security": "workspace:*",
+    "@stacksjs/server": "workspace:*",
     "@stacksjs/cms": "workspace:*",
     "@stacksjs/sites": "workspace:*",
     "@stacksjs/storage": "workspace:*",

--- a/storage/framework/core/actions/src/serve/api.ts
+++ b/storage/framework/core/actions/src/serve/api.ts
@@ -83,6 +83,26 @@ route.use(corsMiddleware.toRouterHandler())
 // Import routes
 await route.importRoutes()
 
+// Say which of the app's own root-mounted routes the views server will never
+// forward, before this process starts answering. The route is registered here
+// and the request is answered there, so a root `GET` that no proxy rule
+// matches renders as a page, finds no page, and 404s - with the handler that
+// would have answered it sitting in this process, unreached and unmentioned
+// (stacksjs/stacks#2326). Best-effort: a diagnostic must never stop a boot.
+try {
+  const { describeUnforwardableRoutes, resolveApiProxyRules, unforwardableRoutes } = await import('@stacksjs/server')
+  const { listRootMountedAppRoutes } = await import('@stacksjs/router')
+  const unreachable = unforwardableRoutes(
+    listRootMountedAppRoutes().filter(entry => entry.method === 'GET' || entry.method === 'HEAD'),
+    resolveApiProxyRules((config as { server?: { proxy?: any } }).server?.proxy),
+  )
+  if (unreachable.length > 0)
+    log.warn(describeUnforwardableRoutes(unreachable))
+}
+catch (error) {
+  log.debug(`[Stacks API] Route reachability check skipped: ${error instanceof Error ? error.message : String(error)}`)
+}
+
 // This process answers JSON. Without this it also mounts a GET route for every
 // `.stx` under `resources/views` — bun-router finds the directory on its own —
 // and serves the whole site with no stylesheet and with every image 404ing,

--- a/storage/framework/core/router/src/index.ts
+++ b/storage/framework/core/router/src/index.ts
@@ -34,7 +34,8 @@ export { Middleware } from './middleware'
 export type { MiddlewareConfig, Request } from './middleware'
 
 // Export route loader
-export { loadRoutes } from './route-loader'
+export type { RootMountedAppRoute } from './route-loader'
+export { listRootMountedAppRoutes, loadRoutes } from './route-loader'
 
 // Export route registry types — owned here rather than in app/Routes.ts
 // so the path doesn't depend on a 5-level relative reach across the

--- a/storage/framework/core/router/src/route-loader.ts
+++ b/storage/framework/core/router/src/route-loader.ts
@@ -34,6 +34,34 @@ import { route } from './stacks-router'
  */
 const NO_PREFIX_KEYS = ['web']
 
+export interface RootMountedAppRoute {
+  method: string
+  path: string
+  /** The registry entry's route file, for the message that names the fix. */
+  file: string
+}
+
+/**
+ * Routes this app registered from its own route files at the document root.
+ *
+ * Recorded because they are the ones that can silently not exist. The views
+ * server forwards `/api/**` and mutating verbs to the API process and answers
+ * everything else itself, so a root-mounted `GET` is rendered as a page,
+ * found to be no page, and 404s - while the handler that would have answered
+ * it sits registered in another process (stacksjs/stacks#2326).
+ *
+ * Scoped to the app's own files on purpose. The framework registers around a
+ * hundred non-`/api` GET routes, and most are reached in a topology of their
+ * own: `/dashboard/**` through the dashboard server, `/__routes` on the API
+ * process itself. Reporting those would bury the one route the developer just
+ * wrote in a list of ninety-nine that are fine.
+ */
+const rootMountedAppRoutes: RootMountedAppRoute[] = []
+
+export function listRootMountedAppRoutes(): readonly RootMountedAppRoute[] {
+  return rootMountedAppRoutes
+}
+
 /**
  * Load all routes from the registry
  */
@@ -60,7 +88,21 @@ export async function loadRoutes(registry: RouteRegistry): Promise<void> {
         })
       }
       else {
+        // Root-mounted, and this is one of the app's own files rather than a
+        // framework default (those load later, from loadFrameworkRoutes).
+        // Diff the table around the import so we know which routes came from
+        // it, since the registry entry names a file and not its contents.
+        const before = registeredRouteKeys()
         await importRouteFile(config.path)
+        for (const entry of currentRouteTable()) {
+          const method = String(entry.method ?? '').toUpperCase()
+          const path = String(entry.path ?? '')
+          if (!method || !path || before.has(`${method} ${path}`))
+            continue
+          // The registry names a file relative to routes/, so print the
+          // path a reader can actually open.
+          rootMountedAppRoutes.push({ method, path, file: `routes/${config.path}.ts` })
+        }
       }
     }
     catch (error) {
@@ -339,4 +381,23 @@ function normalizeMiddleware(middleware: MiddlewareReference | MiddlewareReferen
   if (!middleware) return []
   if (typeof middleware === 'string') return [middleware]
   return middleware
+}
+
+/**
+ * The live route table.
+ *
+ * Reads `route.routes` rather than the middleware registry: the latter only
+ * holds routes that registered middleware, so it answers empty for a plain
+ * route file.
+ */
+function currentRouteTable(): Array<{ method?: string, path?: unknown }> {
+  return (route as unknown as { routes?: Array<{ method?: string, path?: unknown }> }).routes ?? []
+}
+
+/** The table keyed as `METHOD /path`, for diffing one import's effect. */
+function registeredRouteKeys(): Set<string> {
+  const keys = new Set<string>()
+  for (const entry of currentRouteTable())
+    keys.add(`${String(entry.method ?? '').toUpperCase()} ${String(entry.path ?? '')}`)
+  return keys
 }

--- a/storage/framework/core/server/src/proxy.ts
+++ b/storage/framework/core/server/src/proxy.ts
@@ -114,10 +114,24 @@ function matchesPrefix(pathname: string, prefix: string): boolean {
  * configuration pass it in.
  */
 export function isApiBoundRequest(req: Request, pathname: string, rules?: ApiProxyRules): boolean {
-  if (!rules)
-    return pathname.startsWith(DEFAULT_API_PREFIX) || DEFAULT_API_METHODS.includes(req.method)
+  return isApiBoundPath(req.method, pathname, rules)
+}
 
-  if (rules.methods.has(req.method))
+/**
+ * The same decision, without a `Request` to ask.
+ *
+ * Boot-time checks want to know whether a route the API registered can ever
+ * be reached through the views server, and constructing a `Request` per route
+ * to find out would be silly. More to the point, a second implementation of
+ * this rule would drift from the one that actually routes traffic, and a
+ * diagnostic that disagrees with the thing it describes is worse than none.
+ */
+export function isApiBoundPath(method: string, pathname: string, rules?: ApiProxyRules): boolean {
+  const verb = method.toUpperCase()
+  if (!rules)
+    return pathname.startsWith(DEFAULT_API_PREFIX) || DEFAULT_API_METHODS.includes(verb)
+
+  if (rules.methods.has(verb))
     return true
   if (rules.paths.includes(pathname))
     return true
@@ -142,6 +156,49 @@ export function describeApiProxyRules(rules: ApiProxyRules): string {
     parts.push(`paths ${rules.paths.join(' ')}`)
 
   return parts.join(', ')
+}
+
+export interface RoutePathLike {
+  method: string
+  path: string
+}
+
+/**
+ * Which of these routes the views server will never forward.
+ *
+ * A route the API process registers is only reachable through the views
+ * server if these rules send it there. `/api/**` and the mutating verbs go by
+ * default, which is why `route.post('/subscribe', …)` at the root works and
+ * `route.get('/sitemap.xml', …)` does not: the GET is not forwarded, stx
+ * renders it as a page, finds no page, and answers its own 404. The handler
+ * never runs and nothing says so (stacksjs/stacks#2326).
+ *
+ * Give this the app's own root-mounted routes, not the whole table. The
+ * framework registers around a hundred non-`/api` GETs that are reached in
+ * topologies of their own, and listing those buries the one that is broken.
+ */
+export function unforwardableRoutes<T extends RoutePathLike>(routes: readonly T[], rules: ApiProxyRules): T[] {
+  return routes.filter(route => !isApiBoundPath(route.method, route.path, rules))
+}
+
+/**
+ * The boot warning for routes that cannot be reached, naming the fix.
+ *
+ * The silence is the part the report called worst: the route is declared, it
+ * reads correctly in review, and it 404s in production the same way a typo
+ * would.
+ */
+export function describeUnforwardableRoutes(routes: readonly (RoutePathLike & { file?: string })[]): string {
+  const lines = routes.map((route) => {
+    const origin = route.file ? ` (${route.file})` : ''
+    return `  ${route.method} ${route.path}${origin}`
+  })
+
+  return [
+    `${routes.length} root-mounted route${routes.length === 1 ? '' : 's'} the views server will not forward, so ${routes.length === 1 ? 'it' : 'they'} will answer the view 404 rather than reaching the handler:`,
+    ...lines,
+    `Add them to \`proxy.paths\` in config/server.ts (or their prefix to \`proxy.prefixes\`) so the views server forwards them to the API.`,
+  ].join('\n')
 }
 
 export async function proxyToBackend(req: Request, backendBase: string, stripPrefix?: string): Promise<Response> {

--- a/storage/framework/core/server/tests/unforwardable-routes.test.ts
+++ b/storage/framework/core/server/tests/unforwardable-routes.test.ts
@@ -1,0 +1,66 @@
+/**
+ * stacksjs/stacks#2326 - a root-mounted `GET` is registered in the API
+ * process and answered in the views process, and with default rules the views
+ * server forwards only `/api/**` and the mutating verbs. So `route.post('/ingest')`
+ * works, `route.get('/ingest/verify')` renders as a page, finds no page, and
+ * returns the view 404. The handler never runs and nothing says so.
+ *
+ * The views server cannot consult the route table (different process, possibly
+ * a different host), so it cannot fix this at request time. The API process
+ * has both the table and the config, so it can say so at boot.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { describeUnforwardableRoutes, resolveApiProxyRules, unforwardableRoutes } from '../src/proxy'
+
+const defaults = resolveApiProxyRules()
+
+describe('unforwardableRoutes', () => {
+  it('flags a root-mounted GET that no rule forwards', () => {
+    const routes = [{ method: 'GET', path: '/ingest/verify' }]
+
+    expect(unforwardableRoutes(routes, defaults)).toEqual(routes)
+  })
+
+  it('says nothing about the POST beside it, which the verb rule forwards', () => {
+    // The asymmetry in the report: same file, same prefix, one verb reachable.
+    expect(unforwardableRoutes([{ method: 'POST', path: '/ingest' }], defaults)).toEqual([])
+  })
+
+  it('says nothing about a prefixed route', () => {
+    expect(unforwardableRoutes([{ method: 'GET', path: '/api/hello' }], defaults)).toEqual([])
+  })
+
+  it('goes quiet once the path is configured, which is the fix it recommends', () => {
+    const rules = resolveApiProxyRules({ paths: ['/ingest/verify'] })
+
+    expect(unforwardableRoutes([{ method: 'GET', path: '/ingest/verify' }], rules)).toEqual([])
+  })
+
+  it('goes quiet once the prefix is configured', () => {
+    const rules = resolveApiProxyRules({ prefixes: ['/ingest'] })
+
+    expect(unforwardableRoutes([{ method: 'GET', path: '/ingest/verify' }], rules)).toEqual([])
+  })
+})
+
+describe('describeUnforwardableRoutes', () => {
+  it('names each route, its file, and the config key that fixes it', () => {
+    const message = describeUnforwardableRoutes([
+      { method: 'GET', path: '/ingest/verify', file: 'routes/ingest.ts' },
+    ])
+
+    expect(message).toContain('GET /ingest/verify')
+    expect(message).toContain('routes/ingest.ts')
+    expect(message).toContain('proxy.paths')
+    expect(message).toContain('config/server.ts')
+  })
+
+  it('agrees with itself about how many routes it found', () => {
+    const one = describeUnforwardableRoutes([{ method: 'GET', path: '/a' }])
+    const two = describeUnforwardableRoutes([{ method: 'GET', path: '/a' }, { method: 'GET', path: '/b' }])
+
+    expect(one).toContain('1 root-mounted route the')
+    expect(two).toContain('2 root-mounted routes the')
+  })
+})


### PR DESCRIPTION
Closes #2326.

A route registered at the document root is reachable for `POST` and not for `GET`, and nothing says so. `route.post('/ingest', …)` answers; `route.get('/ingest/verify', …)` returns the view 404 and its handler never runs.

## Why the fix is a warning and not a route match

The cause is the verb, not the path. `isApiBoundRequest` decides what the views server forwards, and with default rules that is `/api/**` or a mutating verb. A root `GET` matches neither, so stx-serve handles it, finds no view, and answers its own 404.

That cannot be fixed where it happens. The views server has no route table to consult: registration happens in the API process, a different process under `buddy dev` and potentially a different host in production, where the views site may not ship that code at all. The docstring in `proxy.ts` already worked through and rejected importing the app's routes into the views process.

The API process has both the table and the app's proxy config, so it is where the question can be answered. That was the issue's own fallback ask, and it turns out to be the right one.

## Output

```
1 root-mounted route the views server will not forward, so it will answer the
view 404 rather than reaching the handler:
  GET /ingest/verify (routes/ingest.ts)
Add them to `proxy.paths` in config/server.ts (or their prefix to
`proxy.prefixes`) so the views server forwards them to the API.
```

## Scoped deliberately

My first take on this, in a comment on the issue, was to check every registered non-`/api` `GET`. I measured what that prints on a stock app before building it:

```
route.routes: 1150 total, 497 GET, 100 non-/api GET
```

Including `/dashboard/home`, `/__routes`, `/__openapi.json`, `/_stacks/mail/preview`, `/me`. Most are fine, because `/dashboard/**` is reached through the dashboard server and `/__routes` is served by the API process itself. A warning listing a hundred working routes is noise people learn to scroll past, which is worse than silence because it looks considered.

`loadRoutes` already loads the app's registry **before** framework defaults, so it can record which routes came from a root-mounted app file and report only those. Verified both directions on this repo:

| registry | recorded | flagged |
|---|---|---|
| stock (`'api': 'api'`) | 0 | **0** |
| plus `'ingest': { path: 'ingest', prefix: '' }` | 2 | **1**, the GET |

The POST beside it is not flagged, which is the exact asymmetry the report describes.

## Sharing the predicate

`isApiBoundPath(method, pathname, rules)` is extracted and `isApiBoundRequest` delegates to it, so the check uses the rule that routes real traffic instead of a second copy. A diagnostic that disagreed with the thing it describes would be worse than none.

## Also

`@stacksjs/server` is now declared by `@stacksjs/actions`, which was already importing it dynamically in `dev/views.ts` without declaring it.

## Testing

7 new tests: the flagged GET, the POST that is correctly silent, a prefixed route, and the message going quiet once `proxy.paths` or `proxy.prefixes` covers it, which is the fix it recommends.

- server suite: 133 pass, 0 fail (one flaky failure on the first run did not reproduce across three more)
- router suite: 431 pass, 0 fail
- `bun test ./tests`: 365 pass, 0 fail
- `./buddy lint`: 3198 files, 0 errors, 0 warnings
- `./buddy typecheck`: clean

## Still true and not fixed here

The framework ships `/sitemap.xml` and `/robots.txt` routes that are unreachable through the views server for this same reason. They will now be reported on any app that root-mounts them, but the framework's own default rules do not forward them. Adding them to the defaults would shadow a `public/robots.txt` of the same name, so it wants its own decision rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)