### PR TITLE
feat(cloud): check an attach against the box before deploying onto it

### DIFF
--- a/docs/guide/buddy/commands.md
+++ b/docs/guide/buddy/commands.md
@@ -6,7 +6,7 @@ description: Generated reference for every Buddy command, argument, option, alia
 
 # Buddy Command Reference
 
-This reference is generated from Buddy's runtime command registry and currently contains **306 commands**. Run `bun run docs:buddy` after changing the registry; CI rejects stale output.
+This reference is generated from Buddy's runtime command registry and currently contains **307 commands**. Run `bun run docs:buddy` after changing the registry; CI rejects stale output.
 
 ## Command groups
 
@@ -15,7 +15,7 @@ This reference is generated from Buddy's runtime command registry and currently 
 | `ai` | 1 |
 | `auth` | 4 |
 | `build` | 15 |
-| `cloud` | 8 |
+| `cloud` | 9 |
 | `cms` | 2 |
 | `coming-soon` | 1 |
 | `commerce` | 2 |
@@ -520,6 +520,23 @@ Add a resource to the Stacks Cloud
 | --- | --- | --- | --- |
 | `--jump-box` | Remove the jump-box | boolean, optional | `false` |
 | `-p`, `--project` | Target a specific project | value, optional | `false` |
+| `--verbose` | Enable verbose output | boolean, optional | `false` |
+
+### `cloud:attach`
+
+Attach this project to a server another project owns, after checking it is safe
+
+- Usage: `$ buddy cloud:attach`
+- Namespace: `cloud`
+- Aliases: none
+- Arguments: none
+
+| Option | Description | Contract | Default |
+| --- | --- | --- | --- |
+| `--server` | Server to attach to, by provider name or by owning project slug | value, required | - |
+| `--env` | Environment to take the inventory for | value, optional | - |
+| `--dry-run` | Print the plan and change nothing | boolean, optional | `false` |
+| `-J`, `--json` | Emit the inventory as JSON | boolean, optional | `false` |
 | `--verbose` | Enable verbose output | boolean, optional | `false` |
 
 ### `cloud:cleanup`

