### PR TITLE
feat(cloud): a read-only inventory of what each server is hosting

### DIFF
--- a/docs/guide/buddy/commands.md
+++ b/docs/guide/buddy/commands.md
@@ -6,7 +6,7 @@ description: Generated reference for every Buddy command, argument, option, alia
 
 # Buddy Command Reference
 
-This reference is generated from Buddy's runtime command registry and currently contains **305 commands**. Run `bun run docs:buddy` after changing the registry; CI rejects stale output.
+This reference is generated from Buddy's runtime command registry and currently contains **306 commands**. Run `bun run docs:buddy` after changing the registry; CI rejects stale output.
 
 ## Command groups
 
@@ -15,7 +15,7 @@ This reference is generated from Buddy's runtime command registry and currently 
 | `ai` | 1 |
 | `auth` | 4 |
 | `build` | 15 |
-| `cloud` | 7 |
+| `cloud` | 8 |
 | `cms` | 2 |
 | `coming-soon` | 1 |
 | `commerce` | 2 |
@@ -611,6 +611,22 @@ Remove the Stacks Cloud. In case it fails, try again
 | `--force` | Force deletion of stack in bad state | boolean, optional | `false` |
 | `--yes` | Skip confirmation prompts | boolean, optional | `false` |
 | `-p`, `--project` | Target a specific project | value, optional | `false` |
+| `--verbose` | Enable verbose output | boolean, optional | `false` |
+
+### `cloud:sites`
+
+List every server and what each one is hosting, across projects
+
+- Usage: `$ buddy cloud:sites`
+- Namespace: `cloud`
+- Aliases: none
+- Arguments: none
+
+| Option | Description | Contract | Default |
+| --- | --- | --- | --- |
+| `--env` | Environment to take the inventory for | value, optional | - |
+| `--no-remote` | Skip the SSH read of each box's gateway registry (co-tenants are then not listed) | boolean, optional, negated | `true` |
+| `-J`, `--json` | Emit the inventory as JSON | boolean, optional | `false` |
 | `--verbose` | Enable verbose output | boolean, optional | `false` |
 
 ### `cms:install`

