### PR TITLE
fix(cli): quotes published as unknown, so a new app failed its own typecheck

### DIFF
--- a/storage/framework/core/cli/src/utils.ts
+++ b/storage/framework/core/cli/src/utils.ts
@@ -1,3 +1,4 @@
+import type { CollectionOperations } from '@stacksjs/collections'
 import { collect } from '@stacksjs/collections'
 
 type ColorInput = string | number
@@ -504,17 +505,27 @@ export function box(text: string, options: BoxOptions = {}): string {
 }
 
 /*
- * Inferred, not `any`.
+ * Stated, not inferred, and certainly not `any`.
  *
- * This was annotated `: any`, which threw away the `Collection<string>` that
- * `collect()` already returns. Nothing downstream could see a quote was a
+ * This was annotated `: any`, which threw away the `CollectionOperations<string>`
+ * that `collect()` already returns. Nothing downstream could see a quote was a
  * string: `quotes.random(1).first()` typed as `any` and got interpolated into
  * output unchecked, and `app/Commands/Inspire.ts` wrote
  * `.forEach((quote: string, index: number) => …)` to get names back - which is
  * an assertion over an untyped value, not a check, and would have been
  * accepted just the same if `random()` returned objects.
+ *
+ * Dropping the annotation fixed that inside this repo and broke it outside.
+ * `bun-plugin-dtsx` could not follow the inferred type across the
+ * `@stacksjs/collections` re-export and emitted `export declare const quotes:
+ * unknown`, so a scaffolded app - which resolves this package from its
+ * PUBLISHED dist, not from source - failed its own `buddy typecheck` on the
+ * `inspire` command the scaffold ships. In this repo the same code typechecks,
+ * because here the import resolves to the source above. That is why the type
+ * is written out: it is the one form that survives the package boundary
+ * (stacksjs/stacks#2389).
  */