--- a/storage/framework/core/buddy/src/cloud-attach.ts
+++ b/storage/framework/core/buddy/src/cloud-attach.ts
@@ -1,0 +1,355 @@
+/**
+ * Attaching this project to a server another project owns.
+ *
+ * The mechanism already exists and works: set `cloud.attachTo` to the owner's
+ * slug and `buddy deploy` puts this project's sites on that box instead of
+ * provisioning one. What has never existed is the check BEFORE the deploy.
+ *
+ * Every way an attach goes wrong is currently discovered while it is going
+ * wrong. `assertPortsAreFree` catches a port clash from the deploying machine
+ * over SSH, and the deploy's slug guard catches a tenant claiming the owner's
+ * own gateway fragment - both good, both late, both after the operator has
+ * committed a config change and started shipping. The worst case does not even
+ * error: ts-cloud's units do not bind exclusively, so two services on one port
+ * both bind and the kernel load-balances between them, which is how
+ * predicthq.org spent a day and a half serving a storefront to half its
+ * visitors (see `deploy-port-collision.test.ts`).
+ *
+ * So this module answers one question, from data rather than from config:
+ * given the box's own gateway registry, is it safe for this project to attach?
+ * Ports, hostnames and slug identity are all checked against what the box is
+ * actually serving for OTHER projects, which is the only place that is
+ * knowable - the tenants deploy from their own repositories and appear in no
+ * file here.
+ *
+ * One thing it deliberately cannot do: the attach needs an edit in the owner's
+ * repository too, adding this slug to `tenants` so this project's env keys are
+ * recognised as somebody else's. That file is in a different repository, so the
+ * edit is printed rather than made.
+ */
+
+import type { DeclaredSite, HostedRoute, InventoryServer } from './cloud-inventory'
+
+/** The server an attach would target, or why one could not be picked. */
+export type AttachTarget =
+  | { server: InventoryServer }
+  | { problem: string }
+
+/**
+ * Pick the box named by `--server`, by provider name or by owning project.
+ *
+ * Both spellings are accepted because both are what an operator has: the
+ * provider console shows `stacks-production-app`, while `cloud.attachTo` takes
+ * the owner's slug (`stacks`). Matching either avoids making the operator
+ * translate between them, and an ambiguous match refuses rather than guessing.
+ */
+export function resolveAttachTarget(servers: readonly InventoryServer[], wanted: string, environment?: string): AttachTarget {
+  const target = wanted.trim()
+  if (!target)
+    return { problem: 'No server named. Pass --server <name|owner-slug>.' }
+
+  const [named, ...alsoNamed] = servers.filter(server => server.name === target)
+  if (named && alsoNamed.length === 0)
+    return { server: named }
+
+  let byOwner = servers.filter(server => server.project === target)
+  if (byOwner.length > 1 && environment)
+    byOwner = byOwner.filter(server => !server.environment || server.environment === environment)
+
+  const [owned, ...alsoOwned] = byOwner
+  if (owned && alsoOwned.length === 0)
+    return { server: owned }
+
+  if (byOwner.length > 1) {
+    return {
+      problem: `'${target}' owns ${byOwner.length} servers (${byOwner.map(server => server.name).join(', ')}). `
+        + 'Name one of them with --server, or narrow it with --env.',
+    }
+  }
+
+  return {
+    problem: `No server matched '${target}'. Nothing is named that, and no box carries the label `
+      + `ts-cloud/project=${target}. \`buddy cloud:sites\` lists what is there.`,
+  }
+}
+
+/**
+ * Reasons this attach must not proceed at all, independent of what is on the box.
+ *
+ * Separate from conflicts because these are about identity rather than
+ * occupancy: no amount of moving ports would make them safe.
+ */
+export function attachPreconditions(slug: string, server: InventoryServer): string[] {
+  const problems: string[] = []
+
+  if (!server.project) {
+    problems.push(
+      `'${server.name}' carries no ts-cloud/project label, so it is not a box ts-cloud provisioned. `
+      + 'Attaching to it would deploy into a host nothing here manages.',
+    )
+  }
+  else if (server.project === slug) {
+    // The deploy refuses this too, but only once it is already running: a
+    // tenant's deploy owns /etc/rpx/sites.d/<slug>.json, so sharing a slug with
+    // the owner means overwriting the owner's own gateway fragment and taking
+    // its sites down.
+    problems.push(
+      `This project's slug is '${slug}', which is also the slug that owns '${server.name}'. `
+      + 'A tenant deploy owns /etc/rpx/sites.d/<slug>.json, so attaching would overwrite the owner\'s '
+      + 'gateway fragment and take its sites down. Change this project\'s slug first.',
+    )
+  }
+
+  if (server.status !== 'running')
+    problems.push(`'${server.name}' is ${server.status}, so what it serves could not be read.`)
+
+  if (!server.ipv4)
+    problems.push(`'${server.name}' has no public IPv4 address, so it cannot be reached to check what it serves.`)
+
+  return problems
+}
+
+/** A port on the box, and the project already serving it. */
+export type PortOwners = Map<number, string>
+
+/**
+ * The port from an rpx upstream (`host:port`).
+ *
+ * Splits on the LAST colon so a bracketed IPv6 literal (`[::1]:3022`) parses as
+ * port 3022 rather than as part of the address. Anything that is not a valid
+ * TCP port yields nothing, so a malformed route narrows the map instead of
+ * poisoning it.
+ */
+export function parseUpstreamPort(upstream: string): number | undefined {
+  const separator = upstream.lastIndexOf(':')
+  if (separator < 0)
+    return undefined
+
+  const port = Number(upstream.slice(separator + 1))
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : undefined
+}
+
+/**
+ * Every port the box already serves, mapped to the project that owns it.
+ *
+ * `ignoreSlug` is this project's own slug: a re-attach finds its own fragment
+ * already on the box from the last deploy, and counting it would make every
+ * repeat run conflict with itself. Only app routes are read - a static, redirect
+ * or proxy route binds no port, and their targets are paths and URLs that
+ * happen to contain colons.
+ *
+ * First writer wins, so two fragments disagreeing produce one stable owner
+ * rather than an order-dependent one.
+ */
+export function portOwners(routes: readonly HostedRoute[], ignoreSlug?: string): PortOwners {
+  const owners: PortOwners = new Map()
+
+  for (const route of routes) {
+    if (route.kind !== 'app' || route.slug === ignoreSlug)
+      continue
+
+    for (const upstream of route.target.split(',')) {
+      const port = parseUpstreamPort(upstream.trim())
+      if (port !== undefined && !owners.has(port))
+        owners.set(port, route.slug)
+    }
+  }
+
+  return owners
+}
+
+export interface AttachConflict {
+  kind: 'port' | 'route'
+  site: string
+  detail: string
+  heldBy: string
+}
+
+/**
+ * Where this project's sites would land on top of another project's.
+ *
+ * Two independent collisions, and the port one is the dangerous half: a route
+ * clash produces a visibly wrong page, while a port clash produces a working
+ * box that serves the wrong site to about half its visitors with nothing logged.
+ */
+export function attachConflicts(slug: string, declared: readonly DeclaredSite[], routes: readonly HostedRoute[]): AttachConflict[] {
+  const conflicts: AttachConflict[] = []
+  const ports = portOwners(routes, slug)
+
+  const taken = new Map<string, string>()
+  for (const route of routes) {
+    if (route.slug !== slug)
+      taken.set(routeKey(route.host, route.path), route.slug)
+  }
+
+  for (const site of declared) {
+    if (site.port !== undefined) {
+      const holder = ports.get(site.port)
+      if (holder)
+        conflicts.push({ kind: 'port', site: site.name, detail: `port ${site.port}`, heldBy: holder })
+    }
+
+    if (site.domain) {
+      const holder = taken.get(routeKey(site.domain, site.path))
+      if (holder)
+        conflicts.push({ kind: 'route', site: site.name, detail: `${site.domain}${site.path === '/' ? '/' : site.path}`, heldBy: holder })
+    }
+  }
+
+  return conflicts
+}
+
+function routeKey(host: string, path: string): string {
+  const normalized = path === '/' ? '/' : path.replace(/\/+$/, '')
+  return `${host.toLowerCase()}${normalized || '/'}`
+}
+
+/** The result of editing `config/cloud.ts`, or why it was left alone. */
+export type AttachEdit =
+  | { text: string, changed: boolean }
+  | { problem: string }
+
+/**
+ * Set `cloud.attachTo` in a `config/cloud.ts`.
+ *
+ * Deliberately narrow. This edits TypeScript source with text, which is only
+ * defensible while it refuses everything it does not certainly understand, so
+ * it handles exactly the shape the scaffold generates:
+ *
+ *     cloud: {
+ *       provider: 'hetzner',
+ *     },
+ *
+ * Anything else - two `cloud:` blocks, a nested object inside it, a one-line
+ * form - is reported rather than rewritten, and the caller prints the edit for
+ * a person to make. A config mangled by a clever regex is a far worse outcome
+ * than a config the tool declined to touch. (ts-cloud has real editors for
+ * this in `deploy/site-config-editor`, but they are not reachable from the
+ * published package: stacksjs/ts-cloud#191.)
+ */
+export function setAttachTo(configText: string, owner: string): AttachEdit {
+  const blocks = [...configText.matchAll(/\n( {2})cloud: \{\n([\s\S]*?)\n\1\},\n/g)]
+
+  const [match] = blocks
+  if (!match)
+    return { problem: 'No `cloud: { ... }` block found in config/cloud.ts.' }
+  if (blocks.length > 1)
+    return { problem: `Found ${blocks.length} \`cloud: { ... }\` blocks in config/cloud.ts, so which one to edit is ambiguous.` }
+
+  const [whole, indent, body] = match
+  if (indent === undefined || body === undefined)
+    return { problem: 'The `cloud: { ... }` block did not parse into an indent and a body.' }
+
+  if (body.includes('{'))
+    return { problem: 'The `cloud: { ... }` block holds a nested object, which this edit does not attempt to rewrite.' }
+
+  const existing = body.match(/^\s*attachTo:\s*(['"])([^'"]*)\1\s*,?\s*$/m)
+  if (existing) {
+    const [line, quote = '\'', current = ''] = existing
+    if (current === owner)
+      return { text: configText, changed: false }
+
+    const repointed = line.replace(`${quote}${current}${quote}`, `'${owner}'`)
+    return { text: configText.replace(whole, whole.replace(line, repointed)), changed: true }
+  }
+
+  const inner = `${indent}  `
+  const replacement = whole.replace(
+    `\n${indent}},\n`,
+    `\n${inner}// Deploy onto the box '${owner}' owns rather than provisioning one.\n${inner}attachTo: '${owner}',\n${indent}},\n`,
+  )
+
+  return { text: configText.replace(whole, replacement), changed: true }
+}
+
+export interface AttachPlan {
+  slug: string
+  owner: string
+  server: InventoryServer
+  declared: readonly DeclaredSite[]
+  conflicts: readonly AttachConflict[]
+  /** Was the box's registry actually read? A conflict check that saw nothing proves nothing. */
+  registryRead: boolean
+  /** Why the registry could not be read, when it could not. */
+  registryProblem?: string
+  /**
+   * The `config/cloud.ts` edit, present only when the attach is viable.
+   *
+   * Absent under a conflict or an unread box on purpose: printing "would set
+   * attachTo" underneath a refusal reads as though the operation is going ahead.
+   */
+  edit?: AttachEdit
+  dryRun: boolean
+}
+
+/** The plan an operator reads, as lines. */
+export function describeAttachPlan(plan: AttachPlan): string[] {
+  const { slug, owner, server, declared, conflicts } = plan
+  const lines: string[] = []
+
+  lines.push(`Attach '${slug}' to '${server.name}' (${server.ipv4 ?? 'no IPv4'}), owned by '${owner}'.`, '')
+
+  lines.push(`  ${declared.length} site${declared.length === 1 ? '' : 's'} would deploy onto this box:`)
+  for (const site of declared) {
+    const where = site.loopbackOnly
+      ? `loopback only${site.port ? ` on :${site.port}` : ''}`
+      : `${site.domain}${site.path === '/' ? '/' : site.path}${site.port ? ` on :${site.port}` : ''}`
+    lines.push(`    ${site.name}  ${where}  ->  ${site.installBase ?? '(install path unresolved)'}`)
+  }
+  lines.push('')
+
+  if (!plan.registryRead) {
+    // Saying "no conflicts" here would be a claim about a box nobody asked.
+    lines.push(`  Could not read what '${server.name}' already serves: ${plan.registryProblem ?? 'unknown reason'}`)
+    lines.push('  So this attach is UNCHECKED: a port or hostname already taken by another')
+    lines.push('  project would not error, it would serve that project\'s site from your domain.')
+    lines.push('')
+  }
+  else if (conflicts.length > 0) {
+    lines.push(`  ${conflicts.length} conflict${conflicts.length === 1 ? '' : 's'} with what the box already serves:`)
+    for (const conflict of conflicts)
+      lines.push(`    site '${conflict.site}' wants ${conflict.detail}, held by '${conflict.heldBy}'`)
+    lines.push('')
+    lines.push('  Two services on one port do not error: the kernel load-balances, and each')
+    lines.push('  domain serves the other\'s site about half the time. Pick free ports and')
+    lines.push('  hostnames in config/cloud.ts, then re-run.')
+    lines.push('')
+  }
+  else {
+    lines.push(`  No conflicts with what '${server.name}' already serves.`, '')
+  }
+
+  if (plan.edit)
+    lines.push(...describeEdits(plan, plan.edit))
+
+  return lines
+}
+
+function describeEdits(plan: AttachPlan, edit: AttachEdit): string[] {
+  const lines: string[] = ['  Two edits make the attach real, in two different repositories:', '']
+
+  if ('problem' in edit) {
+    lines.push(`    1. config/cloud.ts here: could not edit it (${edit.problem})`)
+    lines.push(`       Add \`attachTo: '${plan.owner}'\` to the \`cloud\` block by hand.`)
+  }
+  else if (!edit.changed) {
+    lines.push(`    1. config/cloud.ts here: already sets attachTo: '${plan.owner}'. Nothing to do.`)
+  }
+  else if (plan.dryRun) {
+    lines.push(`    1. config/cloud.ts here: would set attachTo: '${plan.owner}' (--dry-run, not written)`)
+  }
+  else {
+    lines.push(`    1. config/cloud.ts here: set attachTo: '${plan.owner}'`)
+  }
+
+  // The half no command can perform: it lives in the owner's repository.
+  lines.push('')
+  lines.push(`    2. In the '${plan.owner}' project's own repository, which this command cannot edit:`)
+  lines.push(`       add '${plan.slug}' to the \`tenants\` array in its config/cloud.ts.`)
+  lines.push(`       Without it, that project's deploy ships ${plan.slug.toUpperCase()}_* keys from its`)
+  lines.push('       env files into this project\'s .env instead of dropping them.')
+  lines.push('')
+  lines.push('  Then `buddy deploy` from here puts these sites on that box.')
+
+  return lines
+}

--- a/storage/framework/core/buddy/src/commands/cloud.ts
+++ b/storage/framework/core/buddy/src/commands/cloud.ts
@@ -208,6 +208,9 @@ export function cloud(buddy: CLI): void {
     diff: 'Show the diff of the current, undeployed cloud changes ',
     dashboard: 'Run the local Stacks Cloud management cockpit (servers, sites, deploys)',
     sites: 'List every server and what each one is hosting, across projects',
+    attach: 'Attach this project to a server another project owns, after checking it is safe',
+    attachServer: 'Server to attach to, by provider name or by owning project slug',
+    dryRun: 'Print the plan and change nothing',
     sitesEnv: 'Environment to take the inventory for',
     remote: 'Skip the SSH read of each box\'s gateway registry (co-tenants are then not listed)',
     json: 'Emit the inventory as JSON',
@@ -851,9 +854,11 @@ export function cloud(buddy: CLI): void {
       // an empty fleet that reads as "you have no servers".
       const provider = tsCloudConfig?.cloud?.provider || process.env.CLOUD_PROVIDER || 'aws'
       if (provider !== 'hetzner') {
-        log.error(`\`buddy cloud:sites\` can only list Hetzner servers, and this project's provider is '${provider}'.`)
-        log.info('The on-box half (the rpx gateway registry) is provider-independent; the server listing is not yet.')
-        process.exit(ExitCode.FatalError)
+        // `log.exit`, not `log.error` + `process.exit`: the write is async and
+        // `process.exit` does not wait for it, so the refusal printed nothing
+        // at all and exited 1.
+        await log.info('The on-box half (the rpx gateway registry) is provider-independent; the server listing is not yet.')
+        await log.exit(`\`buddy cloud:sites\` can only list Hetzner servers, and this project's provider is '${provider}'.`, ExitCode.FatalError)
       }
 
       // ts-cloud owns both of these rules: `resolveSiteKind` decides what a
@@ -907,6 +912,113 @@ export function cloud(buddy: CLI): void {
       // An empty fleet is a fine answer; an empty fleet BECAUSE the lookup
       // failed is not, and the two must not exit the same way.
       process.exit(listing.failure && listing.servers.length === 0 ? ExitCode.FatalError : ExitCode.Success)
+    })
+
+  buddy
+    .command('cloud:attach', descriptions.attach)
+    .option('--server <server>', descriptions.attachServer)
+    .option('--env [env]', descriptions.sitesEnv)
+    .option('--dry-run', descriptions.dryRun, { default: false })
+    .option('-J, --json', descriptions.json, { default: false })
+    .option('--verbose', descriptions.verbose, { default: false })
+    .action(async (options: CloudCliOptions & { server?: string, env?: string, dryRun?: boolean, json?: boolean }) => {
+      log.debug('Running `buddy cloud:attach` ...', options)
+
+      const { declaredSites, listProviderServers, probeHostRoutes } = await import('../cloud-inventory')
+      const {
+        attachConflicts,
+        attachPreconditions,
+        describeAttachPlan,
+        resolveAttachTarget,
+        setAttachTo,
+      } = await import('../cloud-attach')
+      const { loadTsCloudConfig, resolveHetznerApiToken } = await import('./deploy')
+
+      // `log.error` writes asynchronously and `process.exit` does not wait for
+      // it, so the plain pairing printed the refusal nowhere and exited 1 - a
+      // blocked command that looks like a broken one. Every line is awaited and
+      // the last one exits.
+      const refuse = async (...messages: string[]): Promise<never> => {
+        for (const message of messages.slice(0, -1))
+          await log.error(message)
+        return log.exit(messages[messages.length - 1], ExitCode.FatalError)
+      }
+
+      if (!options.server)
+        return await refuse('Which server? Pass --server <name|owner-slug>. `buddy cloud:sites` lists them.')
+
+      const environment = String(options.env || process.env.APP_ENV || process.env.NODE_ENV || 'production')
+      const tsCloudConfig = await loadTsCloudConfig(options.env ? environment : undefined)
+      const slug = tsCloudConfig?.project?.slug || 'app'
+
+      const listing = await listProviderServers(resolveHetznerApiToken(tsCloudConfig))
+      if (listing.failure) {
+        const { describeProviderFailure } = await import('../cloud-inventory')
+        return await refuse(describeProviderFailure(listing.failure))
+      }
+
+      const target = resolveAttachTarget(listing.servers, String(options.server), environment)
+      if ('problem' in target)
+        return await refuse(target.problem)
+
+      const server = target.server
+      const preconditions = attachPreconditions(slug, server)
+      if (preconditions.length > 0)
+        return await refuse(...preconditions)
+
+      let helpers: { resolveSiteKind?: (site: any) => string, siteInstallBase?: (slug: string, site: string) => string } = {}
+      try {
+        const deployApi = await import('@stacksjs/ts-cloud/deploy') as any
+        helpers = { resolveSiteKind: deployApi.resolveSiteKind, siteInstallBase: deployApi.siteInstallBase }
+      }
+      catch (error) {
+        log.debug('Could not load @stacksjs/ts-cloud/deploy for site classification:', error)
+      }
+
+      const declared = declaredSites(tsCloudConfig?.sites, helpers, slug)
+      const { sshExec } = await import('@stacksjs/ts-cloud')
+      const probe = await probeHostRoutes(server, (host, command) => sshExec(host, command, { user: 'root', connectTimeoutSec: 10 }))
+      const conflicts = probe.unavailable ? [] : attachConflicts(slug, declared, probe.routes)
+
+      // The config is only edited once the box has been asked and answered
+      // clean. Writing first and checking after would leave a repo claiming an
+      // attach that must not happen.
+      const blocked = Boolean(probe.unavailable) || conflicts.length > 0
+      let edit: ReturnType<typeof setAttachTo> | undefined
+
+      if (!blocked) {
+        const configPath = p.projectPath('config/cloud.ts')
+        const { readFileSync, writeFileSync } = await import('node:fs')
+        edit = setAttachTo(readFileSync(configPath, 'utf8'), server.project!)
+
+        if (!options.dryRun && 'text' in edit && edit.changed)
+          writeFileSync(configPath, edit.text)
+      }
+
+      const plan = {
+        slug,
+        owner: server.project!,
+        server,
+        declared,
+        conflicts,
+        registryRead: !probe.unavailable,
+        registryProblem: probe.unavailable,
+        edit,
+        dryRun: Boolean(options.dryRun),
+      }
+
+      if (options.json) {
+        const edited = !edit ? undefined : 'problem' in edit ? edit : { changed: edit.changed }
+        console.log(JSON.stringify({ ...plan, edit: edited }, null, 2))
+      }
+      else {
+        for (const line of describeAttachPlan(plan))
+          console.log(line)
+      }
+
+      // An unchecked attach is not a successful one: exiting 0 after failing to
+      // read the box would let a CI job proceed on a check that never ran.
+      process.exit(blocked ? ExitCode.FatalError : ExitCode.Success)
     })
 
   onUnknownSubcommand(buddy, "cloud")

--- a/storage/framework/core/buddy/tests/cloud-attach.test.ts
+++ b/storage/framework/core/buddy/tests/cloud-attach.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  attachConflicts,
+  attachPreconditions,
+  describeAttachPlan,
+  parseUpstreamPort,
+  portOwners,
+  resolveAttachTarget,
+  setAttachTo,
+} from '../src/cloud-attach'
+import { declaredSites, routesFromFragments, toInventoryServer } from '../src/cloud-inventory'
+
+/**
+ * Attaching a project to somebody else's box.
+ *
+ * The failure this is built around is not hypothetical: two services on one
+ * port do not error, because ts-cloud's units do not bind exclusively. The
+ * kernel load-balances between them, both look healthy, and each domain serves
+ * the other project's site about half the time. predicthq.org spent a day and
+ * a half like that. Every check here exists to catch that before a deploy
+ * rather than during one.
+ */
+
+function server(overrides: Record<string, any> = {}): any {
+  return toInventoryServer({
+    id: 1,
+    name: 'stacks-production-app',
+    status: 'running',
+    public_net: { ipv4: { ip: '5.161.0.1' } },
+    labels: { 'ts-cloud/project': 'stacks', 'ts-cloud/environment': 'production', 'ts-cloud/role': 'app' },
+    ...overrides,
+  })
+}
+
+const BOX_ROUTES = routesFromFragments([
+  {
+    slug: 'stacks',
+    proxies: [
+      { to: 'stacksjs.com', from: '127.0.0.1:3000' },
+      { to: 'stacksjs.com', path: '/docs', static: { dir: '/var/www/stacks-docs' } },
+    ],
+  },
+  { slug: 'rappid', proxies: [{ to: 'rappid.hq.training', from: '127.0.0.1:3024' }] },
+])
+
+describe('picking the server to attach to', () => {
+  const servers = [
+    server(),
+    toInventoryServer({ id: 2, name: 'stacks-staging-app', status: 'running', labels: { 'ts-cloud/project': 'stacks', 'ts-cloud/environment': 'staging' } }),
+    toInventoryServer({ id: 3, name: 'bughq-production-app', status: 'running', labels: { 'ts-cloud/project': 'bughq' } }),
+  ]
+
+  it('accepts the provider name an operator reads off the console', () => {
+    expect(resolveAttachTarget(servers, 'bughq-production-app')).toMatchObject({ server: { name: 'bughq-production-app' } })
+  })
+
+  it('accepts the owner slug that `attachTo` actually takes', () => {
+    // The two spellings are what the operator has in front of them, and making
+    // them translate between the console and the config is how the wrong box
+    // gets named.
+    expect(resolveAttachTarget(servers, 'bughq')).toMatchObject({ server: { name: 'bughq-production-app' } })
+  })
+
+  it('refuses rather than guessing when one owner has several boxes', () => {
+    expect(resolveAttachTarget(servers, 'stacks')).toMatchObject({
+      problem: expect.stringContaining('owns 2 servers'),
+    })
+  })
+
+  it('narrows several boxes by environment when one is given', () => {
+    expect(resolveAttachTarget(servers, 'stacks', 'staging')).toMatchObject({ server: { name: 'stacks-staging-app' } })
+  })
+
+  it('says where to look when nothing matched', () => {
+    expect(resolveAttachTarget(servers, 'nope')).toMatchObject({
+      problem: expect.stringContaining('ts-cloud/project=nope'),
+    })
+  })
+
+  it('treats an empty --server as a missing argument, not as a search', () => {
+    expect(resolveAttachTarget(servers, '  ')).toMatchObject({ problem: expect.stringContaining('No server named') })
+  })
+})
+
+describe('preconditions', () => {
+  it('refuses a box ts-cloud does not manage', () => {
+    const problems = attachPreconditions('rappid', toInventoryServer({ id: 9, name: 'hand-rolled', status: 'running', public_net: { ipv4: { ip: '1.1.1.1' } }, labels: {} }))
+
+    expect(problems[0]).toContain('no ts-cloud/project label')
+  })
+
+  it('refuses a tenant whose slug is the box owner\'s', () => {
+    // The deploy refuses this too, but only once it is running. A tenant deploy
+    // owns /etc/rpx/sites.d/<slug>.json, so sharing the owner's slug overwrites
+    // the owner's own gateway fragment and takes its sites down.
+    expect(attachPreconditions('stacks', server())[0]).toContain("also the slug that owns")
+  })
+
+  it('refuses a box that is not running, because nothing can be checked against it', () => {
+    expect(attachPreconditions('rappid', server({ status: 'off' }))[0]).toContain('is off')
+  })
+
+  it('passes a healthy box owned by somebody else', () => {
+    expect(attachPreconditions('rappid', server())).toEqual([])
+  })
+})
+
+describe('reading ports off the box', () => {
+  it('takes the port from an ordinary upstream', () => {
+    expect(parseUpstreamPort('127.0.0.1:3000')).toBe(3000)
+  })
+
+  it('splits a bracketed IPv6 literal on the last colon', () => {
+    expect(parseUpstreamPort('[::1]:3022')).toBe(3022)
+  })
+
+  it('yields nothing for something that is not a port', () => {
+    expect(parseUpstreamPort('/var/www/docs')).toBeUndefined()
+    expect(parseUpstreamPort('127.0.0.1:not-a-port')).toBeUndefined()
+    expect(parseUpstreamPort('127.0.0.1:99999')).toBeUndefined()
+  })
+
+  it('maps each port to the project holding it', () => {
+    // Ordered by how routesFromFragments sorts (slug first), not by port.
+    expect([...portOwners(BOX_ROUTES)]).toEqual([[3024, 'rappid'], [3000, 'stacks']])
+  })
+
+  it('ignores our own fragment, so a re-attach does not conflict with itself', () => {
+    // Every repeat run finds its own fragment already on the box from the last
+    // deploy. Counting it would make the second attach impossible.
+    expect([...portOwners(BOX_ROUTES, 'stacks')]).toEqual([[3024, 'rappid']])
+  })
+
+  it('reads no port from a static or redirect route', () => {
+    // Their targets are paths and URLs, and `https://x.com/y` has a colon in it.
+    const routes = routesFromFragments([{
+      slug: 'x',
+      proxies: [
+        { to: 'a.com', static: { dir: '/var/www/a' } },
+        { to: 'b.com', redirect: { to: 'https://example.com/z' } },
+      ],
+    }])
+
+    expect(portOwners(routes).size).toBe(0)
+  })
+
+  it('reads every upstream of a load-balanced route', () => {
+    const routes = routesFromFragments([{ slug: 'x', proxies: [{ to: 'x.com', from: ['10.0.0.1:3000', '10.0.0.2:3001'] }] }])
+
+    expect([...portOwners(routes)]).toEqual([[3000, 'x'], [3001, 'x']])
+  })
+})
+
+describe('conflicts with what the box already serves', () => {
+  const declared = declaredSites(
+    {
+      main: { domain: 'rappid.hq.training', path: '/', port: 3000, start: 'x' },
+      api: { port: 3008, start: 'x' },
+    },
+    {},
+    'rappid',
+  )
+
+  it('catches the port clash that does not error on its own', () => {
+    const conflicts = attachConflicts('rappid', declared, BOX_ROUTES)
+
+    expect(conflicts).toContainEqual({ kind: 'port', site: 'main', detail: 'port 3000', heldBy: 'stacks' })
+  })
+
+  it('catches a hostname already served by another project', () => {
+    const conflicts = attachConflicts('newproject', declaredSites({ main: { domain: 'stacksjs.com', path: '/docs' } }, {}, 'newproject'), BOX_ROUTES)
+
+    expect(conflicts).toContainEqual({ kind: 'route', site: 'main', detail: 'stacksjs.com/docs', heldBy: 'stacks' })
+  })
+
+  it('does not report a free port as taken', () => {
+    expect(attachConflicts('rappid', declaredSites({ api: { port: 3099, start: 'x' } }, {}, 'rappid'), BOX_ROUTES)).toEqual([])
+  })
+
+  it('does not count our own routes against us', () => {
+    const ours = declaredSites({ main: { domain: 'rappid.hq.training', path: '/', port: 3024, start: 'x' } }, {}, 'rappid')
+
+    expect(attachConflicts('rappid', ours, BOX_ROUTES)).toEqual([])
+  })
+})
+
+describe('editing config/cloud.ts', () => {
+  const SCAFFOLD = readFileSync(
+    join(import.meta.dir, '../../../defaults/scaffold/config/cloud.ts'),
+    'utf8',
+  )
+
+  it('adds attachTo to the shape every new app is scaffolded with', () => {
+    // Read from the real template rather than a hand-written fixture: a
+    // fixture that drifts from the scaffold would pass while the tool broke.
+    const result = setAttachTo(SCAFFOLD, 'stacks') as { text: string, changed: boolean }
+
+    expect(result.changed).toBe(true)
+    expect(result.text).toContain("attachTo: 'stacks',")
+    expect(result.text).toContain("provider: 'hetzner',")
+
+    // Nothing else moved: strip the two lines it added and the original file
+    // comes back byte for byte, so a config full of comments and unrelated
+    // blocks cannot be quietly reflowed by this edit.
+    const ADDED = [
+      "    // Deploy onto the box 'stacks' owns rather than provisioning one.",
+      "    attachTo: 'stacks',",
+    ]
+    const kept = result.text.split('\n')
+    for (const line of ADDED) {
+      const at = kept.indexOf(line)
+      expect(at).toBeGreaterThan(-1)
+      kept.splice(at, 1)
+    }
+    expect(kept.join('\n')).toBe(SCAFFOLD)
+  })
+
+  it('is a no-op when it already attaches to that owner', () => {
+    const once = setAttachTo(SCAFFOLD, 'stacks') as { text: string }
+    const twice = setAttachTo(once.text, 'stacks')
+
+    expect(twice).toEqual({ text: once.text, changed: false })
+  })
+
+  it('repoints an existing attachTo at a different owner', () => {
+    const once = setAttachTo(SCAFFOLD, 'stacks') as { text: string }
+    const moved = setAttachTo(once.text, 'bughq') as { text: string, changed: boolean }
+
+    expect(moved.changed).toBe(true)
+    expect(moved.text).toContain("attachTo: 'bughq',")
+    expect(moved.text).not.toContain("attachTo: 'stacks',")
+  })
+
+  it('refuses a cloud block holding a nested object rather than guessing', () => {
+    const config = `export const tsCloud = {\n  cloud: {\n    provider: 'hetzner',\n    hetzner: { location: 'fsn1' },\n  },\n}\n`
+
+    expect(setAttachTo(config, 'stacks')).toMatchObject({ problem: expect.stringContaining('nested object') })
+  })
+
+  it('refuses when there is more than one cloud block', () => {
+    const config = `const a = {\n  cloud: {\n    provider: 'hetzner',\n  },\n}\nconst b = {\n  cloud: {\n    provider: 'aws',\n  },\n}\n`
+
+    expect(setAttachTo(config, 'stacks')).toMatchObject({ problem: expect.stringContaining('2 `cloud:') })
+  })
+
+  it('refuses when there is no cloud block at all', () => {
+    expect(setAttachTo('export const tsCloud = {}\n', 'stacks')).toMatchObject({ problem: expect.stringContaining('No `cloud:') })
+  })
+
+  it('leaves the file alone in every refusal', () => {
+    // The point of refusing is that the file survives. A "clever" edit that
+    // half-works is worse than one that never ran.
+    const config = `export const tsCloud = {\n  cloud: {\n    provider: 'hetzner',\n    hetzner: { location: 'fsn1' },\n  },\n}\n`
+    const result = setAttachTo(config, 'stacks')
+
+    expect('text' in result).toBe(false)
+  })
+})
+
+describe('the plan an operator reads', () => {
+  const declared = declaredSites(
+    { main: { domain: 'rappid.hq.training', path: '/', port: 3024, start: 'x' }, api: { port: 3008, start: 'x' } },
+    { siteInstallBase: (slug, site) => `/var/www/${slug}-${site}` },
+    'rappid',
+  )
+
+  function plan(overrides: Record<string, any> = {}): any {
+    return {
+      slug: 'rappid',
+      owner: 'stacks',
+      server: server(),
+      declared,
+      conflicts: [],
+      registryRead: true,
+      edit: { text: '', changed: true },
+      dryRun: false,
+      ...overrides,
+    }
+  }
+
+  it('always names the edit it cannot make, in the other repository', () => {
+    const output = describeAttachPlan(plan()).join('\n')
+
+    expect(output).toContain("add 'rappid' to the `tenants` array")
+    expect(output).toContain('RAPPID_* keys')
+  })
+
+  it('does not describe config edits when the attach is refused', () => {
+    // "Two edits make the attach real" printed under a conflict list reads as
+    // though it is going ahead anyway.
+    const output = describeAttachPlan(plan({
+      conflicts: [{ kind: 'port', site: 'main', detail: 'port 3000', heldBy: 'stacks' }],
+      edit: undefined,
+    })).join('\n')
+
+    expect(output).not.toContain('Two edits make the attach real')
+    expect(output).toContain('then re-run')
+  })
+
+  it('will not claim there are no conflicts when the box was never read', () => {
+    // "No conflicts" after failing to ask is the single most dangerous thing
+    // this command could print.
+    const output = describeAttachPlan(plan({ registryRead: false, registryProblem: 'Permission denied (publickey).' })).join('\n')
+
+    expect(output).toContain('UNCHECKED')
+    expect(output).toContain('Permission denied (publickey).')
+    expect(output).not.toContain('No conflicts')
+  })
+
+  it('explains why a port clash is not a loud failure', () => {
+    const output = describeAttachPlan(plan({ conflicts: [{ kind: 'port', site: 'main', detail: 'port 3000', heldBy: 'stacks' }] })).join('\n')
+
+    expect(output).toContain("site 'main' wants port 3000, held by 'stacks'")
+    expect(output).toContain('the kernel load-balances')
+  })
+
+  it('says the config was not written on a dry run', () => {
+    expect(describeAttachPlan(plan({ dryRun: true })).join('\n')).toContain('--dry-run, not written')
+  })
+
+  it('shows loopback-only sites as such rather than inventing a hostname', () => {
+    expect(describeAttachPlan(plan()).join('\n')).toContain('api  loopback only on :3008')
+  })
+})


### PR DESCRIPTION
Second command for #2342. `buddy cloud:attach --server <name|owner-slug>` answers "is it safe for this project to attach to that box?" **before** a deploy, from the box's own gateway registry rather than from config.

## The failure this exists to prevent

Attaching already works: set `cloud.attachTo`, and `buddy deploy` puts the sites on that box. Every way it goes wrong is currently discovered while it is going wrong. `assertPortsAreFree` catches a port clash over SSH from inside the deploy, and the slug guard catches a tenant claiming the owner's gateway fragment. Both good, both after a config change is committed and files are shipping.

The worst case does not error at all. ts-cloud's units do not set exclusive binding, so two services on one port both bind and the kernel load-balances between them. Both look healthy, nothing is logged, and each domain serves the other project's site about half the time. That is what happened to predicthq.org for a day and a half (pinned in `deploy-port-collision.test.ts`).

## What it checks

```
$ buddy cloud:attach --server stacks --dry-run

Attach 'rappid' to 'stacks-production-app' (5.161.0.1), owned by 'stacks'.

  2 sites would deploy onto this box:
    main  rappid.hq.training/ on :3024  ->  /var/www/rappid-main
    api  loopback only on :3008  ->  /var/www/rappid-api

  No conflicts with what 'stacks-production-app' already serves.

  Two edits make the attach real, in two different repositories:

    1. config/cloud.ts here: would set attachTo: 'stacks' (--dry-run, not written)

    2. In the 'stacks' project's own repository, which this command cannot edit:
       add 'rappid' to the `tenants` array in its config/cloud.ts.
       Without it, that project's deploy ships RAPPID_* keys from its
       env files into this project's .env instead of dropping them.

  Then `buddy deploy` from here puts these sites on that box.
```

And when it is not safe:

```
  2 conflicts with what the box already serves:
    site 'main' wants port 3000, held by 'stacks'
    site 'main' wants stacksjs.com/, held by 'stacks'

  Two services on one port do not error: the kernel load-balances, and each
  domain serves the other's site about half the time. Pick free ports and
  hostnames in config/cloud.ts, then re-run.
```

- Target resolves by **provider name or owning project slug** (both are what the operator has in front of them), narrowing by `--env`, and refuses an ambiguous match rather than picking one.
- Refuses a box with no `ts-cloud/project` label, a box whose owner slug is this project's own, and a box that is not running.
- Reports every declared port already held by another project, and every hostname + path another project already serves.

## Where it refuses to guess

- **A box that could not be read prints `UNCHECKED`, never "no conflicts."** "No conflicts" after failing to ask is the most dangerous sentence this command could produce. It exits non-zero so a CI job cannot proceed on a check that never ran.
- **A refused attach prints no config edits at all.** "Two edits make the attach real" underneath a conflict list reads as though it is going ahead anyway.
- **The config edit handles exactly the shape the scaffold generates** and reports anything else instead of rewriting it: two `cloud:` blocks, a nested object inside one, no block at all. A config mangled by a clever regex is a far worse outcome than one the tool declined to touch. The test asserts the output is the scaffold **byte for byte** with exactly the two added lines removed.
- **The second edit is printed, not made**, because it lives in the owner's repository.

Order matters: the box is asked first, and `config/cloud.ts` is only written once it has answered clean. Writing first would leave a repo claiming an attach that must not happen.

## Also fixes a bug in `cloud:sites` from #2378

Its non-Hetzner refusal paired `log.error` with `process.exit`. The write is async and `process.exit` does not wait for it, so the refusal **printed nothing at all** and exited 1. Reproduced and fixed here, and the new command's refusal path is built on `log.exit` from the start.

## Upstream context that changed since #2378

I opened ts-cloud#190 claiming the `move` primitive did not exist. **That was wrong and I have closed it.** `dist/operations/` holds a complete implementation of all of stacksjs/ts-cloud#167: `planSiteMove` (20 exports), `planServerRename`, a drained-site scanner, and `operations/plan` - a plan-then-apply runner with `satisfied()`-based resumability, typed confirmation for destructive steps, and an audit hook. That last one is exactly the "print the plan ts-cloud produced" this issue's `--dry-run` criterion asks for.

None of it is reachable: `dist/operations/` ships no `.js`, the subpaths do not resolve, and across all 1067 exported names from root + `/deploy` + `/drivers` not one operations symbol appears. Tracked in ts-cloud#191, which I retitled and broadened.

So `cloud:move`, `cloud:rename` and `cloud:destroy` should be thin callers of those functions rather than anything designed here, and they wait on that export. `attach` is the one operation that does not need them, which is why it is this PR.

## Verification

- 34 new tests, **628 pass / 0 fail** across the buddy suite.
- The config-edit test reads the **real scaffold template** (`defaults/scaffold/config/cloud.ts`) rather than a fixture, so a template that drifts fails the test instead of passing while the tool breaks.
- Separately verified by hand that the edit lands correctly in this repo's own 920-line `config/cloud.ts` (2 lines added, in the right place, nothing else moved).
- `buddy lint` clean (3200 files). `buddy typecheck` green, `bun run typecheck` clean for every file touched.
- `docs:buddy:check` passing.

**Not verified live.** `HCLOUD_TOKEN` is encrypted and I have no key, so the provider lookup and the SSH probe have not run against a real fleet. Refusal paths (no `--server`, no token) were exercised end to end and exit 1 correctly; the conflict logic is covered by tests with injected data.