### PR TITLE
fix(logging): apply config/logging.ts even when something logged first

### DIFF
--- a/docs/basics/logging.md
+++ b/docs/basics/logging.md
@@ -126,34 +126,81 @@ await endTimer({ rowCount: users.length })
 
 ## Configuration
 
-Configure logging in `stacks.config.ts`:
+Configure logging in `config/logging.ts`:
+
+```typescript
+import type { LogRecord } from '@stacksjs/types'
+
+export default {
+  // Minimum level the console prints. Optional; see precedence below.
+  level: 'info',
+
+  // 'text' (default in development) or 'json' (default in production)
+  format: 'text',
+
+  // Where the log file goes. Only its directory is used.
+  logsPath: 'storage/logs/stacks.log',
+
+  // Write logs to file as well as the console
+  writeToFile: true,
+
+  // Ship the log stream somewhere else - see below
+  transports: [],
+}
+```
+
+### Level precedence
+
+**`LOG_LEVEL` env var > `config/logging.ts` > `info`.** The env var is there so a
+single run can be made verbose without editing the project; the config file is
+the setting the project ships with.
+
+### Transports
+
+A transport receives every record *before* formatting collapses it, so `args`
+still holds the real `Error` and the real context object. That is the seam for
+shipping logs to a log service, an OTel exporter, or a test sink, without
+rewriting a single call site.
 
 ```typescript
 export default {
-  logging: {
-    // Minimum log level
-    level: process.env.LOG_LEVEL || 'info',
-
-    // Log file directory
-    logDirectory: 'storage/logs',
-
-    // Write logs to file
-    writeToFile: true,
-
-    // Show tags in output (e.g., [STACKS])
-    showTags: false,
-
-    // Colorful console output
-    fancy: process.env.NODE_ENV !== 'production',
-
-    // Date format
-    dateFormat: 'YYYY-MM-DD HH:mm:ss',
-
-    // Sensitive fields to redact
-    redact: ['password', 'token', 'secret', 'creditCard'],
-  }
+  transports: [
+    {
+      name: 'log-service',
+      // Optional: this transport's own floor. Omit it to receive everything,
+      // including debug records the console is configured to suppress.
+      level: 'warning',
+      log(record: LogRecord) {
+        void fetch('https://logs.example.com/ingest', {
+          method: 'POST',
+          body: JSON.stringify(record),
+        })
+      },
+      // Optional: called on shutdown, for a transport that batches.
+      async flush() {},
+    },
+  ],
 }
 ```
+
+A transport that throws is contained and reported once on stderr, then left
+alone - the logger is frequently the thing reporting a failure and must not
+become a second one.
+
+To attach one from a package rather than from the project's config, use
+`registerTransport()`, which returns a function that detaches it:
+
+```typescript
+import { registerTransport } from '@stacksjs/logging'
+
+const detach = registerTransport({ name: 'my-sink', log: record => sink.push(record) })
+```
+
+Records emitted before `config/logging.ts` has finished loading do not reach the
+transports it declares - they do not exist yet. Everything from that point on
+does. `await logger()` resolves once the config has been applied, if you need to
+wait for it (but never call it from inside a `config/*.ts` file, which would
+wait on its own load).
 
 ## Log Channels
 