-export const quotes = collect([
+export const quotes: CollectionOperations<string> = collect([
   // could be queried from any API or database
   'The best way to get started is to quit talking and begin doing.',
   'The pessimist sees difficulty in every opportunity. The optimist sees opportunity in every difficulty.',

--- a/storage/framework/core/cli/tests/published-declarations.test.ts
+++ b/storage/framework/core/cli/tests/published-declarations.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Exports must carry a type the DECLARATION EMIT can keep
+ * (stacksjs/stacks#2389).
+ *
+ * `quotes` was written `export const quotes = collect([...])` and inferred
+ * `CollectionOperations<string>` perfectly well inside this repo. It did not
+ * survive the package boundary: `bun-plugin-dtsx` could not follow the type
+ * out through the `@stacksjs/collections` re-export and published
+ *
+ *     export declare const quotes: unknown;
+ *
+ * so a freshly scaffolded app - which resolves `@stacksjs/cli` from its
+ * PUBLISHED dist, not from this source - failed its own `buddy typecheck` on
+ * the `inspire` command the scaffold ships:
+ *
+ *     error TS18046: 'quotes' is of type 'unknown'.
+ *     error TS7006: Parameter 'quote' implicitly has an 'any' type.
+ *
+ * A type-level test cannot catch this. In this repo the import resolves to the
+ * source above, where inference works either way, so `quotes` checks out as
+ * `CollectionOperations<string>` whether or not the annotation is there. The
+ * only thing that differs is what gets EMITTED, which is why this asserts on
+ * the source text.
+ *
+ * The repo already has the rule that prevents this class: `isolatedDeclarations`
+ * is set in `core/tsconfig.build.json` and flags the unannotated form as
+ * TS9010, "Variable must have an explicit type annotation". Nothing runs that
+ * config in CI though - it reports 1909 errors repo-wide today - so the guard
+ * is inert and this stands in for it here.
+ */
+import { describe, expect, it } from 'bun:test'
+import { join } from 'node:path'
+
+const utilsSource = await Bun.file(join(import.meta.dir, '../src/utils.ts')).text()
+
+describe('declaration emit survives the package boundary (#2389)', () => {
+  it('annotates the quotes export explicitly', () => {
+    // Not `export const quotes = collect([`, which publishes as `unknown`.
+    expect(utilsSource).toContain('export const quotes: CollectionOperations<string> = collect([')
+  })
+
+  it('imports the annotation as a type, so it costs no runtime', () => {
+    expect(utilsSource).toContain("import type { CollectionOperations } from '@stacksjs/collections'")
+  })
+
+  it('control: quotes is still exported and still built by collect', () => {
+    // Without this, deleting the export satisfies both assertions above by
+    // making them unreachable rather than true.
+    expect(utilsSource).toMatch(/export const quotes[^=]*= collect\(\[/)
+  })
+})

--- a/storage/framework/core/collections/src/index.ts
+++ b/storage/framework/core/collections/src/index.ts
@@ -1,3 +1,27 @@
 // Avoid ts-collect 0.4.1 and 0.4.2: their published dist is unparseable, so an
 // import here took the whole test suite down. Fixed in 0.4.3.
 export { collect } from 'ts-collect'
+
+/*
+ * The types, not just the function.
+ *
+ * `collect()` returns `CollectionOperations<T>`, and this package used to
+ * export no way to name it. A consumer that wanted to annotate a collection
+ * had to reach past this package into `ts-collect` itself, so in practice
+ * nobody did, and declarations fell back to whatever could be inferred.
+ *
+ * That is not free at a package boundary: `bun-plugin-dtsx` could not follow
+ * the inferred type out through this re-export and emitted
+ * `export declare const quotes: unknown` for `@stacksjs/cli`, which is what
+ * made a freshly scaffolded app fail its own `buddy typecheck`
+ * (stacksjs/stacks#2389).
+ */
+export type {
+  Collection,
+  CollectionMetrics,
+  CollectionOperations,
+  LazyCollectionOperations,
+  PaginationResult,
+  StandardDeviationResult,
+  ValidationSchema,
+} from 'ts-collect'


### PR DESCRIPTION
Fixes #2389.

## Reproduced against the real published package

```
$ bun add @stacksjs/cli@0.73.2
$ cat inspire.ts
import { quotes } from '@stacksjs/cli'
quotes.random(2).toArray().forEach((quote, index) => { ... })

$ tsc --noEmit
inspire.ts(3,1):  error TS18046: 'quotes' is of type 'unknown'.
inspire.ts(3,37): error TS7006: Parameter 'quote' implicitly has an 'any' type.
inspire.ts(3,44): error TS7006: Parameter 'index' implicitly has an 'any' type.
```

That is the `inspire` command the scaffold ships, so it is the first command a new app runs and it is red on a tree nobody has touched. The issue reported the TS7006s; there is an `unknown` error above them too.

## The source was never wrong

`export const quotes = collect([...])` infers `CollectionOperations<string>` correctly, and it typechecks **in this repo**, because here the import resolves to `src/`. It only breaks once emitted: `bun-plugin-dtsx` cannot follow the inferred type out through the `@stacksjs/collections` re-export and emits `unknown`.

An earlier change removed a `: any` annotation here in favour of that inference. It was right about `any` and had no way to know the inference would not survive the package boundary. This is why the type is now written out rather than inferred: it is the one form declaration emit keeps.

## Two changes

**`@stacksjs/collections` exports the types it is built around**, not just `collect()`. A consumer had no way to name `CollectionOperations` without reaching past the package into `ts-collect`, which is why nobody annotated.

**`quotes` states its type.** Emit goes from `export declare const quotes: unknown` to `export declare const quotes: CollectionOperations<string>`, with the type import carried into the `.d.ts`.

## The guard already existed and is inert

`isolatedDeclarations` is set in `core/tsconfig.build.json`, which every core package extends. It catches exactly this:

```
src/utils.ts(527,14): error TS9010: Variable must have an explicit type annotation with --isolatedDeclarations.
```

and `src/utils.ts` is clean once annotated. But nothing runs that config in CI - it reports **1909 errors repo-wide** today - so the rule that would have prevented this never fired. Too large to fix here; worth its own issue.

## Verification

- The minimal app on the **rebuilt** declarations typechecks clean.
- Positive check, not just absence of errors: `quotes.toArray()[0]` is assignable to `string` and **rejected** as `number`, so the element type really is `string`.
- cli + collections suites: **111 pass / 0 fail**.
- `./buddy typecheck` clean; `bun run typecheck` shows only the 4 pre-existing errors in the gitignored `storage/framework/cache/models/*`.
- `./buddy lint`: 1 error, pre-existing and untracked (`libs/entries/web-components.ts`, not in CI).

## On the test

A type-level test cannot guard this: in-repo the import resolves to source, where inference works whether or not the annotation is present, so `quotes` checks out as `CollectionOperations<string>` either way. Only the *emitted* declaration differs. The test therefore asserts the source form, with a control so deleting the export cannot satisfy it vacuously - it fails 2 of 3 on the shipped bug.