### PR TITLE
fix(deps): stop the release recording generated packages as workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   "workspaces": [
     "storage/framework",
     "storage/framework/libs/*",
-    "storage/framework/libs/packages/*",
     "storage/framework/views/*",
     "storage/framework/core",
     "storage/framework/core/*"

--- a/storage/framework/core/actions/tests/library-packages.test.ts
+++ b/storage/framework/core/actions/tests/library-packages.test.ts
@@ -329,3 +329,52 @@ describe('buildLibraryPackages', () => {
     })).rejects.toThrow(/No functions packages are configured/)
   })
 })
+
+/**
+ * The generated library packages must not be workspace members
+ * (stacksjs/stacks#2387).
+ *
+ * `buddy release` runs the entry generator before it bumps, so every release
+ * wrote `package.json` files into `storage/framework/libs/packages/*`. That
+ * path used to be a workspace glob, so the install that follows recorded three
+ * directories in `bun.lock` that no checkout has: everything under
+ * `libs/packages/` is gitignored. CI then failed at `bun install
+ * --frozen-lockfile` with "lockfile had changes, but lockfile is frozen",
+ * before a single job ran, taking lint, typecheck, test, compile and
+ * artifact-freshness with it.
+ *
+ * It was fixed by hand twice (ab7b7e3, then again after v0.73.0) and came back
+ * both times, because nothing stopped the glob from matching generated output.
+ * This is that stop.
+ */
+describe('workspace globs vs generated packages (#2387)', () => {
+  it('does not make the generated library packages workspace members', async () => {
+    const manifest = await Bun.file(projectPath('package.json')).json()
+    const workspaces: string[] = manifest.workspaces ?? []
+
+    expect(workspaces).not.toContain('storage/framework/libs/packages/*')
+  })
+
+  it('keeps every workspace glob off the gitignored library output', async () => {
+    // Stated as the rule rather than the one offending string, so a glob that
+    // reaches the same directory by another spelling is caught too.
+    const manifest = await Bun.file(projectPath('package.json')).json()
+    const workspaces: string[] = manifest.workspaces ?? []
+
+    const reachesGeneratedPackages = workspaces.filter(glob =>
+      glob.replace(/\/\*+$/, '').replace(/\/+$/, '') === 'storage/framework/libs/packages',
+    )
+
+    expect(reachesGeneratedPackages).toEqual([])
+  })
+
+  it('control: the tracked libs workspace is still declared', async () => {
+    // Without this, the assertions above pass just as well on an empty list,
+    // and dropping every workspace would read as a fix.
+    const manifest = await Bun.file(projectPath('package.json')).json()
+    const workspaces: string[] = manifest.workspaces ?? []
+
+    expect(workspaces).toContain('storage/framework/libs/*')
+    expect(workspaces).toContain('storage/framework/core/*')
+  })
+})


### PR DESCRIPTION
Fixes #2387.

## The loop

`buddy release` runs the entry generator before it bumps, so **every release** writes `package.json` files into `storage/framework/libs/packages/hello-world-{components,elements,fx}`. That path was a workspace glob in the root `package.json`, so the install that follows recorded all three in `bun.lock`.

Everything under `libs/packages/` is gitignored (`*`, keeping only `.gitignore`). So CI checks out a tree where the workspaces the lockfile names do not exist, and fails at `bun install --frozen-lockfile` **before a single job runs**, taking lint, typecheck, test, compile and artifact-freshness with it.

Hand-fixed in `ab7b7e380`, back with v0.73.0, hand-fixed again in `7dd37a5d5` (whose message is literally "again"). Nothing stopped the glob from matching generated output, so it was going to recur on every release.

## Reproduced, then fixed, then re-verified

Before:

```
$ ./buddy generate:entries && bun install --lockfile-only
Saved bun.lock (319 packages)
$ grep -c hello-world bun.lock
9
$ rm -rf storage/framework/libs/packages/hello-world-*   # a fresh checkout
$ bun install --frozen-lockfile
error: lockfile had changes, but lockfile is frozen
```

After:

```
$ ./buddy generate:entries && bun install --lockfile-only
Saved bun.lock (316 packages)
$ grep -c hello-world bun.lock
0
$ git status --short bun.lock          # byte for byte unchanged
$ rm -rf storage/framework/libs/packages/hello-world-*
$ bun install --frozen-lockfile
Checked 292 installs across 316 packages (no changes)
```

## Why removing the glob is the whole fix

The issue offered three options and rated the release cleaning up after itself the weakest. This is option 3, and it is safe because the glob bought nothing:

- **Nothing imports these packages by name.** `hello-world-*` appears only in `config/library.ts` and the config defaults, never in an import.
- **The bundler already marks `@stacksjs/*` external** (`library/build.ts:140`), so it never resolved siblings through the workspace.
- **Build and publish both address each package by explicit directory** (`pkg.dir`), not by workspace resolution.
- The **full library build still passes**, `validateDeclarations` and `validateRuntimeExports` included, producing all three packages.

`storage/framework/libs/*` stays: `libs/components` is tracked, carries a `package.json`, and is a real workspace member. `libs/packages/*` was the only glob matching exclusively generated output.

## Guard

Three tests in `library-packages.test.ts`. The first pins the exact string; the second states the rule, so a glob reaching the same directory by another spelling (`.../packages/**`, a trailing slash) is caught too; the third is a control asserting the tracked workspaces are still declared, so deleting the whole list cannot read as a fix.

Restoring the glob fails the first two and leaves the control green.

## Verification

- Actions suite: **460 pass / 0 fail** across 38 files.
- `./buddy typecheck`: clean.
- `./buddy lint`: 1 error, pre-existing and untracked (`storage/framework/libs/entries/web-components.ts`, dated Aug 26, not present in CI). Unchanged by this diff.