--- a/docs/packages/logging.md
+++ b/docs/packages/logging.md
@@ -519,7 +519,7 @@ log.info('Payment processed', {
 | `dump(...args)` | Dump objects |
 | `dd(...args)` | Dump and die |
 | `echo(...args)` | Echo output |
-| `logger()` | Get logger instance |
+| `logger()` | Get the logger, once `config/logging.ts` has been applied |
 
 ### Logger Class
 

--- a/storage/framework/core/logging/src/index.ts
+++ b/storage/framework/core/logging/src/index.ts
@@ -185,6 +185,38 @@ export function parseLogLevel(raw: string | undefined, fallback: LogLevel = 'inf
   return fallback
 }
 
+/** `level` from `config/logging.ts`, once it has loaded. Set by the config refresh. */
+let _configLevel: LogLevel | undefined
+
+/** Memo for the env level, so an invalid `LOG_LEVEL` warns once and not per call. */
+let _envLevelRaw: string | undefined
+let _envLevelParsed: LogLevel | undefined
+
+/**
+ * The level in force right now, at the same precedence the logger itself was
+ * built with: **env var > config file > default**.
+ *
+ * Exists because the synchronous fast paths need an answer without awaiting
+ * the logger, and the env var is the only part of that answer available
+ * synchronously. The config half arrives later and is filled in by the
+ * refresh; until then this reports what the logger is actually doing.
+ *
+ * Env is re-read per call rather than snapshotted: `LOG_LEVEL` is routinely
+ * set from inside a process (tests, `buddy` subcommands) after this module has
+ * loaded, and a snapshot would ignore it.
+ */
+export function currentLevel(): LogLevel {
+  const raw = process.env.LOG_LEVEL
+  if (raw) {
+    if (raw !== _envLevelRaw) {
+      _envLevelRaw = raw
+      _envLevelParsed = parseLogLevel(raw)
+    }
+    return _envLevelParsed!
+  }
+  return _configLevel ?? 'info'
+}
+
 /** Parse + validate `LOG_FORMAT`; defaults to json in prod, text in dev. */
 export function parseLogFormat(raw: string | undefined): LogFormat {
   if (raw === 'json' || raw === 'text') return raw
@@ -376,6 +408,202 @@ function activeTraceId(): string | undefined {
   }
 }
 
+// --- Reading `config/logging.ts` --------------------------------------------
+//
+// `@stacksjs/config` loads the project's `config/*.ts` files asynchronously and
+// signals completion with `overridesReady`, so anything this package reads
+// during its own lazy init can predate them. That used to be permanent:
+// the init was memoized behind `if (_logger) return`, transports were
+// registered only inside it, and so whichever code logged first decided
+// whether `config/logging.ts` counted at all. `LOG_LEVEL=debug` made losing
+// that race routine rather than rare, because it makes boot-time `log.debug()`
+// calls actually fire - so turning on debug logging to investigate a problem
+// switched off the transports you would have read it in
+// (stacksjs/stacks#2397).
+//
+// The fix is to revisit, not to wait. Waiting is not open to us: a
+// `config/*.ts` file that logs while it is being evaluated would deadlock
+// against its own load if the log call awaited `overridesReady`, and config
+// files routinely import framework packages that log.
+
+/** The shape this package reads out of `config/logging.ts`. */
+interface LoggingConfigSection {
+  level?: string
+  format?: string
+  writeToFile?: boolean
+  logsPath?: string
+  transports?: unknown
+}
+
+interface BuiltSettings extends ResolvedLogSettings {
+  logDirectory: string
+}
+
+/**
+ * Where `@stacksjs/config` anchors its readiness Promise on `globalThis`. It
+ * does that so duplicate module instances coordinate; reading the same anchor
+ * here means this package can see the project's config land without depending
+ * on the config module resolving from its own location.
+ */
+const CONFIG_READY_KEY = Symbol.for('@stacksjs/config:overridesReady')
+
+/** What `_logger` was built with, so a refresh can tell whether it is stale. */
+let _builtWith: BuiltSettings | null = null
+
+/** Read the config section as it stands right now, without awaiting readiness. */
+async function readLoggingConfigNow(): Promise<LoggingConfigSection | null> {
+  try {
+    const cfg = await import('@stacksjs/config') as { logging?: LoggingConfigSection }
+    return cfg.logging ?? null
+  }
+  catch {
+    // Config layer unavailable (e.g. a compiled binary with config loading
+    // skipped) - env + defaults still apply.
+    return null
+  }
+}
+
+/**
+ * The readiness Promise `@stacksjs/config` anchors on `globalThis`, if the
+ * config layer is present in this process at all.
+ *
+ * Preferred over importing `@stacksjs/config` and reading its exports: it
+ * resolves to the very object the config loader mutates, so it carries the
+ * project's `config/logging.ts` verbatim, and reading it does not require this
+ * package to resolve the config module from its own location - which it cannot
+ * always do (a compiled binary skips config loading; a package test run has no
+ * built config package to resolve).
+ */
+function configReadySignal(): Promise<{ logging?: LoggingConfigSection } | undefined> | null {
+  const anchored = (globalThis as Record<symbol, unknown>)[CONFIG_READY_KEY]
+  if (!anchored || typeof (anchored as Promise<unknown>).then !== 'function')
+    return null
+  return anchored as Promise<{ logging?: LoggingConfigSection } | undefined>
+}
+
+/**
+ * Settings + log directory for a given config section. Precedence: env >
+ * config > default.
+ *
+ * `fallbackDirectory` is what the logger is already writing to, and is used
+ * when the config section names no `logsPath` of its own. Without it a refresh
+ * would re-derive the default and could move the log directory (the framework
+ * default `logsPath` is relative; the derived fallback is absolute) purely as
+ * a side effect of re-reading a config that never mentioned it.
+ */
+async function resolveSettings(logging: LoggingConfigSection | null, fallbackDirectory?: string): Promise<BuiltSettings> {
+  const { level, format, writeToFile } = resolveLogSettings({
+    envLevel: process.env.LOG_LEVEL,
+    envFormat: process.env.LOG_FORMAT,
+    cfgLevel: logging?.level,
+    cfgFormat: logging?.format,
+    cfgWriteToFile: typeof logging?.writeToFile === 'boolean' ? logging.writeToFile : undefined,
+    isProduction: process.env.NODE_ENV === 'production',
+  })
+
+  // Resolve the log directory: config's `logsPath` dir wins, else the
+  // project's storage/logs, else a relative fallback.
+  let logDirectory: string | undefined
+  if (logging?.logsPath) {
+    const np = await import('node:path')
+    logDirectory = np.dirname(logging.logsPath)
+  }
+  if (!logDirectory)
+    logDirectory = fallbackDirectory
+  if (!logDirectory) {
+    try {
+      // Lazy import path to avoid a circular dependency (path imports logging).
+      const p = await import('@stacksjs/path')
+      logDirectory = p.projectPath('storage/logs')
+    }
+    catch {
+      logDirectory = 'storage/logs'
+    }
+  }
+
+  return { level, format, writeToFile, logDirectory }
+}
+
+/** Attach transports a config section declares, skipping any already attached. */
+function attachDeclaredTransports(logging: LoggingConfigSection | null): void {
+  if (!Array.isArray(logging?.transports))
+    return
+  for (const transport of logging.transports) {
+    // Identity-checked: the first init may already have attached these (when
+    // config happened to be loaded by then), and a second copy of a transport
+    // would deliver every record to it twice.
+    if (!_transports.includes(transport as LogTransport))
+      addTransport(transport)
+  }
+}
+
+/**
+ * Apply `config/logging.ts` once it has actually loaded.
+ *
+ * Started by `initLogger` and deliberately never awaited by it - see the note
+ * above on why the log path cannot block on config readiness. Runs once per
+ * process; failures are swallowed because the config layer reports its own.
+ */
+let _configApplied: Promise<void> | null = null
+function applyConfigWhenReady(): void {
+  if (_configApplied) return
+
+  const ready = configReadySignal()
+  // Nothing to subscribe to yet. Deliberately not memoized as "no config":
+  // the anchor is installed when `@stacksjs/config` is first imported, and
+  // nothing guarantees that happens before the first log line.
+  if (!ready) return
+
+  _configApplied = ready.then(async (resolved) => {
+    const logging = resolved?.logging
+    if (!logging) return
+
+    // Attached in the first continuation off the readiness Promise, before any
+    // further await. Anything deferred past this point is a record that code
+    // waking on the same Promise logs into a transport not yet attached, for
+    // no reason other than hop count.
+    attachDeclaredTransports(logging)
+    if (logging.level)
+      _configLevel = parseLogLevel(logging.level)
+
+    const built = _builtWith
+    if (!built || !_logger)
+      return
+
+    const next = await resolveSettings(logging, built.logDirectory)
+    if (built.level === next.level && built.format === next.format
+      && built.writeToFile === next.writeToFile && built.logDirectory === next.logDirectory) {
+      return
+    }
+
+    // Rebuild rather than reach into the instance: clarity reads its settings
+    // from the config it was constructed with and exposes no setter for them.
+    // Drain and destroy the old one first - it owns rotation intervals that
+    // would otherwise keep firing (and hold the process open) alongside the
+    // replacement's.
+    const previous = _logger
+    _logger = new Logger('stacks', {
+      level: next.level,
+      logDirectory: next.logDirectory,
+      showTags: false,
+      fancy: next.format !== 'json',
+      format: next.format,
+      writeToFile: next.writeToFile,
+    })
+    _builtWith = next
+    try {
+      await (previous as unknown as { flush?: () => Promise<void> }).flush?.()
+      await (previous as unknown as { destroy?: () => Promise<void> }).destroy?.()
+    }
+    catch {
+      // Best effort. The replacement is already live either way.
+    }
+  }).catch(() => {
+    // A config that fails to load or validate reports that itself; there is
+    // nothing here to apply.
+  })
+}
+
 async function initLogger(): Promise<void> {
   if (_logger) return
   if (_loggerInitPromise) return _loggerInitPromise
@@ -388,75 +616,56 @@ async function initLogger(): Promise<void> {
     // truth (stacksjs/stacks#1935). Best-effort + lazy: any failure
     // falls back to env + defaults (today's behavior). Precedence is
     // **env var > config file > default**.
-    let cfgLevel: string | undefined
-    let cfgFormat: string | undefined
-    let cfgLogDir: string | undefined
-    let cfgWriteToFile: boolean | undefined
-    try {
-      const cfg = await import('@stacksjs/config') as {
-        logging?: { level?: string, format?: string, writeToFile?: boolean, logsPath?: string, transports?: unknown }
-      }
-      const logging = cfg.logging
-      if (logging) {
-        cfgLevel = logging.level
-        cfgFormat = logging.format
-        if (typeof logging.writeToFile === 'boolean') cfgWriteToFile = logging.writeToFile
-        if (logging.logsPath) {
-          const np = await import('node:path')
-          cfgLogDir = np.dirname(logging.logsPath)
-        }
-        // Config-declared transports. Added directly rather than through
-        // `registerTransport`, which would re-enter this function.
-        if (Array.isArray(logging.transports)) {
-          for (const transport of logging.transports)
-            addTransport(transport)
-        }
-      }
-    }
-    catch {
-      // Config layer unavailable (e.g. compiled binary with config
-      // loading skipped) — env + defaults below still apply.
-    }
+    //
+    // This read is unavoidably a snapshot - it is the one that may lose the
+    // race described above - so `applyConfigWhenReady()` below revisits it.
+    const logging = await readLoggingConfigNow()
+    attachDeclaredTransports(logging)
+    if (logging?.level)
+      _configLevel = parseLogLevel(logging.level)
 
-    // env > config > default
-    const { level, format, writeToFile } = resolveLogSettings({
-      envLevel: process.env.LOG_LEVEL,
-      envFormat: process.env.LOG_FORMAT,
-      cfgLevel,
-      cfgFormat,
-      cfgWriteToFile,
-      isProduction: process.env.NODE_ENV === 'production',
-    })
-
-    // Resolve the log directory: config's `logsPath` dir wins, else the
-    // project's storage/logs, else a relative fallback.
-    let logDirectory = cfgLogDir
-    if (!logDirectory) {
-      try {
-        // Lazy import path to avoid a circular dependency (path imports logging).
-        const p = await import('@stacksjs/path')
-        logDirectory = p.projectPath('storage/logs')
-      }
-      catch {
-        logDirectory = 'storage/logs'
-      }
-    }
+    const settings = await resolveSettings(logging)
 
     _logger = new Logger('stacks', {
-      level,
-      logDirectory,
+      level: settings.level,
+      logDirectory: settings.logDirectory,
       showTags: false,
-      fancy: format !== 'json',
-      format,
-      writeToFile,
+      fancy: settings.format !== 'json',
+      format: settings.format,
+      writeToFile: settings.writeToFile,
     })
+    _builtWith = settings
   })()
+
+  // Fire-and-forget: importing `@stacksjs/config` above installs the readiness
+  // anchor, so by the time this runs there is something to subscribe to.
+  void _loggerInitPromise.then(applyConfigWhenReady)
 
   return _loggerInitPromise
 }
 
 async function getLogger(): Promise<Logger> {
   await initLogger()
+  return _logger!
+}
+
+/**
+ * The configured logger.
+ *
+ * Unlike the accessor the `log.*` methods use internally, this one waits for
+ * `config/logging.ts` to have been applied, so what it hands back is the
+ * logger the project asked for rather than whatever was available the first
+ * time something logged.
+ *
+ * The one thing not to do with it is call it from inside a `config/*.ts` file,
+ * or from a module one of them imports at evaluation time: it waits on the
+ * very load those files are part of. The `log.*` methods have no such
+ * restriction - they never wait on config - and are what that code wants.
+ */
+export async function logger(): Promise<Logger> {
+  await initLogger()
+  applyConfigWhenReady()
+  if (_configApplied) await _configApplied
   return _logger!
 }
 
@@ -681,16 +890,30 @@ export const log: Log = {
     // every call still ran formatMessage + getLogger + a level-filtered
     // logger.debug and left a floating Promise, despite emitting nothing.
     // Mirrors the underlying logger: debug ranks below info/warn/error.
-    const lvl = ((process.env.LOG_LEVEL as string) || 'info').toLowerCase()
-    const suppressed = lvl === 'info' || lvl === 'warn' || lvl === 'error'
+    //
+    // The level this consults has to be the *resolved* one. Reading
+    // `process.env.LOG_LEVEL` straight, as this did, meant `level: 'debug'`
+    // in `config/logging.ts` never enabled a single `log.debug` line - the
+    // env var was the only thing that could (stacksjs/stacks#2397).
+    const suppressed = currentLevel() !== 'debug'
 
     // The fast path is unchanged when nothing is attached, which is the common
     // case. A transport, though, is allowed to be more verbose than the
     // terminal: shipping debug lines to a log service while keeping the console
     // at info is a normal thing to want, and suppressing them here would make
     // it impossible.
-    if (suppressed && _transports.length === 0)
+    if (suppressed && _transports.length === 0) {
+      // A suppressed debug line must still not leave `config/logging.ts`
+      // unread: it may declare a transport that wants the debug records the
+      // console does not, and reading that file is exactly what initializing
+      // does. Both guards latch for the rest of the process, so this costs two
+      // boolean checks per call once it has happened.
+      if (!_logger && !_loggerInitPromise)
+        void initLogger()
+      else if (!_configApplied)
+        applyConfigWhenReady()
       return
+    }
 
     const message = formatMessage(...args)
     if (suppressed) {
@@ -809,9 +1032,6 @@ export async function dd(...args: any[]): Promise<never> {
 export async function echo(...args: any[]): Promise<void> {
   await log.debug(...args)
 }
-
-// Export logger getter for debugging
-export { getLogger as logger }
 
 export interface ReportOptions {
   /** Override the detected HTTP status (otherwise read from the error). */

--- a/storage/framework/core/logging/tests/config-race.test.ts
+++ b/storage/framework/core/logging/tests/config-race.test.ts
@@ -1,0 +1,212 @@
+/**
+ * `config/logging.ts` vs. whoever logs first.
+ *
+ * `@stacksjs/config` loads the project's config files asynchronously, so the
+ * read this package does during its own lazy init can predate them. That used
+ * to be permanent - the init was memoized, transports were registered only
+ * inside it - so whichever code logged first decided whether `config/logging.ts`
+ * counted at all, and `LOG_LEVEL=debug` made losing that race routine because
+ * it makes boot-time `log.debug()` calls actually fire. Turning on debug
+ * logging to investigate a problem switched off the transports you would have
+ * read it in (stacksjs/stacks#2397).
+ *
+ * These run in child processes on purpose. The thing under test is what the
+ * module does on the way up, once per process, and no amount of in-process
+ * setup can rewind that.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+
+const SRC = new URL('../src/index.ts', import.meta.url).pathname
+
+interface ChildResult {
+  attached: string[]
+  seen: string[]
+  level: string
+}
+
+/**
+ * Run `body` in a fresh process with the logging source imported as `lg`, and
+ * return what it printed.
+ *
+ * The child runs from a temp directory so it picks up no `bunfig.toml`, and
+ * therefore no preload that would import the real config layer and install an
+ * anchor of its own. `@stacksjs/*` still resolves: those imports are resolved
+ * relative to the source file, not the working directory.
+ */
+async function inChildProcess(body: string, env: Record<string, string> = {}): Promise<ChildResult> {
+  const directory = await mkdtemp(join(tmpdir(), 'stacks-logging-race-'))
+  const script = join(directory, 'child.ts')
+
+  await writeFile(script, `
+    const KEY = Symbol.for('@stacksjs/config:overridesReady')
+    const seen: string[] = []
+
+    /**
+     * Stand in for the config layer: installs the readiness anchor and hands
+     * back the resolver, so a test says exactly when the config lands rather
+     * than racing a timer against the logger's own startup.
+     */
+    function pendingConfig(): (section: unknown) => void {
+      let land: (value: unknown) => void = () => {}
+      ;(globalThis as any)[KEY] = new Promise((resolve) => { land = resolve })
+      return (section: unknown) => land({ logging: section })
+    }
+
+    /** A transport shaped like one declared in \`config/logging.ts\`. */
+    function declaredTransport(name = 'declared') {
+      return { name, log: (record: any) => { seen.push(record.level + ':' + record.message) } }
+    }
+
+    const lg = await import(${JSON.stringify(SRC)})
+    const { log } = lg
+
+    ${body}
+
+    console.log('__RESULT__' + JSON.stringify({
+      attached: lg.transports().map((t: any) => t.name),
+      seen,
+      level: lg.currentLevel(),
+    }))
+  `)
+
+  try {
+    const child = Bun.spawn(['bun', 'run', script], {
+      cwd: directory,
+      env: { ...process.env, ...env },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const [stdout, code] = await Promise.all([new Response(child.stdout).text(), child.exited])
+    const marker = stdout.split('__RESULT__')[1]
+    if (code !== 0 || !marker) {
+      const stderr = await new Response(child.stderr).text()
+      throw new Error(`child exited ${code}\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`)
+    }
+    return JSON.parse(marker.trim()) as ChildResult
+  }
+  finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+describe('transports declared in config/logging.ts', () => {
+  it('attaches them even when something logged before the config loaded', async () => {
+    // The reported failure, start to finish: a boot-time debug line initializes
+    // the logger against a config that has not landed, and the transport
+    // declared in `config/logging.ts` is dropped for the life of the process.
+    const result = await inChildProcess(`
+      const land = pendingConfig()
+      await log.debug('logged during boot, before the config lands')
+      land({ transports: [declaredTransport()] })
+      await lg.logger()
+      await log.info('after the config landed')
+    `, { LOG_LEVEL: 'debug' })
+
+    expect(result.attached).toEqual(['declared'])
+    // The boot line is genuinely not deliverable - the transport did not exist
+    // when it was emitted. Everything from the config landing onwards is.
+    expect(result.seen).toEqual(['info:after the config landed'])
+  })
+
+  it('attaches them when nothing logged first', async () => {
+    // The control. This path always worked, and has to keep working: the fix
+    // must not trade one ordering for the other.
+    const result = await inChildProcess(`
+      const land = pendingConfig()
+      land({ transports: [declaredTransport()] })
+      await lg.logger()
+      await log.info('first line of the process')
+    `)
+
+    expect(result.attached).toEqual(['declared'])
+    expect(result.seen).toEqual(['info:first line of the process'])
+  })
+
+  it('attaches each declared transport exactly once', async () => {
+    // The config is read in two places now - the init's snapshot and the
+    // refresh - and several call sites can ask for the refresh. A transport
+    // attached twice would deliver every record twice.
+    const result = await inChildProcess(`
+      const land = pendingConfig()
+      land({ transports: [declaredTransport()] })
+      await lg.logger()
+      await log.info('one')
+      await log.info('two')
+    `)
+
+    expect(result.attached).toEqual(['declared'])
+    expect(result.seen).toEqual(['info:one', 'info:two'])
+  })
+
+  it('reaches a transport that wants the debug records the console suppresses', async () => {
+    // A transport is allowed to be more verbose than the terminal. That relies
+    // on `log.debug`'s fast path not bailing out before the config has been
+    // read - which is what it did, because "no transports attached" looked
+    // like a settled fact while `config/logging.ts` was still loading.
+    const result = await inChildProcess(`
+      const land = pendingConfig()
+      await log.debug('too early to be delivered anywhere')
+      land({ transports: [declaredTransport()] })
+      await lg.logger()
+      await log.debug('shipped to the transport, not to the console')
+    `, { LOG_LEVEL: 'info' })
+
+    expect(result.attached).toEqual(['declared'])
+    expect(result.seen).toEqual(['debug:shipped to the transport, not to the console'])
+  })
+})
+
+describe('level declared in config/logging.ts', () => {
+  it('enables debug output on its own, with no LOG_LEVEL set', async () => {
+    // `log.debug` used to consult `process.env.LOG_LEVEL` directly, so
+    // `level: 'debug'` in the config file never enabled a single debug line.
+    const result = await inChildProcess(`
+      const land = pendingConfig()
+      land({ level: 'debug', transports: [declaredTransport()] })
+      await lg.logger()
+      await log.debug('enabled by the config file alone')
+    `, { LOG_LEVEL: '' })
+
+    expect(result.level).toBe('debug')
+    expect(result.seen).toEqual(['debug:enabled by the config file alone'])
+  })
+
+  it('still loses to LOG_LEVEL, which outranks it', async () => {
+    // Precedence is env > config > default, and stays that way.
+    const result = await inChildProcess(`
+      const land = pendingConfig()
+      land({ level: 'debug', transports: [declaredTransport()] })
+      await lg.logger()
+      await log.debug('below the console threshold')
+      await log.warn('kept')
+    `, { LOG_LEVEL: 'warning' })
+
+    expect(result.level).toBe('warning')
+    // The transport still sees the debug record: an unfiltered transport is
+    // allowed to be more verbose than the terminal, and `level` here is about
+    // what the console prints. Asserted rather than assumed, because the fix
+    // touches the same fast path that decides it.
+    expect(result.seen).toEqual(['debug:below the console threshold', 'warning:kept'])
+  })
+})
+
+describe('without a config layer', () => {
+  it('logs against env and defaults rather than waiting for one', async () => {
+    // A compiled binary skips config loading entirely, so nothing ever anchors
+    // a readiness Promise. Waiting on one that will not arrive would hang every
+    // log call in the process.
+    const result = await inChildProcess(`
+      await log.info('no config in this process')
+      await lg.logger()
+      await log.debug('still nothing to wait for')
+    `, { LOG_LEVEL: 'debug' })
+
+    expect(result.attached).toEqual([])
+    expect(result.level).toBe('debug')
+  })
+})


### PR DESCRIPTION
Closes #2397.

## The bug

`@stacksjs/logging` read `@stacksjs/config` during its own lazy init and memoized the result. The config layer populates `config/*.ts` asynchronously (`overridesReady`), so that read could predate them - and because transports were registered **only** inside that init, behind `if (_logger) return`, whichever code logged first decided whether `config/logging.ts` counted at all.

`LOG_LEVEL=debug` made losing that race routine rather than rare, because it makes boot-time `log.debug()` calls actually fire. Turning on debug logging to investigate a production problem stopped shipping the logs to the place you would read them, and nothing warned - `config.logging.transports` still listed the transport.

Reproduced against the local packages before touching anything:

```
$ bun check.ts                      # nothing logs early
{"configDeclares":["probe"],"loggerHolds":["probe"]}

$ EARLY_LOG=1 LOG_LEVEL=debug bun check.ts
{"configDeclares":["probe"],"loggerHolds":[]}      # dropped
```

## Two more symptoms of the same root cause

Found while reproducing, both fixed here:

- **`level` was dropped by the same race.** `configLevel: "debug"` / `loggerLevel: "info"`. The most-used key in `config/logging.ts`, silently ignored.
- **`log.debug` read `process.env.LOG_LEVEL` directly**, so `level: 'debug'` in the config file never enabled a single debug line *even when the race was won*. Verified: config level `debug`, no env var, `log.debug(...)` printed nothing.

## The fix

**Revisit rather than wait.** Waiting is not open to us, and that constraint drove the design: a `config/*.ts` file that logs while it is being evaluated would deadlock against its own load if the log call awaited `overridesReady`, and config files routinely import framework packages that log.

So the init keeps its non-blocking snapshot, and a refresh subscribes to readiness and applies what actually landed:

- attaches declared transports, identity-checked so the two reads cannot double-attach
- records the config level, which `log.debug`'s fast path now consults
- rebuilds the logger only if the resolved settings changed. clarity exposes no setter for level or format, so a change means a new instance; the old one is drained and `destroy()`ed first, since it owns rotation intervals that would otherwise keep firing alongside the replacement's.

Two ordering details that are load-bearing rather than incidental:

- Transports attach in the **first continuation** off the readiness Promise. Deferring past that point means code waking on the same Promise logs into a transport that is about to exist. Measured: with the extra hops it missed the first line, without them it does not.
- `log.debug`'s fast path no longer returns before the logger has had a chance to read the config. `_transports.length === 0` looked like a settled fact while `config/logging.ts` was still loading, which is exactly how a transport that wants debug records the console suppresses got starved.

`logger()` now waits for the config to have been applied, making it a deterministic handle for "the logger the project asked for". The `log.*` methods deliberately do not, and are what config-time code should use.

## What is deliberately *not* fixed

Records emitted **before** the config file loads still do not reach the transports it declares. They do not exist yet, and buffering boot records for later replay would be a new feature with its own semantics (and would make config-declared transports behave unlike `registerTransport`, which has never replayed). What is fixed is that everything from the config landing onwards ships. Documented in `docs/basics/logging.md`.

## Tests

7 new tests, in child processes: the behaviour under test is what the module does on the way up, once per process, and no in-process setup can rewind that. They drive the readiness anchor `@stacksjs/config` publishes on `globalThis`, so they neither need the config package to be built nor depend on it - which matters, because CI builds only `composables` and `browser`, and a test reaching for `@stacksjs/config` would pass locally and fail there.

**All 7 fail on the unfixed source** (0 pass / 7 fail), including the control cases. The config is landed by an explicit resolver rather than a timer, so none of them race the logger's own startup.

## Verification

- `bun test ./storage/framework/core/logging/tests` - 113 pass, 0 fail
- sweep of `config`, `cli`, `error-handling`, `queue`, `cache` - 748 pass, 0 fail
- `./buddy typecheck` clean; `bun run typecheck` shows only the 4 pre-existing errors in gitignored `storage/framework/cache/models/*`
- `./buddy lint` shows only the pre-existing untracked `storage/framework/libs/entries/web-components.ts` error
- `docs:links:check` and `docs:artifacts:check` pass

## Docs

`docs/basics/logging.md`'s Configuration section named `stacks.config.ts` (a file that does not exist) and listed keys the package does not read (`logDirectory`, `showTags`, `fancy`, `dateFormat`, `redact`). Replaced with the real shape, plus the level precedence and the transports contract - which was undocumented, which is part of why this went unnoticed. The rest of that page is still stale; not fixed here.