--- a/storage/framework/core/buddy/src/cloud-inventory.ts
+++ b/storage/framework/core/buddy/src/cloud-inventory.ts
@@ -1,0 +1,591 @@
+/**
+ * Read-only inventory of what is hosted on which server.
+ *
+ * Consolidating boxes (stacksjs/stacks#2342) starts with a question nothing
+ * could answer: what is actually running on each server? `config/cloud.ts`
+ * cannot answer it. It describes ONE project's sites, and the boxes are
+ * multi-tenant - other projects deploy onto them from their own repositories
+ * with `cloud.attachTo`, and their sites appear nowhere in this file. Reading
+ * config here and calling it an inventory would report a shared box as if this
+ * project were alone on it, which is exactly the wrong answer to act on.
+ *
+ * So the inventory is assembled from three sources, weakest to strongest:
+ *
+ *  1. `config/cloud.ts` - what THIS project intends to deploy, and where.
+ *  2. The provider API - which servers exist, and which project owns each
+ *     (ts-cloud stamps `ts-cloud/project`, `/environment` and `/role` labels
+ *     on every box it provisions).
+ *  3. The box's own rpx registry (`/etc/rpx/sites.d`) - one JSON fragment per
+ *     project, holding every route that project serves here. This is the only
+ *     source that sees co-tenants, so it is the one that decides what is
+ *     hosted where. `@stacksjs/ts-cloud` already builds and parses it for the
+ *     port allocator; this module reuses those primitives rather than
+ *     inventing a second reading of the same files.
+ *
+ * The pure half (shaping, reconciling, rendering) is separated from the two IO
+ * calls so the reconciliation can be tested without a server or a token.
+ */
+
+/** A server as reported by the provider, with its ts-cloud identity resolved. */
+export interface InventoryServer {
+  id: string
+  name: string
+  status: string
+  ipv4?: string
+  ipv6?: string
+  type?: string
+  location?: string
+  labels: Record<string, string>
+  /** `ts-cloud/project`: the project that provisioned and owns this box. */
+  project?: string
+  /** `ts-cloud/environment`: production, staging, ... */
+  environment?: string
+  /** `ts-cloud/role`: app, services, lb. */
+  role?: string
+}
+
+/** One site this project declares in `config/cloud.ts`. */
+export interface DeclaredSite {
+  name: string
+  kind: string
+  domain?: string
+  path: string
+  port?: number
+  /** `/var/www/<slug>-<name>`, the install base ts-cloud derives. */
+  installBase?: string
+  /**
+   * No `domain`, so the gateway never routes it and it cannot appear in the
+   * box's registry. That is a deliberate configuration (loopback-only
+   * services reached through another site's proxy), not a missing deploy.
+   */
+  loopbackOnly: boolean
+}
+
+/** One route the box serves, as recorded by the project that deployed it. */
+export interface HostedRoute {
+  /** The project that owns this route (the fragment's `slug`). */
+  slug: string
+  host: string
+  path: string
+  /** Where the route goes: an upstream, a static dir, or a redirect target. */
+  target: string
+  kind: 'app' | 'static' | 'redirect' | 'unknown'
+}
+
+/** What a box answered when asked for its registry. */
+export interface HostProbe {
+  server: string
+  ip?: string
+  routes: HostedRoute[]
+  /** Why the probe produced nothing, when it produced nothing. */
+  unavailable?: string
+}
+
+/** Declared sites lined up against what a box actually serves. */
+export interface Reconciliation {
+  /** Declared here and present on the box. */
+  present: DeclaredSite[]
+  /** Declared here, routable, and absent from the box's registry. */
+  absent: DeclaredSite[]
+  /** Declared here with no domain: no gateway route by design. */
+  loopback: DeclaredSite[]
+  /** Routes on the box owned by some other project. */
+  foreign: HostedRoute[]
+}
+
+const LABEL_PROJECT = 'ts-cloud/project'
+const LABEL_ENVIRONMENT = 'ts-cloud/environment'
+const LABEL_ROLE = 'ts-cloud/role'
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+/**
+ * Shape one provider server record into the inventory's own type.
+ *
+ * Written against the Hetzner server payload (the shape `resolveAttachTargetBox`
+ * in the deploy command already reads), but only touches fields any provider
+ * listing carries, so an AWS/local-box listing can be mapped onto it too.
+ */
+export function toInventoryServer(raw: any): InventoryServer {
+  const labels: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw?.labels ?? {})) {
+    if (typeof value === 'string')
+      labels[key] = value
+  }
+
+  return {
+    id: String(raw?.id ?? ''),
+    name: text(raw?.name) ?? '(unnamed)',
+    status: text(raw?.status) ?? 'unknown',
+    ipv4: text(raw?.public_net?.ipv4?.ip),
+    ipv6: text(raw?.public_net?.ipv6?.ip),
+    type: text(raw?.server_type?.name),
+    location: text(raw?.datacenter?.location?.name) ?? text(raw?.datacenter?.name),
+    labels,
+    project: text(labels[LABEL_PROJECT]),
+    environment: text(labels[LABEL_ENVIRONMENT]),
+    role: text(labels[LABEL_ROLE]),
+  }
+}
+
+/**
+ * The sites this project declares, in the same terms the box reports.
+ *
+ * `kind` and `installBase` come from ts-cloud when it is loadable, because
+ * `siteInstallBase` is documented as the single source of truth for the
+ * install path and a second copy of that rule here would be free to drift.
+ * When ts-cloud cannot be loaded the site is still listed, without them: a
+ * partial inventory beats no inventory, and every other field is local.
+ */
+export function declaredSites(
+  sites: Record<string, any> | undefined,
+  helpers?: { resolveSiteKind?: (site: any) => string, siteInstallBase?: (slug: string, site: string) => string },
+  slug?: string,
+): DeclaredSite[] {
+  return Object.entries(sites ?? {}).map(([name, site]) => {
+    const domain = text(site?.domain)
+    const port = Number(site?.port)
+
+    return {
+      name,
+      kind: helpers?.resolveSiteKind?.(site) ?? 'unknown',
+      domain,
+      path: text(site?.path) ?? '/',
+      port: Number.isFinite(port) && port > 0 ? port : undefined,
+      installBase: slug && helpers?.siteInstallBase ? helpers.siteInstallBase(slug, name) : undefined,
+      loopbackOnly: !domain,
+    }
+  })
+}
+
+/**
+ * Flatten the box's registry fragments into one route list.
+ *
+ * A fragment is `{ slug, ...RpxGatewayConfig }`, so `proxies` carries the
+ * routes: `to` is the public host, `path` the prefix it owns, and exactly one
+ * of `from` / `static` / `redirect` says where it goes. A fragment written by
+ * an older ts-cloud may have no `slug`, which the writer defaults to `app`.
+ */
+export function routesFromFragments(fragments: readonly any[]): HostedRoute[] {
+  const routes: HostedRoute[] = []
+
+  for (const fragment of fragments) {
+    const slug = text(fragment?.slug) ?? 'app'
+
+    for (const proxy of (Array.isArray(fragment?.proxies) ? fragment.proxies : [])) {
+      const host = text(proxy?.to)
+      if (!host)
+        continue
+
+      routes.push({
+        slug,
+        host,
+        path: text(proxy?.path) ?? '/',
+        ...describeRouteTarget(proxy),
+      })
+    }
+  }
+
+  return routes.sort((a, b) => a.slug.localeCompare(b.slug) || a.host.localeCompare(b.host) || a.path.localeCompare(b.path))
+}
+
+function describeRouteTarget(proxy: any): { target: string, kind: HostedRoute['kind'] } {
+  const from = proxy?.from
+  if (typeof from === 'string' && from.trim())
+    return { target: from.trim(), kind: 'app' }
+  if (Array.isArray(from) && from.length)
+    return { target: from.filter((u: unknown) => typeof u === 'string').join(', '), kind: 'app' }
+
+  const staticRoute = proxy?.static
+  if (typeof staticRoute === 'string' && staticRoute.trim())
+    return { target: staticRoute.trim(), kind: 'static' }
+  if (staticRoute && typeof staticRoute === 'object' && text(staticRoute.dir))
+    return { target: text(staticRoute.dir)!, kind: 'static' }
+
+  const redirect = text(proxy?.redirect?.to) ?? text(proxy?.redirect)
+  if (redirect)
+    return { target: redirect, kind: 'redirect' }
+
+  return { target: '(no upstream)', kind: 'unknown' }
+}
+
+/**
+ * Line this project's declared sites up against what the box serves.
+ *
+ * Matching is on host + path rather than on the site key, because the site key
+ * is local to a repository and the box has no idea what it is. Two projects
+ * both calling a site `main` is normal; two projects serving the same host and
+ * path is the collision worth seeing.
+ */
+export function reconcile(declared: readonly DeclaredSite[], routes: readonly HostedRoute[], slug: string): Reconciliation {
+  const ours = new Set(
+    routes.filter(route => route.slug === slug).map(route => routeKey(route.host, route.path)),
+  )
+
+  const present: DeclaredSite[] = []
+  const absent: DeclaredSite[] = []
+  const loopback: DeclaredSite[] = []
+
+  for (const site of declared) {
+    if (site.loopbackOnly)
+      loopback.push(site)
+    else if (ours.has(routeKey(site.domain!, site.path)))
+      present.push(site)
+    else
+      absent.push(site)
+  }
+
+  return { present, absent, loopback, foreign: routes.filter(route => route.slug !== slug) }
+}
+
+function routeKey(host: string, path: string): string {
+  const normalized = path === '/' ? '/' : path.replace(/\/+$/, '')
+  return `${host.toLowerCase()}${normalized || '/'}`
+}
+
+/** Group routes by the project that owns them, biggest tenant first. */
+export function tenantsOf(routes: readonly HostedRoute[]): Array<{ slug: string, routes: HostedRoute[] }> {
+  const bySlug = new Map<string, HostedRoute[]>()
+  for (const route of routes) {
+    const bucket = bySlug.get(route.slug)
+    if (bucket)
+      bucket.push(route)
+    else
+      bySlug.set(route.slug, [route])
+  }
+
+  return [...bySlug.entries()]
+    .map(([slug, grouped]) => ({ slug, routes: grouped }))
+    .sort((a, b) => b.routes.length - a.routes.length || a.slug.localeCompare(b.slug))
+}
+
+/**
+ * Which servers this project's own sites are not accounted for on.
+ *
+ * A project attaches to exactly one box per environment, so its sites should
+ * all show up in one place. Sites missing everywhere is the signal that
+ * matters for consolidation: either they were never deployed, or they are on a
+ * box this listing did not reach.
+ */
+export function unaccountedSites(declared: readonly DeclaredSite[], probes: readonly HostProbe[], slug: string): DeclaredSite[] {
+  const seen = new Set<string>()
+  for (const probe of probes) {
+    for (const route of probe.routes) {
+      if (route.slug === slug)
+        seen.add(routeKey(route.host, route.path))
+    }
+  }
+
+  return declared.filter(site => !site.loopbackOnly && !seen.has(routeKey(site.domain!, site.path)))
+}
+
+/* ------------------------------------------------------------------------ *
+ * IO: the two calls that leave this machine.
+ * ------------------------------------------------------------------------ */
+
+/** Why a provider listing came back with nothing. */
+export type ProviderFailure =
+  | { kind: 'no-token' }
+  | { kind: 'request-failed', status: number, detail?: string }
+
+export interface ProviderListing {
+  servers: InventoryServer[]
+  failure?: ProviderFailure
+}
+
+/**
+ * Every server in the Hetzner project, not just this one's.
+ *
+ * Deliberately unfiltered. `resolveAttachTargetBox` in the deploy command asks
+ * the same API for ONE box by label; consolidation needs the opposite - the
+ * full fleet, including boxes this project has no connection to, because
+ * "which boxes could these sites move onto" is the question being answered.
+ *
+ * Failures are reported rather than swallowed, for the reason the deploy
+ * command learned the hard way: a missing token, a 401 and an empty project
+ * are three very different answers and they used to print as one.
+ */
+export async function listProviderServers(token: string | undefined, fetchImpl: typeof fetch = fetch): Promise<ProviderListing> {
+  if (!token)
+    return { servers: [], failure: { kind: 'no-token' } }
+
+  const servers: InventoryServer[] = []
+  let page = 1
+
+  // Hetzner pages at 25 by default, so a fleet of any size needs the loop. The
+  // bound stops a malformed `next_page` from spinning forever.
+  while (page > 0 && page <= 40) {
+    let response: Response
+    try {
+      response = await fetchImpl(`https://api.hetzner.cloud/v1/servers?page=${page}&per_page=50`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    }
+    catch (error) {
+      return { servers, failure: { kind: 'request-failed', status: 0, detail: error instanceof Error ? error.message : String(error) } }
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+      return { servers, failure: { kind: 'request-failed', status: response.status, detail: body.slice(0, 200) || undefined } }
+    }
+
+    const payload = await response.json().catch(() => ({})) as any
+    for (const raw of (Array.isArray(payload?.servers) ? payload.servers : []))
+      servers.push(toInventoryServer(raw))
+
+    const next = Number(payload?.meta?.pagination?.next_page)
+    page = Number.isFinite(next) && next > page ? next : 0
+  }
+
+  return { servers: servers.sort((a, b) => a.name.localeCompare(b.name)) }
+}
+
+/** How to phrase a provider failure for an operator. */
+export function describeProviderFailure(failure: ProviderFailure): string {
+  if (failure.kind === 'no-token') {
+    return 'No Hetzner API token, so no servers were looked up. '
+      + 'Set HCLOUD_TOKEN (or HETZNER_API_TOKEN, or hetzner.apiToken in config/cloud.ts).'
+  }
+
+  const where = failure.status > 0 ? `returned HTTP ${failure.status}` : 'could not be reached'
+  return `The Hetzner API ${where}, so the server list is incomplete.${failure.detail ? ` ${failure.detail}` : ''}`
+    + (failure.status === 401 || failure.status === 403
+      ? ' That is an auth failure, not an empty project: check the token is valid for this Hetzner project.'
+      : '')
+}
+
+/**
+ * Where the rpx gateway keeps one registry fragment per project.
+ *
+ * Duplicated from ts-cloud's `HOST_SITES_DIR` rather than imported, because
+ * that module (`deploy/site-ports`) publishes a `.d.ts` with no JavaScript
+ * behind it - the whole file is types-only in 0.12.4 and 0.12.7, so
+ * `buildHostSitePortsScript` and `parseHostSiteFragments` type-check on import
+ * and then throw at runtime. Reported upstream; when they become loadable,
+ * delete both helpers below and call ts-cloud's.
+ */
+export const HOST_SITES_DIR = '/etc/rpx/sites.d'
+
+/**
+ * A shell snippet dumping every registry fragment, one base64 line per file.
+ *
+ * base64 rather than `cat`, because the fragments are pretty-printed JSON
+ * spanning many lines and this keeps the output unambiguously one record per
+ * line without needing a JSON tool on the box. A missing directory prints
+ * nothing and reads back as "no co-tenants", which is the truth on a box that
+ * has never been deployed to.
+ */
+export function buildHostRoutesScript(sitesDir: string = HOST_SITES_DIR): string {
+  return `d='${sitesDir}'
+[ -d "$d" ] || exit 0
+find "$d" -maxdepth 1 -type f -name '*.json' | sort | while IFS= read -r f; do
+  base64 < "$f" | tr -d '\\n'
+  echo
+done`
+}
+
+/**
+ * Parse {@link buildHostRoutesScript} output into fragments.
+ *
+ * A line that will not decode or parse is skipped rather than thrown, matching
+ * how the box's own assembler treats a corrupt fragment: one bad file must not
+ * take the listing down. The cost is that its routes are invisible here, which
+ * is still strictly more than the nothing this command could see before.
+ */
+export function parseHostRoutesOutput(stdout: string): any[] {
+  const fragments: any[] = []
+
+  for (const line of stdout.split('\n')) {
+    const encoded = line.trim()
+    if (!encoded)
+      continue
+
+    try {
+      fragments.push(JSON.parse(Buffer.from(encoded, 'base64').toString('utf8')))
+    }
+    catch {
+      // Skip: see the note above.
+    }
+  }
+
+  return fragments
+}
+
+/**
+ * Ask one box what it serves.
+ *
+ * Never throws. A box that is off, unreachable, or refuses the key returns an
+ * `unavailable` reason instead, so one unreachable server does not cost the
+ * listing of every other one - the same failure the captured-mail inbox had,
+ * where a single bad record 503'd the whole endpoint.
+ */
+export async function probeHostRoutes(
+  server: InventoryServer,
+  exec: (host: string, command: string) => Promise<{ code: number, stdout: string, stderr: string }>,
+): Promise<HostProbe> {
+  if (!server.ipv4)
+    return { server: server.name, routes: [], unavailable: 'no public IPv4 address to reach it on' }
+
+  if (server.status !== 'running')
+    return { server: server.name, ip: server.ipv4, routes: [], unavailable: `server is ${server.status}` }
+
+  try {
+    const result = await exec(server.ipv4, buildHostRoutesScript())
+    if (result.code !== 0) {
+      const reason = result.stderr.trim().split('\n')[0] || `ssh exited ${result.code}`
+      return { server: server.name, ip: server.ipv4, routes: [], unavailable: reason }
+    }
+
+    return { server: server.name, ip: server.ipv4, routes: routesFromFragments(parseHostRoutesOutput(result.stdout)) }
+  }
+  catch (error) {
+    return {
+      server: server.name,
+      ip: server.ipv4,
+      routes: [],
+      unavailable: error instanceof Error ? error.message.split('\n')[0] : String(error),
+    }
+  }
+}
+
+/* ------------------------------------------------------------------------ *
+ * Rendering.
+ * ------------------------------------------------------------------------ */
+
+export interface Inventory {
+  slug: string
+  environment: string
+  servers: InventoryServer[]
+  probes: HostProbe[]
+  declared: DeclaredSite[]
+  providerFailure?: ProviderFailure
+}
+
+/**
+ * The listing an operator reads, as lines.
+ *
+ * Returned rather than logged so the format is testable and the command stays
+ * a thin caller. Every count is stated so a partial answer reads as partial:
+ * a box that could not be probed says so on its own line, and the summary
+ * separates "not deployed" from "not visible from here".
+ */
+export function describeInventory(inventory: Inventory): string[] {
+  const lines: string[] = []
+  const { slug, servers, probes, declared } = inventory
+
+  if (inventory.providerFailure)
+    lines.push(describeProviderFailure(inventory.providerFailure), '')
+
+  if (servers.length === 0) {
+    lines.push('No servers found.')
+  }
+  else {
+    lines.push(`${servers.length} server${servers.length === 1 ? '' : 's'}:`, '')
+  }
+
+  const probesByServer = new Map(probes.map(probe => [probe.server, probe]))
+
+  for (const server of servers) {
+    const facts = [server.ipv4, server.type, server.location, server.status].filter(Boolean)
+    lines.push(`  ${server.name}  ${facts.join('  ')}`)
+    lines.push(`    ${describeOwnership(server)}`)
+
+    const probe = probesByServer.get(server.name)
+    if (!probe) {
+      lines.push('    not probed (--no-remote), so co-tenants on this box are not listed')
+      lines.push('')
+      continue
+    }
+
+    if (probe.unavailable) {
+      lines.push(`    could not read ${HOST_SITES_DIR}: ${probe.unavailable}`)
+      lines.push('')
+      continue
+    }
+
+    const tenants = tenantsOf(probe.routes)
+    if (tenants.length === 0) {
+      lines.push(`    serves nothing: ${HOST_SITES_DIR} is empty or absent`)
+      lines.push('')
+      continue
+    }
+
+    lines.push(`    serves ${probe.routes.length} route${probe.routes.length === 1 ? '' : 's'} for ${tenants.length} project${tenants.length === 1 ? '' : 's'}:`)
+    for (const tenant of tenants) {
+      lines.push(`      ${tenant.slug}${tenant.slug === slug ? ' (this project)' : ''}`)
+      for (const route of tenant.routes)
+        lines.push(`        ${route.host}${route.path === '/' ? '/' : route.path}  ->  ${describeTarget(route)}`)
+    }
+
+    lines.push('')
+  }
+
+  lines.push(...describeDeclared(inventory))
+
+  return lines
+}
+
+function describeOwnership(server: InventoryServer): string {
+  if (!server.project)
+    return 'no ts-cloud labels: provisioned outside ts-cloud, or by a version that did not label boxes'
+
+  const detail = [server.environment, server.role && `role ${server.role}`].filter(Boolean).join(', ')
+  return `owned by '${server.project}'${detail ? ` (${detail})` : ''}`
+}
+
+function describeTarget(route: HostedRoute): string {
+  if (route.kind === 'redirect')
+    return `redirect to ${route.target}`
+  if (route.kind === 'static')
+    return `static ${route.target}`
+  return route.target
+}
+
+function describeDeclared(inventory: Inventory): string[] {
+  const { slug, declared, probes } = inventory
+  if (declared.length === 0)
+    return [`This project ('${slug}') declares no sites in config/cloud.ts.`]
+
+  const lines = [`This project ('${slug}') declares ${declared.length} site${declared.length === 1 ? '' : 's'}: ${declared.map(site => site.name).join(', ')}`]
+  const loopback = declared.filter(site => site.loopbackOnly)
+
+  if (loopback.length > 0) {
+    lines.push(
+      `  ${loopback.length} with no domain, so the gateway never routes ${loopback.length === 1 ? 'it' : 'them'} `
+      + `(reached through another site's proxy): ${loopback.map(site => site.name).join(', ')}`,
+    )
+  }
+
+  // Reconciliation needs at least one box that actually answered. Without one,
+  // every routable site is "not found", which is a true statement about this
+  // listing and a false one about the deployment - the shape of wrong answer
+  // this command exists to stop producing.
+  const answered = probes.filter(probe => !probe.unavailable)
+  if (answered.length === 0) {
+    lines.push('  Nothing to reconcile them against: no box reported what it serves.')
+    return lines
+  }
+
+  const unaccounted = unaccountedSites(declared, answered, slug)
+  lines.push(`  ${declared.length - loopback.length - unaccounted.length} routed by a box above`)
+
+  if (unaccounted.length > 0) {
+    // Two very different causes, and this listing cannot tell them apart, so
+    // it must not pick one: an undeployed site and a site on a box that was
+    // not read look identical from here.
+    lines.push(`  ${unaccounted.length} not routed by any box above: ${unaccounted.map(site => site.name).join(', ')}`)
+    const unread = probes.length - answered.length
+    const unprobed = inventory.servers.length - probes.length
+    if (unread > 0)
+      lines.push(`    Either they were never deployed, or they are on one of the ${unread} server${unread === 1 ? '' : 's'} that could not be read.`)
+    else if (unprobed > 0)
+      lines.push(`    Either they were never deployed, or they are on one of the ${unprobed} server${unprobed === 1 ? '' : 's'} this run did not probe.`)
+    else
+      lines.push('    Either they were never deployed, or they are on a server outside this provider account.')
+  }
+
+  return lines
+}

--- a/storage/framework/core/buddy/src/commands/cloud.ts
+++ b/storage/framework/core/buddy/src/commands/cloud.ts
@@ -1,3 +1,4 @@
+import type { HostProbe } from '../cloud-inventory'
 import type { CLI, CloudCliOptions } from '@stacksjs/types'
 import process from 'node:process'
 import { intro, italic, log, onUnknownSubcommand, outro, prompts, runCommand, text, underline } from "@stacksjs/cli"
@@ -206,6 +207,10 @@ export function cloud(buddy: CLI): void {
     invalidateCache: 'Invalidate the CloudFront cache',
     diff: 'Show the diff of the current, undeployed cloud changes ',
     dashboard: 'Run the local Stacks Cloud management cockpit (servers, sites, deploys)',
+    sites: 'List every server and what each one is hosting, across projects',
+    sitesEnv: 'Environment to take the inventory for',
+    remote: 'Skip the SSH read of each box\'s gateway registry (co-tenants are then not listed)',
+    json: 'Emit the inventory as JSON',
     host: 'Host to bind the dashboard to',
     port: 'Port to bind the dashboard to',
     env: 'Environment to manage',
@@ -819,6 +824,89 @@ export function cloud(buddy: CLI): void {
         )
         process.exit(ExitCode.FatalError)
       }
+    })
+
+  buddy
+    .command('cloud:sites', descriptions.sites)
+    .option('--env [env]', descriptions.sitesEnv)
+    .option('--no-remote', descriptions.remote)
+    .option('-J, --json', descriptions.json, { default: false })
+    .option('--verbose', descriptions.verbose, { default: false })
+    .action(async (options: CloudCliOptions & { env?: string, remote?: boolean, json?: boolean }) => {
+      log.debug('Running `buddy cloud:sites` ...', options)
+
+      const {
+        declaredSites,
+        describeInventory,
+        listProviderServers,
+        probeHostRoutes,
+      } = await import('../cloud-inventory')
+      const { loadTsCloudConfig, resolveHetznerApiToken } = await import('./deploy')
+
+      const environment = String(options.env || process.env.APP_ENV || process.env.NODE_ENV || 'production')
+      const tsCloudConfig = await loadTsCloudConfig(options.env ? environment : undefined)
+      const slug = tsCloudConfig?.project?.slug || 'app'
+
+      // Only the Hetzner listing is implemented, and saying so beats printing
+      // an empty fleet that reads as "you have no servers".
+      const provider = tsCloudConfig?.cloud?.provider || process.env.CLOUD_PROVIDER || 'aws'
+      if (provider !== 'hetzner') {
+        log.error(`\`buddy cloud:sites\` can only list Hetzner servers, and this project's provider is '${provider}'.`)
+        log.info('The on-box half (the rpx gateway registry) is provider-independent; the server listing is not yet.')
+        process.exit(ExitCode.FatalError)
+      }
+
+      // ts-cloud owns both of these rules: `resolveSiteKind` decides what a
+      // site IS, and `siteInstallBase` is documented as the single source of
+      // truth for where it lands. Re-deriving either here would be free to
+      // drift from what the deploy actually does.
+      let helpers: { resolveSiteKind?: (site: any) => string, siteInstallBase?: (slug: string, site: string) => string } = {}
+      try {
+        const deployApi = await import('@stacksjs/ts-cloud/deploy') as any
+        helpers = { resolveSiteKind: deployApi.resolveSiteKind, siteInstallBase: deployApi.siteInstallBase }
+      }
+      catch (error) {
+        log.debug('Could not load @stacksjs/ts-cloud/deploy for site classification:', error)
+      }
+
+      const declared = declaredSites(tsCloudConfig?.sites, helpers, slug)
+      const listing = await listProviderServers(resolveHetznerApiToken(tsCloudConfig))
+
+      const probes: HostProbe[] = []
+      if (options.remote !== false) {
+        const { sshExec } = await import('@stacksjs/ts-cloud')
+        // Batched rather than one Promise.all over the fleet: each probe opens
+        // an SSH connection, and a large project should not fire forty at once.
+        const batchSize = 6
+        for (let index = 0; index < listing.servers.length; index += batchSize) {
+          probes.push(...await Promise.all(
+            listing.servers.slice(index, index + batchSize).map(server =>
+              probeHostRoutes(server, (host, command) => sshExec(host, command, { user: 'root', connectTimeoutSec: 10 })),
+            ),
+          ))
+        }
+      }
+
+      const inventory = {
+        slug,
+        environment,
+        servers: listing.servers,
+        probes,
+        declared,
+        providerFailure: listing.failure,
+      }
+
+      if (options.json) {
+        console.log(JSON.stringify(inventory, null, 2))
+      }
+      else {
+        for (const line of describeInventory(inventory))
+          console.log(line)
+      }
+
+      // An empty fleet is a fine answer; an empty fleet BECAUSE the lookup
+      // failed is not, and the two must not exit the same way.
+      process.exit(listing.failure && listing.servers.length === 0 ? ExitCode.FatalError : ExitCode.Success)
     })
 
   onUnknownSubcommand(buddy, "cloud")

