### PR TITLE
fix(env): make env:rotate --dry-run and --stdout stop destroying the keypair

### DIFF
--- a/docs/guide/buddy/commands.md
+++ b/docs/guide/buddy/commands.md
@@ -1713,7 +1713,8 @@ Rotate a keypair
 | --- | --- | --- | --- |
 | `-f`, `--file` | The environment file to use | value, optional | `""` |
 | `--fk`, `--file-keys` | The path to the file containing the keys | value, optional | `""` |
-| `-o`, `--stdout` | Output the result to stdout | boolean, optional | `false` |
+| `-o`, `--stdout` | Print the rotated file and its new keypair without writing either | boolean, optional | `false` |
+| `--dry-run` | Report what would change without writing anything | boolean, optional | `false` |
 | `--ek`, `--exclude-key` | The key to exclude from encryption | value, optional | `""` |
 
 Examples:
@@ -1721,6 +1722,7 @@ Examples:
 ```bash
 buddy env:rotate
 buddy env:rotate --file .env.production
+buddy env:rotate --file .env.production --dry-run
 ```
 
 ### `env:set`

--- a/storage/framework/core/buddy/src/commands/env.ts
+++ b/storage/framework/core/buddy/src/commands/env.ts
@@ -25,6 +25,8 @@ interface EnvOptions {
   strict: boolean
   /** The global `--env <environment>` flag, e.g. `production`. */
   env: string
+  /** `env:rotate`: report what would change and write nothing. */
+  dryRun: boolean
 }
 
 export function env(buddy: CLI): void {
@@ -41,6 +43,8 @@ export function env(buddy: CLI): void {
     fileKeys: 'The path to the file containing the keys',
     excludeKey: 'The key to exclude from encryption',
     rotate: 'Rotate a keypair',
+    rotateStdout: 'Print the rotated file and its new keypair without writing either',
+    rotateDryRun: 'Report what would change without writing anything',
     format: 'The format to output the result (json, shell, eval)',
     all: 'Get all environment variables',
     file: 'The environment file to use',
@@ -217,10 +221,12 @@ export function env(buddy: CLI): void {
     .command('env:rotate [key]', descriptions.rotate)
     .option('-f, --file [file]', descriptions.file, { default: '' })
     .option('-fk, --file-keys [fileKeys]', descriptions.fileKeys, { default: '' })
-    .option('-o, --stdout', descriptions.stdout, { default: false })
+    .option('-o, --stdout', descriptions.rotateStdout, { default: false })
+    .option('--dry-run', descriptions.rotateDryRun, { default: false })
     .option('-ek, --exclude-key [excludeKey]', descriptions.excludeKey, { default: '' })
     .example('buddy env:rotate')
     .example('buddy env:rotate --file .env.production')
+    .example('buddy env:rotate --file .env.production --dry-run')
     .action(async (key: string, options: EnvOptions) => {
       log.debug('Running `buddy env:rotate` ...', options)
 
@@ -230,10 +236,15 @@ export function env(buddy: CLI): void {
         key,
         excludeKey: options.excludeKey,
         stdout: options.stdout,
+        dryRun: options.dryRun,
       })
 
       if (result.success) {
         console.log(result.output)
+        // The new keypair goes to stderr, so `env:rotate --stdout > file` still
+        // captures only the env file while the keys that output needs stay in
+        // front of whoever ran it.
+        if (result.notice) console.error(result.notice)
         process.exit(ExitCode.Success)
       }
       else {

--- a/storage/framework/core/env/src/cli.ts
+++ b/storage/framework/core/env/src/cli.ts
@@ -71,6 +71,31 @@ export function resolveEnvFile(file?: string, environment?: string): string {
   return `.env.${name}`
 }
 
+/**
+ * Whether `--key` / `--exclude-key` select this variable.
+ *
+ * Shared so `env:rotate --dry-run` counts exactly the values a real rotation
+ * would re-encrypt, rather than a second opinion that can drift from it.
+ */
+function inEncryptScope(key: string, options: Pick<EncryptOptions, 'key' | 'excludeKey'>): boolean {
+  return (!options.key || key.includes(options.key)) && (!options.excludeKey || !key.includes(options.excludeKey))
+}
+
+/** The variables in a decrypted env body that an encrypt pass would rewrite. */
+function encryptableKeys(envContent: string, options: Pick<EncryptOptions, 'key' | 'excludeKey'>): string[] {
+  const keys: string[] = []
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    if (trimmed.startsWith('DOTENV_PUBLIC_KEY')) continue
+    const match = trimmed.match(/^([^=]+)=(.*)$/)
+    if (!match || match[1] === undefined) continue
+    const key = match[1].trim()
+    if (inEncryptScope(key, options)) keys.push(key)
+  }
+  return keys
+}
+
 function encryptedEnvContent(envContent: string, publicKey: string, publicKeyName: string, options: Pick<EncryptOptions, 'key' | 'excludeKey'>): string {
   const encryptedLines: string[] = [
     '#/-------------------[DOTENV_PUBLIC_KEY]--------------------/',
@@ -108,7 +133,7 @@ function encryptedEnvContent(envContent: string, publicKey: string, publicKeyNam
     let value = match[2].trim()
     if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith(`'`) && value.endsWith(`'`)))
       value = value.slice(1, -1)
-    const selected = (!options.key || key.includes(options.key)) && (!options.excludeKey || !key.includes(options.excludeKey))
+    const selected = inEncryptScope(key, options)
     if (selected && !value.startsWith('encrypted:')) value = encryptValue(value, publicKey)
     encryptedLines.push(`${key}="${value}"`)
   }
@@ -684,37 +709,40 @@ export function getKeypair(
   }
 }
 
-/**
- * Rotate keypair and re-encrypt all values
- */
-export function rotateKeypair(
-  options: { file?: string, keysFile?: string, key?: string, excludeKey?: string, stdout?: boolean, cwd?: string } = {},
-): { success: boolean, output?: string, error?: string } {
-  // First decrypt
-  const decryptResult = decryptEnv({
-    file: options.file,
-    keysFile: options.keysFile,
-    stdout: true,
-    cwd: options.cwd,
-  })
+export interface RotateOptions {
+  file?: string
+  keysFile?: string
+  key?: string // Specific key to re-encrypt
+  excludeKey?: string // Key pattern to exclude
+  /**
+   * Print the rotation instead of applying it. Writes nothing at all: the new
+   * env content comes back as `output`, the new keypair as `notice`.
+   */
+  stdout?: boolean
+  /** Report what would change. Writes nothing and generates no key material. */
+  dryRun?: boolean
+  cwd?: string
+}
 
-  if (!decryptResult.success) {
-    return decryptResult
-  }
+export interface RotateResult {
+  success: boolean
+  output?: string
+  error?: string
+  /**
+   * Text for stderr rather than stdout, so a caller redirecting `--stdout`
+   * captures only the env file while the keypair still reaches the operator.
+   */
+  notice?: string
+}
 
-  const cwd = options.cwd || process.cwd()
-  const envPath = resolve(cwd, options.file || '.env')
-  const keysPath = resolve(cwd, options.keysFile || '.env.keys')
-
-  if (decryptResult.output === undefined) return { success: false, error: 'Rotation produced no decrypted content' }
-  const keypair = generateKeypair()
-  const originalEnv = readFileSync(envPath)
-  const originalKeys = readFileSync(keysPath)
-  const lines = originalKeys.toString('utf8').split('\n')
-  const envFileName = options.file || '.env'
-  const env = basename(envFileName).replace(/^\.env\./, '').replace(/^\.env$/, '').toUpperCase()
-  const publicKeyName = env ? `DOTENV_PUBLIC_KEY_${env}` : 'DOTENV_PUBLIC_KEY'
-  const privateKeyName = env ? `DOTENV_PRIVATE_KEY_${env}` : 'DOTENV_PRIVATE_KEY'
+/** Replace (or add) this file's keypair in a `.env.keys` body. */
+function rotatedKeysContent(
+  keysContent: string,
+  keypair: { publicKey: string, privateKey: string },
+  publicKeyName: string,
+  privateKeyName: string,
+): string {
+  const lines = keysContent.split('\n')
   let replacedPublic = false
   let replacedPrivate = false
   for (let i = 0; i < lines.length; i++) {
@@ -731,8 +759,80 @@ export function rotateKeypair(
   }
   if (!replacedPublic) lines.push(`${publicKeyName}="${keypair.publicKey}"`)
   if (!replacedPrivate) lines.push(`${privateKeyName}="${keypair.privateKey}"`)
-  const nextKeys = `${lines.join('\n').replace(/\n+$/, '')}\n`
+  return `${lines.join('\n').replace(/\n+$/, '')}\n`
+}
+
+/**
+ * Rotate an env file's keypair and re-encrypt every value under the new one.
+ *
+ * A rotation is only meaningful as a PAIR: the re-encrypted file and the
+ * keypair that opens it have to land together, or one of them is useless.
+ * `--stdout` used to break that pair - it replaced the keypair in `.env.keys`
+ * and printed the new env content instead of writing it, so the file left on
+ * disk was still encrypted under a private key that had just been overwritten,
+ * and every value in it was unrecoverable (stacksjs/stacks#2398). It now writes
+ * nothing and hands back both halves. `--dry-run` writes nothing either, and
+ * does not even generate a keypair: a preview that produced real key material
+ * and threw it away would be a rotation, not a preview.
+ */
+export function rotateKeypair(options: RotateOptions = {}): RotateResult {
+  // Decrypt into memory. The `stdout: true` here is what keeps the plaintext
+  // off disk, and is unrelated to this function's own `stdout` option.
+  const decryptResult = decryptEnv({
+    file: options.file,
+    keysFile: options.keysFile,
+    stdout: true,
+    cwd: options.cwd,
+  })
+
+  if (!decryptResult.success) {
+    return decryptResult
+  }
+
+  if (decryptResult.output === undefined) return { success: false, error: 'Rotation produced no decrypted content' }
+
+  const cwd = options.cwd || process.cwd()
+  const envFileName = options.file || '.env'
+  const keysFileName = options.keysFile || '.env.keys'
+  const envPath = resolve(cwd, envFileName)
+  const keysPath = resolve(cwd, keysFileName)
+  const { publicKeyName, privateKeyName } = envKeyNames(options.file)
+
+  // Checked before `--stdout`, so asking for both gets the safer one.
+  if (options.dryRun) {
+    const values = encryptableKeys(decryptResult.output, options)
+    return {
+      success: true,
+      output: [
+        'Dry run: nothing was written.',
+        `${envFileName}: ${values.length} value${values.length === 1 ? '' : 's'} would be re-encrypted under a new ${publicKeyName}.`,
+        `${keysFileName}: ${publicKeyName} and ${privateKeyName} would be replaced.`,
+        `The current ${privateKeyName} decrypts nothing once that happens, so keep a copy until the rotation is verified.`,
+      ].join('\n'),
+    }
+  }
+
+  const keypair = generateKeypair()
   const nextEnv = encryptedEnvContent(decryptResult.output, keypair.publicKey, publicKeyName, options)
+
+  if (options.stdout) {
+    return {
+      success: true,
+      output: nextEnv,
+      notice: [
+        `Nothing was written. To adopt the output above, put this keypair in ${keysFileName}:`,
+        '',
+        `${publicKeyName}="${keypair.publicKey}"`,
+        `${privateKeyName}="${keypair.privateKey}"`,
+        '',
+        `Without it that output cannot be decrypted. Run without --stdout to have both applied together.`,
+      ].join('\n'),
+    }
+  }
+
+  const originalEnv = readFileSync(envPath)
+  const originalKeys = readFileSync(keysPath)
+  const nextKeys = rotatedKeysContent(originalKeys.toString('utf8'), keypair, publicKeyName, privateKeyName)
 
   const token = `${process.pid}-${Date.now()}`
   const envTemp = resolve(dirname(envPath), `.${basename(envPath)}.${token}.rotate`)
@@ -740,10 +840,6 @@ export function rotateKeypair(
   try {
     writeFileSync(envTemp, nextEnv, { encoding: 'utf8', mode: 0o600 })
     writeFileSync(keysTemp, nextKeys, { encoding: 'utf8', mode: 0o600 })
-    if (options.stdout) {
-      renameSync(keysTemp, keysPath)
-      return { success: true, output: nextEnv }
-    }
     renameSync(envTemp, envPath)
     try {
       renameSync(keysTemp, keysPath)
@@ -752,7 +848,7 @@ export function rotateKeypair(
       writeFileSync(envPath, originalEnv)
       throw error
     }
-    return { success: true, output: `✔ rotated (${options.file || '.env'}) to encrypted:v2` }
+    return { success: true, output: `✔ rotated (${envFileName}) to encrypted:v2` }
   }
   catch (error) {
     if (!existsSync(keysPath)) writeFileSync(keysPath, originalKeys, { mode: 0o600 })

--- a/storage/framework/core/env/tests/rotate-flags.test.ts
+++ b/storage/framework/core/env/tests/rotate-flags.test.ts
@@ -1,0 +1,159 @@
+/**
+ * `env:rotate --dry-run` and `--stdout`.
+ *
+ * Both flags are advertised on the command, and neither did what it says. The
+ * asymmetry is the point: `--dry-run` was not implemented at all and performed
+ * a real rotation, while `--stdout` was half-implemented, which is worse. It
+ * replaced the keypair in `.env.keys` and printed the re-encrypted file instead
+ * of writing it, so the file left on disk was still encrypted under a private
+ * key that had just been overwritten. Every value in it became unrecoverable
+ * (stacksjs/stacks#2398).
+ *
+ * So these tests are mostly about what is NOT on disk afterwards, and about the
+ * output of `--stdout` being a usable pair rather than half of one.
+ */
+
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { encryptEnv, getEnv, rotateKeypair } from '../src/cli'
+import { parse } from '../src/parser'
+
+const directories: string[] = []
+
+/** An encrypted `.env.production` plus the `.env.keys` that opens it. */
+function encryptedProject(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'stacks-env-rotate-flags-'))
+  directories.push(directory)
+  writeFileSync(join(directory, '.env.production'), 'APP_NAME=Acme\nDB_PASSWORD=hunter2\nAPI_TOKEN=abc123\n', { mode: 0o600 })
+  const encrypted = encryptEnv({ file: '.env.production', cwd: directory })
+  expect(encrypted.success).toBe(true)
+  return directory
+}
+
+const bytes = (directory: string, file: string): string => readFileSync(join(directory, file), 'utf8')
+
+/** What the values decrypt to right now, using whatever `.env.keys` holds. */
+const readSecret = (directory: string): string | undefined =>
+  getEnv('DB_PASSWORD', { file: '.env.production', cwd: directory }).output
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { force: true, recursive: true })
+})
+
+describe('env:rotate --dry-run', () => {
+  it('writes to neither file and leaves the values readable', () => {
+    const directory = encryptedProject()
+    const before = { env: bytes(directory, '.env.production'), keys: bytes(directory, '.env.keys') }
+
+    const result = rotateKeypair({ file: '.env.production', cwd: directory, dryRun: true })
+
+    expect(result.success).toBe(true)
+    expect(bytes(directory, '.env.production')).toBe(before.env)
+    expect(bytes(directory, '.env.keys')).toBe(before.keys)
+    // The whole failure was a "preview" that destroyed the key. If the secret
+    // still reads back, the keypair on disk is still the file's own.
+    expect(readSecret(directory)).toBe('hunter2')
+    expect(readdirSync(directory).filter(name => name.endsWith('.rotate'))).toEqual([])
+  })
+
+  it('reports what would change, naming both files and counting the values', () => {
+    const directory = encryptedProject()
+
+    const result = rotateKeypair({ file: '.env.production', cwd: directory, dryRun: true })
+
+    expect(result.output).toContain('nothing was written')
+    expect(result.output).toContain('.env.production: 3 values would be re-encrypted')
+    expect(result.output).toContain('.env.keys: DOTENV_PUBLIC_KEY_PRODUCTION and DOTENV_PRIVATE_KEY_PRODUCTION would be replaced')
+  })
+
+  it('counts only the values the same run would actually re-encrypt', () => {
+    // The count comes from the predicate the encrypt pass itself uses, so
+    // `--exclude-key` cannot make the preview disagree with the rotation.
+    const directory = encryptedProject()
+
+    const result = rotateKeypair({ file: '.env.production', cwd: directory, excludeKey: 'TOKEN', dryRun: true })
+
+    expect(result.output).toContain('2 values would be re-encrypted')
+  })
+
+  it('wins when --stdout is passed as well', () => {
+    // Asking for both should get the one that cannot lose anything.
+    const directory = encryptedProject()
+    const before = { env: bytes(directory, '.env.production'), keys: bytes(directory, '.env.keys') }
+
+    const result = rotateKeypair({ file: '.env.production', cwd: directory, dryRun: true, stdout: true })
+
+    expect(result.output).toContain('nothing was written')
+    expect(result.notice).toBeUndefined()
+    expect(bytes(directory, '.env.production')).toBe(before.env)
+    expect(bytes(directory, '.env.keys')).toBe(before.keys)
+  })
+})
+
+describe('env:rotate --stdout', () => {
+  it('writes to neither file and leaves the values readable', () => {
+    const directory = encryptedProject()
+    const before = { env: bytes(directory, '.env.production'), keys: bytes(directory, '.env.keys') }
+
+    const result = rotateKeypair({ file: '.env.production', cwd: directory, stdout: true })
+
+    expect(result.success).toBe(true)
+    expect(bytes(directory, '.env.production')).toBe(before.env)
+    // This is the regression. `.env.keys` used to be rewritten here, which
+    // overwrote the private key the untouched file above is encrypted under.
+    expect(bytes(directory, '.env.keys')).toBe(before.keys)
+    expect(readSecret(directory)).toBe('hunter2')
+    expect(readdirSync(directory).filter(name => name.endsWith('.rotate'))).toEqual([])
+  })
+
+  it('hands back a usable pair, not half of one', () => {
+    const directory = encryptedProject()
+
+    const result = rotateKeypair({ file: '.env.production', cwd: directory, stdout: true })
+
+    // Adopt the output exactly as the notice instructs, and the values have to
+    // come back. Printing ciphertext whose private key was never reported is
+    // the same lost-secret outcome by a different route, so this is asserted
+    // end to end rather than by checking the notice merely mentions a key.
+    const adopted = mkdtempSync(join(tmpdir(), 'stacks-env-rotate-adopt-'))
+    directories.push(adopted)
+    const { parsed } = parse(result.notice!)
+    writeFileSync(join(adopted, '.env.production'), result.output!, { mode: 0o600 })
+    writeFileSync(join(adopted, '.env.keys'), [
+      `DOTENV_PUBLIC_KEY_PRODUCTION="${parsed.DOTENV_PUBLIC_KEY_PRODUCTION}"`,
+      `DOTENV_PRIVATE_KEY_PRODUCTION="${parsed.DOTENV_PRIVATE_KEY_PRODUCTION}"`,
+      '',
+    ].join('\n'), { mode: 0o600 })
+
+    expect(readSecret(adopted)).toBe('hunter2')
+  })
+
+  it('keeps the keypair out of the redirectable output', () => {
+    // `env:rotate --stdout > file` has to produce a valid env file, so the
+    // private key belongs on the other stream.
+    const directory = encryptedProject()
+
+    const result = rotateKeypair({ file: '.env.production', cwd: directory, stdout: true })
+
+    expect(result.output).not.toContain('x25519-private:')
+    expect(result.notice).toContain('x25519-private:')
+  })
+})
+
+describe('env:rotate with no flags', () => {
+  it('still rotates both files together', () => {
+    // The control. The flags above write nothing; the command itself has to
+    // keep writing both halves, or the fix traded one lost secret for another.
+    const directory = encryptedProject()
+    const before = { env: bytes(directory, '.env.production'), keys: bytes(directory, '.env.keys') }
+
+    const result = rotateKeypair({ file: '.env.production', cwd: directory })
+
+    expect(result.success).toBe(true)
+    expect(bytes(directory, '.env.production')).not.toBe(before.env)
+    expect(bytes(directory, '.env.keys')).not.toBe(before.keys)
+    expect(readSecret(directory)).toBe('hunter2')
+  })
+})


### PR DESCRIPTION
Closes #2398.

## The bug

`buddy env:rotate` advertises `--dry-run` and `--stdout`, and honoured neither. The failure modes were not symmetric.

**`--dry-run` was not implemented at all.** `dryRun` appeared nowhere in the env package, so it performed a real rotation of production secrets. It was never declared on the command either - it comes from the process-wide flag set in `global-options.ts`, which registers it once on the CLI object, so it appears in the help for every command and is parsed into `options.dryRun` whether or not anything reads it.

**`--stdout` was half-implemented, which is worse.** It replaced the keypair in `.env.keys` and printed the re-encrypted content instead of writing it, so the file left on disk was still encrypted under a private key that had just been overwritten.

### A correction to the issue

The issue says `--stdout` "writes the re-encrypted `.env.<environment>` to disk but not the matching `.env.keys`". Reproducing it in a sandbox showed the **opposite**:

```
=== --stdout (before the fix) ===
env file rewritten : false
keys file rewritten: true
readable after     : "encrypted:v2:eyJ2IjoyLCJlcGsiOi..."
```

`.env.production` is untouched and `.env.keys` is rewritten. The impact in the issue is exactly right - every value in the file becomes unrecoverable - but it is reached by the opposite route: the file is fine and the key that opens it is gone. The `grep`-the-two-public-keys evidence in the issue is consistent with either direction, which is how I got it backwards.

## The fix

Both flags now write nothing.

**`--dry-run`** reports which files would change, how many values would be re-encrypted, and that the current private key stops decrypting anything:

```
$ buddy env:rotate --file .env.rotatetest --file-keys .env.rotatetest.keys --dry-run
Dry run: nothing was written.
.env.rotatetest: 3 values would be re-encrypted under a new DOTENV_PUBLIC_KEY_ROTATETEST.
.env.rotatetest.keys: DOTENV_PUBLIC_KEY_ROTATETEST and DOTENV_PRIVATE_KEY_ROTATETEST would be replaced.
The current DOTENV_PRIVATE_KEY_ROTATETEST decrypts nothing once that happens, so keep a copy until the rotation is verified.
--- env changed: NO | keys changed: NO ---
```

It generates no keypair at all. A preview that produced real key material and discarded it would be a rotation, not a preview. It also wins when `--stdout` is passed alongside it, so asking for both gets the one that cannot lose anything.

**`--stdout`** returns the rotated env content and the new keypair, applying neither. The keypair goes to **stderr**, so a redirect still captures a valid env file while the keys that output needs stay in front of whoever ran it:

```
$ buddy env:rotate --file .env.rotatetest --file-keys .env.rotatetest.keys --stdout > rotated.env
--- env changed: NO | keys changed: NO ---

# stdout -> rotated.env:
#/-------------------[DOTENV_PUBLIC_KEY]--------------------/
DOTENV_PUBLIC_KEY_ROTATETEST="x25519-public:MCowBQYDK2VuAyEA0cJz4..."

# stderr:
Nothing was written. To adopt the output above, put this keypair in .env.rotatetest.keys:

DOTENV_PUBLIC_KEY_ROTATETEST="x25519-public:MCowBQYDK2VuAyEA0cJz4..."
DOTENV_PRIVATE_KEY_ROTATETEST="x25519-private:MC4CAQAwBQYDK2VuBCIEIPflH..."

Without it that output cannot be decrypted. Run without --stdout to have both applied together.
```

A rotation is only meaningful as a **pair**. Printing the ciphertext without the key that opens it is the same lost-secret outcome by a different route, which is why the notice is not just advice - a test adopts the output exactly as instructed and asserts the secret decrypts.

The dry-run count comes from the predicate the encrypt pass itself uses, extracted into `inEncryptScope()` rather than restated, so `--key` / `--exclude-key` cannot make the preview disagree with the rotation it previews.

## Audit of the siblings named in the issue

- **`env:decrypt --stdout`** returns before `writeFileSync(envPath, output)`. It does **not** write plaintext to disk. The issue's worry was unfounded.
- **`env:encrypt --stdout`** does write `.env.keys` when the file has no keypair yet. That one is required rather than a bug: without persisting the key, the ciphertext it prints to stdout could never be decrypted. Same reasoning that makes rotate's old behaviour wrong, applied the other way.

## The broader point in the issue

The issue asks whether `--dry-run` should be refused by commands that do not implement it, rather than inherited from the global set and ignored. It is a single, well-contained place (`registerGlobalOptions` in `global-options.ts`), so it is very doable - **but the blast radius is the whole CLI**: 292 command registrations across 71 files, of which 15 declare their own `--dry-run` and 19 read `options.dryRun`. Turning it into an error would change behaviour for roughly 250 invocations that currently accept and ignore it, including anything scripted.

That is a policy call rather than a bug fix, so I have not made it here. Happy to open it as its own PR if you want it.

## Tests

8 new tests in `storage/framework/core/env/tests/rotate-flags.test.ts`, following the existing `rotation-v2.test.ts` pattern. They assert on file **bytes** before and after, not mtimes, and on whether the secret still reads back - which is the thing that was actually lost.

**7 of the 8 fail on the unfixed source.** The eighth is the control (a plain `env:rotate` still writes both halves together) and passes on both, so the fix cannot have traded one lost secret for another.

## Verification

- `bun test ./storage/framework/core/env/tests` - 232 pass, 0 fail
- `bun test ./storage/framework/core/buddy/tests` - 569 pass, 0 fail
- End-to-end through the real `./buddy` CLI against an isolated fixture (`--file-keys` pointed at a throwaway keys file, so the repo's own keys were never in scope) - output above
- `./buddy typecheck` and `bun run typecheck` clean (only the 4 pre-existing errors in gitignored `storage/framework/cache/models/*`)
- `./buddy lint` shows only the pre-existing untracked `storage/framework/libs/entries/web-components.ts` error
- `docs:buddy:check` was stale after the new option; regenerated with `bun run docs:buddy`. `docs:links:check` and `docs:artifacts:check` pass.