--- a/storage/framework/core/buddy/src/commands/deploy.ts
+++ b/storage/framework/core/buddy/src/commands/deploy.ts
@@ -572,7 +572,7 @@ async function uploadMailServerToS3(bucketName: string, region: string, mode: st
  * Returns undefined if the project has no ts-cloud config (older projects /
  * pure AWS setups that only export the legacy `CloudConfig`).
  */
-async function loadTsCloudConfig(envName?: string): Promise<any | undefined> {
+export async function loadTsCloudConfig(envName?: string): Promise<any | undefined> {
   try {
     const base = p.projectPath('config/cloud.ts')
     // Always cache-bust when an environment is known so the config module

--- a/storage/framework/core/buddy/tests/cloud-inventory.test.ts
+++ b/storage/framework/core/buddy/tests/cloud-inventory.test.ts
@@ -1,0 +1,521 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  buildHostRoutesScript,
+  declaredSites,
+  describeInventory,
+  describeProviderFailure,
+  listProviderServers,
+  parseHostRoutesOutput,
+  probeHostRoutes,
+  reconcile,
+  routesFromFragments,
+  tenantsOf,
+  toInventoryServer,
+  unaccountedSites,
+} from '../src/cloud-inventory'
+
+/**
+ * What is hosted where (stacksjs/stacks#2342).
+ *
+ * The trap this whole module exists to avoid: `config/cloud.ts` describes ONE
+ * project, the boxes are shared, and so reading config alone reports a
+ * multi-tenant server as if this project were alone on it. Every test below
+ * that matters is about a co-tenant being visible, or about a partial answer
+ * being labelled partial rather than passed off as a complete one.
+ */
+
+function fragment(slug: string, proxies: any[]): string {
+  return Buffer.from(JSON.stringify({ slug, proxies })).toString('base64')
+}
+
+const STACKS_FRAGMENT = {
+  slug: 'stacks',
+  proxies: [
+    { to: 'stacksjs.com', from: '127.0.0.1:3000' },
+    { to: 'stacksjs.com', path: '/docs', static: { dir: '/var/www/stacks-docs', spa: false } },
+    { to: 'stacksjs.com', path: '/discord', redirect: { to: 'https://discord.gg/example', preservePath: false } },
+  ],
+}
+
+const RAPPID_FRAGMENT = {
+  slug: 'rappid',
+  proxies: [{ to: 'rappid.hq.training', from: '127.0.0.1:3024' }],
+}
+
+describe('provider server shaping', () => {
+  it('resolves the ts-cloud identity a box was labelled with', () => {
+    const server = toInventoryServer({
+      id: 12345,
+      name: 'stacks-production-app',
+      status: 'running',
+      public_net: { ipv4: { ip: '5.161.0.1' }, ipv6: { ip: '2a01:4f8::/64' } },
+      server_type: { name: 'cpx41' },
+      datacenter: { name: 'fsn1-dc14', location: { name: 'fsn1' } },
+      labels: { 'ts-cloud/project': 'stacks', 'ts-cloud/environment': 'production', 'ts-cloud/role': 'app' },
+    })
+
+    expect(server).toMatchObject({
+      id: '12345',
+      name: 'stacks-production-app',
+      status: 'running',
+      ipv4: '5.161.0.1',
+      type: 'cpx41',
+      location: 'fsn1',
+      project: 'stacks',
+      environment: 'production',
+      role: 'app',
+    })
+  })
+
+  it('keeps an unlabelled box in the listing rather than dropping it', () => {
+    // A box provisioned by hand, or by a ts-cloud old enough not to label, is
+    // exactly the kind of server a consolidation needs to see. Requiring the
+    // labels would hide it.
+    const server = toInventoryServer({ id: 7, name: 'legacy-box', status: 'running', labels: {} })
+
+    expect(server.project).toBeUndefined()
+    expect(server.name).toBe('legacy-box')
+  })
+})
+
+describe('the box registry', () => {
+  it('reads every project on the box, not just ours', () => {
+    const routes = routesFromFragments([STACKS_FRAGMENT, RAPPID_FRAGMENT])
+
+    expect(routes.map(route => `${route.slug} ${route.host}${route.path}`)).toEqual([
+      'rappid rappid.hq.training/',
+      'stacks stacksjs.com/',
+      'stacks stacksjs.com/discord',
+      'stacks stacksjs.com/docs',
+    ])
+  })
+
+  it('describes each route by where it actually goes', () => {
+    const routes = routesFromFragments([STACKS_FRAGMENT])
+    const byPath = Object.fromEntries(routes.map(route => [route.path, route]))
+
+    expect(byPath['/']).toMatchObject({ kind: 'app', target: '127.0.0.1:3000' })
+    expect(byPath['/docs']).toMatchObject({ kind: 'static', target: '/var/www/stacks-docs' })
+    expect(byPath['/discord']).toMatchObject({ kind: 'redirect', target: 'https://discord.gg/example' })
+  })
+
+  it('reads a load-balanced route as its whole upstream pool', () => {
+    const routes = routesFromFragments([{ slug: 'x', proxies: [{ to: 'x.com', from: ['10.0.0.1:3000', '10.0.0.2:3000'] }] }])
+
+    expect(routes[0]).toMatchObject({ kind: 'app', target: '10.0.0.1:3000, 10.0.0.2:3000' })
+  })
+
+  it('defaults a fragment with no slug to the same owner the writer would', () => {
+    // An older ts-cloud wrote fragments without `slug`; its writer defaults to
+    // 'app'. Reading them as an unnamed tenant would split one project in two.
+    expect(routesFromFragments([{ proxies: [{ to: 'old.example', from: '127.0.0.1:3000' }] }])[0].slug).toBe('app')
+  })
+
+  it('groups tenants biggest first so the box owner reads at the top', () => {
+    expect(tenantsOf(routesFromFragments([STACKS_FRAGMENT, RAPPID_FRAGMENT])).map(t => t.slug)).toEqual(['stacks', 'rappid'])
+  })
+})
+
+describe('parsing what the box printed', () => {
+  it('decodes one base64 fragment per line', () => {
+    const stdout = `${fragment('stacks', [{ to: 'stacksjs.com', from: '127.0.0.1:3000' }])}\n${fragment('rappid', [])}\n`
+
+    expect(parseHostRoutesOutput(stdout).map((f: any) => f.slug)).toEqual(['stacks', 'rappid'])
+  })
+
+  it('skips a corrupt fragment instead of losing the whole listing', () => {
+    // The box's own assembler tolerates a bad fragment; a listing that threw
+    // would be strictly less useful than one that is short by a single file.
+    const stdout = `not-base64-at-all\n${fragment('rappid', [])}\n`
+
+    expect(parseHostRoutesOutput(stdout).map((f: any) => f.slug)).toEqual(['rappid'])
+  })
+
+  it('reads an empty box as no co-tenants rather than an error', () => {
+    expect(parseHostRoutesOutput('')).toEqual([])
+  })
+
+  it('emits one line per fragment even though the files are pretty-printed', () => {
+    const script = buildHostRoutesScript('/etc/rpx/sites.d')
+
+    expect(script).toContain('/etc/rpx/sites.d')
+    // base64 wraps its output; without collapsing it a single fragment would
+    // parse as a dozen unrelated lines.
+    expect(script).toContain("tr -d '\\n'")
+    // A box that has never been deployed to has no such directory, and that
+    // must read as "nothing hosted", not as a failure.
+    expect(script).toContain('[ -d "$d" ] || exit 0')
+  })
+})
+
+describe('the shell snippet, run for real', () => {
+  /**
+   * The script is the one piece that cannot be reasoned about from types: it
+   * has to survive `base64` wrapping its output at 76 columns, a directory
+   * that does not exist, and files it must not pick up. Running it against a
+   * real shell is the only way to know, and a local bash is close enough to
+   * the box's to catch the mistakes that matter.
+   */
+  async function run(dir: string): Promise<string> {
+    const proc = Bun.spawn(['bash', '-c', buildHostRoutesScript(dir)], { stdout: 'pipe', stderr: 'pipe' })
+    const stdout = await new Response(proc.stdout).text()
+    await proc.exited
+    return stdout
+  }
+
+  it('round-trips a pretty-printed fragment through one line of output', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'stacks-sites-d-'))
+    try {
+      // Pretty-printed and long enough that base64 wraps it, which is exactly
+      // what broke a naive `cat` of these files.
+      await writeFile(join(dir, 'stacks.json'), JSON.stringify(STACKS_FRAGMENT, null, 2))
+      await writeFile(join(dir, 'rappid.json'), JSON.stringify(RAPPID_FRAGMENT, null, 2))
+      await writeFile(join(dir, 'notes.txt'), 'not a fragment')
+
+      const fragments = parseHostRoutesOutput(await run(dir))
+
+      expect(fragments.map((f: any) => f.slug).sort()).toEqual(['rappid', 'stacks'])
+      expect(routesFromFragments(fragments)).toHaveLength(4)
+    }
+    finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('prints nothing for a box that has never been deployed to', async () => {
+    expect(await run(join(tmpdir(), 'stacks-sites-d-does-not-exist'))).toBe('')
+  })
+})
+
+describe('probing a box', () => {
+  const server = { id: '1', name: 'box', status: 'running', ipv4: '5.5.5.5', labels: {} }
+
+  it('returns the routes a reachable box reports', async () => {
+    const probe = await probeHostRoutes(server, async () => ({
+      code: 0,
+      stdout: `${fragment('stacks', [{ to: 'stacksjs.com', from: '127.0.0.1:3000' }])}\n`,
+      stderr: '',
+    }))
+
+    expect(probe.unavailable).toBeUndefined()
+    expect(probe.routes).toHaveLength(1)
+  })
+
+  it('reports an unreachable box instead of failing the whole listing', async () => {
+    const probe = await probeHostRoutes(server, async () => {
+      throw new Error('Permission denied (publickey).\nssh gave up')
+    })
+
+    expect(probe.routes).toEqual([])
+    expect(probe.unavailable).toBe('Permission denied (publickey).')
+  })
+
+  it('does not ssh into a box that is powered off', async () => {
+    let attempted = false
+    const probe = await probeHostRoutes({ ...server, status: 'off' }, async () => {
+      attempted = true
+      return { code: 0, stdout: '', stderr: '' }
+    })
+
+    expect(attempted).toBe(false)
+    expect(probe.unavailable).toBe('server is off')
+  })
+
+  it('surfaces the remote stderr when the command itself fails', async () => {
+    const probe = await probeHostRoutes(server, async () => ({ code: 1, stdout: '', stderr: 'find: permission denied\n' }))
+
+    expect(probe.unavailable).toBe('find: permission denied')
+  })
+})
+
+describe('declared sites', () => {
+  const sites = {
+    main: { root: '.', domain: 'stacksjs.com', path: '/', start: 'bun serve', port: 3000 },
+    api: { root: '.', start: 'bun api', port: 3008 },
+    docs: { root: 'dist/docs', domain: 'stacksjs.com', path: '/docs' },
+  }
+
+  it('marks a domainless site as loopback-only rather than as missing', () => {
+    // `api` is deliberately domainless: the gateway skips it and it is reached
+    // through main's same-origin /api proxy. Reporting it as an undeployed
+    // site would be a false alarm on every single run.
+    const declared = declaredSites(sites, {}, 'stacks')
+
+    expect(declared.find(site => site.name === 'api')?.loopbackOnly).toBe(true)
+    expect(declared.find(site => site.name === 'main')?.loopbackOnly).toBe(false)
+  })
+
+  it('takes the install path from ts-cloud rather than deriving its own', () => {
+    const declared = declaredSites(sites, { siteInstallBase: (slug, site) => `/var/www/${slug}-${site}` }, 'stacks')
+
+    expect(declared.find(site => site.name === 'docs')?.installBase).toBe('/var/www/stacks-docs')
+  })
+
+  it('still lists the sites when ts-cloud could not be loaded', () => {
+    const declared = declaredSites(sites)
+
+    expect(declared).toHaveLength(3)
+    expect(declared[0].installBase).toBeUndefined()
+  })
+})
+
+describe('reconciling config against the box', () => {
+  const declared = declaredSites(
+    {
+      main: { domain: 'stacksjs.com', path: '/', port: 3000, start: 'x' },
+      docs: { domain: 'stacksjs.com', path: '/docs' },
+      blog: { domain: 'stacksjs.com', path: '/blog' },
+      api: { port: 3008, start: 'x' },
+    },
+    {},
+    'stacks',
+  )
+  const routes = routesFromFragments([STACKS_FRAGMENT, RAPPID_FRAGMENT])
+
+  it('separates present, absent, loopback and somebody else entirely', () => {
+    const result = reconcile(declared, routes, 'stacks')
+
+    expect(result.present.map(site => site.name).sort()).toEqual(['docs', 'main'])
+    expect(result.absent.map(site => site.name)).toEqual(['blog'])
+    expect(result.loopback.map(site => site.name)).toEqual(['api'])
+    expect(result.foreign.map(route => route.slug)).toEqual(['rappid'])
+  })
+
+  it('matches on host and path, not on the site key', () => {
+    // The box has no idea what a repository calls its sites, and two projects
+    // both naming one `main` is normal. Keying on the name would match routes
+    // across projects.
+    const result = reconcile(
+      declaredSites({ frontend: { domain: 'stacksjs.com', path: '/' } }, {}, 'stacks'),
+      routes,
+      'stacks',
+    )
+
+    expect(result.present.map(site => site.name)).toEqual(['frontend'])
+  })
+
+  it('does not credit our site to another project serving the same host', () => {
+    const result = reconcile(
+      declaredSites({ main: { domain: 'rappid.hq.training', path: '/' } }, {}, 'stacks'),
+      routes,
+      'stacks',
+    )
+
+    expect(result.present).toEqual([])
+    expect(result.absent.map(site => site.name)).toEqual(['main'])
+  })
+
+  it('ignores a trailing slash on a path prefix', () => {
+    const result = reconcile(declaredSites({ docs: { domain: 'stacksjs.com', path: '/docs/' } }, {}, 'stacks'), routes, 'stacks')
+
+    expect(result.present.map(site => site.name)).toEqual(['docs'])
+  })
+})
+
+describe('sites unaccounted for across the whole fleet', () => {
+  const declared = declaredSites(
+    { main: { domain: 'stacksjs.com', path: '/' }, blog: { domain: 'blog.example', path: '/' }, api: { port: 3008 } },
+    {},
+    'stacks',
+  )
+
+  it('only counts a site missing when no probed box serves it', () => {
+    const probes = [
+      { server: 'a', routes: routesFromFragments([STACKS_FRAGMENT]) },
+      { server: 'b', routes: routesFromFragments([RAPPID_FRAGMENT]) },
+    ]
+
+    expect(unaccountedSites(declared, probes, 'stacks').map(site => site.name)).toEqual(['blog'])
+  })
+
+  it('never counts a loopback-only site as missing', () => {
+    expect(unaccountedSites(declared, [], 'stacks').map(site => site.name)).toEqual(['main', 'blog'])
+  })
+})
+
+describe('the listing an operator reads', () => {
+  const servers = [
+    toInventoryServer({
+      id: 1,
+      name: 'stacks-production-app',
+      status: 'running',
+      public_net: { ipv4: { ip: '5.161.0.1' } },
+      server_type: { name: 'cpx41' },
+      datacenter: { location: { name: 'fsn1' } },
+      labels: { 'ts-cloud/project': 'stacks', 'ts-cloud/environment': 'production', 'ts-cloud/role': 'app' },
+    }),
+  ]
+
+  const declared = declaredSites(
+    { main: { domain: 'stacksjs.com', path: '/' }, blog: { domain: 'blog.example', path: '/' }, api: { port: 3008 } },
+    {},
+    'stacks',
+  )
+
+  it('names the co-tenant sharing the box', () => {
+    const output = describeInventory({
+      slug: 'stacks',
+      environment: 'production',
+      servers,
+      probes: [{ server: 'stacks-production-app', ip: '5.161.0.1', routes: routesFromFragments([STACKS_FRAGMENT, RAPPID_FRAGMENT]) }],
+      declared,
+    }).join('\n')
+
+    expect(output).toContain('serves 4 routes for 2 projects')
+    expect(output).toContain('stacks (this project)')
+    expect(output).toContain('rappid')
+    expect(output).toContain('rappid.hq.training/  ->  127.0.0.1:3024')
+  })
+
+  it('says a box was not probed rather than implying it hosts nothing', () => {
+    const output = describeInventory({
+      slug: 'stacks',
+      environment: 'production',
+      servers,
+      probes: [],
+      declared,
+    }).join('\n')
+
+    expect(output).toContain('not probed (--no-remote)')
+    expect(output).toContain('Nothing to reconcile them against')
+  })
+
+  it('says why a box could not be read, and refuses to reconcile against nothing', () => {
+    // The distinction that keeps this listing honest: unreachable is not the
+    // same claim as undeployed. With no box answering, every routable site
+    // would otherwise be reported missing - a true statement about the
+    // listing and a false one about the deployment.
+    const output = describeInventory({
+      slug: 'stacks',
+      environment: 'production',
+      servers,
+      probes: [{ server: 'stacks-production-app', ip: '5.161.0.1', routes: [], unavailable: 'Permission denied (publickey).' }],
+      declared,
+    }).join('\n')
+
+    expect(output).toContain('could not read /etc/rpx/sites.d: Permission denied (publickey).')
+    expect(output).toContain('Nothing to reconcile them against')
+    expect(output).not.toContain('not routed by any box above')
+  })
+
+  it('blames an unreadable box before it blames the deploy', () => {
+    const output = describeInventory({
+      slug: 'stacks',
+      environment: 'production',
+      servers: [...servers, toInventoryServer({ id: 2, name: 'other', status: 'running', labels: {} })],
+      probes: [
+        { server: 'stacks-production-app', routes: routesFromFragments([STACKS_FRAGMENT]) },
+        { server: 'other', routes: [], unavailable: 'Permission denied (publickey).' },
+      ],
+      declared,
+    }).join('\n')
+
+    expect(output).toContain('1 not routed by any box above: blog')
+    expect(output).toContain('one of the 1 server that could not be read')
+  })
+
+  it('points at the boxes it skipped when the run stayed local', () => {
+    const output = describeInventory({
+      slug: 'stacks',
+      environment: 'production',
+      servers: [...servers, toInventoryServer({ id: 2, name: 'other', status: 'running', labels: {} })],
+      probes: [{ server: 'stacks-production-app', routes: routesFromFragments([STACKS_FRAGMENT]) }],
+      declared,
+    }).join('\n')
+
+    expect(output).toContain('one of the 1 server this run did not probe')
+  })
+
+  it('explains a domainless site instead of listing it as missing', () => {
+    const output = describeInventory({
+      slug: 'stacks',
+      environment: 'production',
+      servers,
+      probes: [{ server: 'stacks-production-app', routes: routesFromFragments([STACKS_FRAGMENT]) }],
+      declared,
+    }).join('\n')
+
+    expect(output).toContain('1 with no domain')
+    expect(output).toContain('1 not routed by any box above: blog')
+  })
+
+  it('leads with the provider failure when the fleet could not be listed', () => {
+    const output = describeInventory({
+      slug: 'stacks',
+      environment: 'production',
+      servers: [],
+      probes: [],
+      declared,
+      providerFailure: { kind: 'no-token' },
+    }).join('\n')
+
+    expect(output.startsWith('No Hetzner API token')).toBe(true)
+    expect(output).toContain('No servers found.')
+  })
+})
+
+describe('provider failures', () => {
+  it('tells a missing token apart from an empty project', () => {
+    expect(describeProviderFailure({ kind: 'no-token' })).toContain('HCLOUD_TOKEN')
+  })
+
+  it('calls a 401 an auth failure rather than an empty fleet', () => {
+    // The deploy command learned this one the hard way: a token problem and a
+    // genuinely empty project used to print the same sentence.
+    expect(describeProviderFailure({ kind: 'request-failed', status: 401 })).toContain('auth failure')
+  })
+
+  it('says a network error left the answer unknown', () => {
+    expect(describeProviderFailure({ kind: 'request-failed', status: 0 })).toContain('could not be reached')
+  })
+})
+
+describe('listing the fleet', () => {
+  it('does not call the API without a token', async () => {
+    let called = false
+    const listing = await listProviderServers(undefined, (async () => {
+      called = true
+      return new Response('{}')
+    }) as unknown as typeof fetch)
+
+    expect(called).toBe(false)
+    expect(listing.failure).toEqual({ kind: 'no-token' })
+  })
+
+  it('follows pagination so a large fleet is not silently truncated', async () => {
+    const pages: Record<string, any> = {
+      '1': { servers: [{ id: 1, name: 'b', labels: {} }], meta: { pagination: { next_page: 2 } } },
+      '2': { servers: [{ id: 2, name: 'a', labels: {} }], meta: { pagination: { next_page: null } } },
+    }
+    const listing = await listProviderServers('token', (async (url: string) => {
+      const page = new URL(url).searchParams.get('page') as string
+      return new Response(JSON.stringify(pages[page]))
+    }) as unknown as typeof fetch)
+
+    expect(listing.servers.map(server => server.name)).toEqual(['a', 'b'])
+  })
+
+  it('reports an HTTP failure instead of returning an empty fleet', async () => {
+    const listing = await listProviderServers('token', (async () =>
+      new Response('unauthorized', { status: 401 })) as unknown as typeof fetch)
+
+    expect(listing.servers).toEqual([])
+    expect(listing.failure).toMatchObject({ kind: 'request-failed', status: 401 })
+  })
+
+  it('keeps the servers it did read when a later page fails', async () => {
+    let call = 0
+    const listing = await listProviderServers('token', (async () => {
+      call += 1
+      if (call === 1)
+        return new Response(JSON.stringify({ servers: [{ id: 1, name: 'a', labels: {} }], meta: { pagination: { next_page: 2 } } }))
+      throw new Error('socket hang up')
+    }) as unknown as typeof fetch)
+
+    expect(listing.servers.map(server => server.name)).toEqual(['a'])
+    expect(listing.failure).toMatchObject({ kind: 'request-failed', status: 0 })
+  })
+})


### PR DESCRIPTION
Closes part of #2342: the read side. `buddy cloud:sites` answers "what is on each box, including other people's projects", which is the question a consolidation has to answer before anything can be moved.

## Why this could not just read config

`config/cloud.ts` describes ONE project's sites, and the boxes are multi-tenant: other projects deploy onto them from their own repositories with `cloud.attachTo` and appear nowhere in this file. Reading config and calling it an inventory would report a shared box as if this project were alone on it.

Worth correcting something I said while scoping #2342: I described `cc59f7e7ff` ("register rappid as a tenant of the production box") as the attach operation done by hand. It is not. That commit adds a slug to `tenants`, which the config comment describes as an env-namespace guard, "a guard, not an inventory" - it lists `bughq`, which runs its own box, and `ghost`, which is a former name. The actual attach lives in the other repository as `cloud.attachTo: 'stacks'`.

## What it reads

| Source | Answers |
|---|---|
| `config/cloud.ts` | what this project intends to deploy |
| Hetzner API | which servers exist, and which project owns each (the `ts-cloud/project`, `/environment`, `/role` labels) |
| `/etc/rpx/sites.d` on each box, over SSH | every route each project serves there, one JSON fragment per project |

Only the third sees co-tenants, so it is what decides the answer. `--no-remote` skips it, and the output then says the co-tenants are unlisted rather than implying there are none.

```
$ buddy cloud:sites

2 servers:

  stacks-production-app  5.161.0.1  cpx41  fsn1  running
    owned by 'stacks' (production, role app)
    serves 4 routes for 2 projects:
      stacks (this project)
        stacksjs.com/         ->  127.0.0.1:3000
        stacksjs.com/docs     ->  static /var/www/stacks-docs
        stacksjs.com/discord  ->  redirect to https://discord.gg/...
      rappid
        rappid.hq.training/   ->  127.0.0.1:3024

This project ('stacks') declares 8 sites: main, api, docs, blog, ...
  1 with no domain, so the gateway never routes it (reached through another site's proxy): api
  7 routed by a box above
```

## Where it refuses to guess

Three places, each one a confident wrong answer it would otherwise print:

- A site with no `domain` is never routed by the gateway **by design** (`api` is reached through main's same-origin `/api` proxy). Reported as such, not as an undeployed site: otherwise every single run raises a false alarm.
- With **no box answering**, nothing is reconciled at all. "Every site is missing" is a true statement about the listing and a false one about the deployment.
- A site missing from the boxes that **did** answer names the unread boxes as the other explanation, rather than asserting it was never deployed.

Same discipline on the provider call: a missing token, a 401 and an empty project are three different answers and each gets its own sentence, which is the lesson `describeAttachLookupFailure` already learned in the deploy command. An empty fleet exits 0; an empty fleet *because the lookup failed* exits 1.

## Upstream gap found while building this

`@stacksjs/ts-cloud`'s `deploy/site-ports` module would have supplied the registry script and parser (`buildHostSitePortsScript`, `parseHostSiteFragments`, `occupiedHostPorts`). It publishes a `.d.ts` with **no JavaScript behind it** - probed on both 0.12.4 and 0.12.7:

```
$ grep -rl "buildHostSitePortsScript" package/dist/          # 0.12.7
package/dist/deploy/site-ports.d.ts
$ grep -rl "buildHostSitePortsScript" --include="*.js" package/dist/
(nothing)
```

The package's `"./*"` wildcard export means an import of it type-checks and then throws at runtime. So this PR carries its own copy of the script and parser, with a comment saying to delete both once the upstream export is loadable. Filing that upstream alongside the `move` primitive.

`resolveSiteKind` and `siteInstallBase` **are** loadable (via `@stacksjs/ts-cloud/deploy`, verified with a real import), and both are called rather than re-derived, since `siteInstallBase` is documented as the single source of truth for the install path.

## Verification

- 40 new tests, `594 pass / 0 fail` across the whole buddy suite.
- The shell snippet is run against a **real bash** with real pretty-printed fixture files, because base64 wrapping its output at 76 columns is exactly the kind of thing types cannot catch.
- `buddy lint` clean (3199 files, 0 errors). `buddy typecheck` green; `bun run typecheck` reports only pre-existing errors in the untracked generated `storage/framework/cache/models/` tree, none in the files touched here.
- `docs:buddy:check` regenerated and passing.

**Not verified live.** `HCLOUD_TOKEN` is encrypted in `.env.production` and I have no key, so neither the Hetzner listing nor the SSH probe has run against the real fleet. Both paths are covered by tests with injected `fetch`/`exec`, and the shell half against a real shell, but the first run against the production box is still the first run. Also worth noting: `node_modules` here holds ts-cloud 0.12.4 while `package.json` declares `^0.12.7`; the exports this uses are present in both, and I checked the `site-ports` gap in both.

## Not in scope

The write side of #2342 (`attach`, `move`, `destroy`, `rename`). `move` in particular has no primitive in ts-cloud at all - the entire consolidation vocabulary present in 0.12.7 is `renameServer` - so it needs the upstream issue first.