### PR TITLE
fix(create): scaffold from the tag matching the framework version the app pins

### DIFF
--- a/storage/framework/core/buddy/src/commands/create.ts
+++ b/storage/framework/core/buddy/src/commands/create.ts
@@ -10,6 +10,7 @@ import { ExitCode } from '@stacksjs/types'
 import { uninstallAllFeatures } from './features'
 import { ensurePantryDependencies, ensurePantryInstalled } from './setup'
 import { resultFailed } from '../result'
+import { fetchPublishedVersions } from '../registry'
 
 interface NewOptions extends CreateOptions {
   withCore?: boolean
@@ -180,12 +181,65 @@ async function isOnline(): Promise<boolean> {
  * first, which would take the repository's history with it. `isFolderCheck()`
  * has already established the target holds nothing but `.git`.
  */
+/**
+ * The template ref to scaffold from: the tag matching the framework version the
+ * app is about to pin, or `null` for the default branch.
+ *
+ * This used to be the default branch unconditionally, while `unpublish:core`
+ * pinned the framework to the newest PUBLISHED version. Those are two different
+ * points in history, and the gap between them is exactly where a release has
+ * not happened yet - so a freshly scaffolded app carried userland (`config/`,
+ * `app/`, `routes/`) written against framework changes it could not install,
+ * and failed its own `./buddy typecheck` before the user had touched anything.
+ * `MobileConfig` did it in stacksjs/stacks#2322, and `security.api` was doing
+ * it again while this was being written.
+ *
+ * Scaffolding from the tag removes the disagreement by construction rather than
+ * reporting it afterwards, and makes `buddy new` reproducible: two people
+ * scaffolding a week apart get the same app rather than whatever main happened
+ * to be.
+ */
+export async function templateRef(
+  fetchVersions: typeof fetchPublishedVersions = fetchPublishedVersions,
+): Promise<string | null> {
+  try {
+    const { latest } = await fetchVersions('stacks')
+    // A package with no release has no tag to scaffold from either.
+    return latest ? `v${latest}` : null
+  }
+  catch {
+    // An unreachable registry is not a reason to refuse to scaffold. The
+    // default branch is what shipped before this, so fall back to it.
+    return null
+  }
+}
+
+/** The gitit spec for a template ref, or the default branch when there is none. */
+export function templateSpec(ref: string | null): string {
+  return ref ? `gh:stacksjs/stacks#${ref}` : 'gh:stacksjs/stacks'
+}
+
 async function download(name: string, path: string, _options: CreateOptions) {
   log.info('Setting up your stack.')
 
+  const ref = await templateRef()
+
   try {
     const { downloadTemplate } = await import('@stacksjs/gitit')
-    await downloadTemplate('gh:stacksjs/stacks', { dir: name, force: true })
+    try {
+      await downloadTemplate(templateSpec(ref), { dir: name, force: true })
+    }
+    catch (error) {
+      // The registry named a version whose tag is not on GitHub - a publish
+      // that landed without its tag, or a tag naming scheme that has moved on.
+      // Scaffolding from the default branch is the old behaviour and still
+      // produces a working app far more often than not, so say what happened
+      // and carry on rather than failing here.
+      if (!ref) throw error
+      log.warn(`No ${ref} tag to scaffold from (${error instanceof Error ? error.message : String(error)}).`)
+      log.info('Falling back to the default branch. If this app does not typecheck, that gap is why.')
+      await downloadTemplate(templateSpec(null), { dir: name, force: true })
+    }
     log.success(`Successfully scaffolded your project at ${cyan(path)}`)
     return { isErr: false as const }
   }

--- a/storage/framework/core/buddy/src/commands/publish.ts
+++ b/storage/framework/core/buddy/src/commands/publish.ts
@@ -9,6 +9,7 @@ import { path } from '@stacksjs/path'
 import { fs, globSync } from '@stacksjs/storage'
 import { pruneVendoredCoreFromWorkflows, splitFrameworkTypecheckScript } from '../workflow-prune'
 import { detectInstaller, findCoreReferences, isDanglingLink, rewriteCoreCommandPaths, rewriteCoreSourceImports, rewriteSurvivingFrameworkManifests } from '../unvendor-rewrite'
+import { fetchPublishedVersions } from '../registry'
 import { ExitCode } from '@stacksjs/types'
 
 interface PublishOptions {
@@ -1084,25 +1085,6 @@ async function resolvePublishedVersion(depName: string, vendored: string): Promi
   log.warn(`${depName}@${vendored} is not published yet - the vendored copy is ahead of npm.`)
   log.info(`Pinning the newest published version instead, ${depName}@^${published.latest}.`)
   return published.latest
-}
-
-async function fetchPublishedVersions(depName: string): Promise<{ latest?: string, versions: Set<string> }> {
-  const response = await fetch(`https://registry.npmjs.org/${depName.replace('/', '%2F')}`, {
-    headers: { accept: 'application/vnd.npm.install-v1+json' },
-  })
-
-  if (!response.ok)
-    throw new Error(`registry responded ${response.status}`)
-
-  const packument = await response.json() as {
-    'dist-tags'?: Record<string, string>
-    'versions'?: Record<string, unknown>
-  }
-
-  return {
-    latest: packument['dist-tags']?.latest,
-    versions: new Set(Object.keys(packument.versions ?? {})),
-  }
 }
 
 /** Accepts `router`, `@stacksjs/router`, or `core/router`. */

--- a/storage/framework/core/buddy/src/registry.ts
+++ b/storage/framework/core/buddy/src/registry.ts
@@ -1,0 +1,43 @@
+/**
+ * What npm actually has.
+ *
+ * Both scaffolding and unvendoring have to reconcile the checkout in front of
+ * them with the versions a user can install, and they were reconciling it
+ * differently: `unpublish:core` asked the registry before writing a range,
+ * while `buddy new` did not ask at all. Split out so there is one answer to
+ * "what is published" rather than one per caller.
+ */
+
+export interface PublishedVersions {
+  /** The `latest` dist-tag, absent if the package has no releases. */
+  latest?: string
+  /** Every version the registry lists. */
+  versions: Set<string>
+}
+
+/**
+ * Ask the registry what exists for a package.
+ *
+ * Uses the abbreviated packument (`application/vnd.npm.install-v1+json`), which
+ * is a fraction of the full document and carries the two things wanted here.
+ * Throws on any non-OK response so callers can decide what an unreachable
+ * registry means for them; it is not always fatal.
+ */
+export async function fetchPublishedVersions(depName: string): Promise<PublishedVersions> {
+  const response = await fetch(`https://registry.npmjs.org/${depName.replace('/', '%2F')}`, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  })
+
+  if (!response.ok)
+    throw new Error(`registry responded ${response.status}`)
+
+  const packument = await response.json() as {
+    'dist-tags'?: Record<string, string>
+    'versions'?: Record<string, unknown>
+  }
+
+  return {
+    latest: packument['dist-tags']?.latest,
+    versions: new Set(Object.keys(packument.versions ?? {})),
+  }
+}

--- a/storage/framework/core/buddy/tests/scaffold-template-ref.test.ts
+++ b/storage/framework/core/buddy/tests/scaffold-template-ref.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Which point in history `buddy new` scaffolds from.
+ *
+ * It used to be the default branch, unconditionally, while the unvendor step
+ * pinned the framework to the newest PUBLISHED version. Those are two different
+ * commits whenever a release has not happened yet, and the gap between them is
+ * userland written against framework changes the app cannot install. A freshly
+ * scaffolded app then failed its own `./buddy typecheck` before the user had
+ * touched anything.
+ *
+ * It has happened at least twice: `MobileConfig` in stacksjs/stacks#2322, and
+ * `security.api` (from #2375) six commits after v0.73.3, which is what this was
+ * measured against - the repository's own `config/` did not typecheck against
+ * the framework a `buddy new` app would have installed that day.
+ *
+ * Scaffolding from the tag that matches the pinned version closes the gap by
+ * construction. These tests pin the resolution and its fallbacks; what they
+ * cannot cover is the download itself, which needs the network.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { templateRef, templateSpec } from '../src/commands/create'
+
+describe('templateRef', () => {
+  it('scaffolds from the tag matching the newest published release', async () => {
+    const ref = await templateRef(async () => ({ latest: '0.73.3', versions: new Set(['0.73.2', '0.73.3']) }))
+
+    // The `v` prefix is the repository's tag naming, and the whole point is
+    // that this names the SAME release the app is about to pin.
+    expect(ref).toBe('v0.73.3')
+  })
+
+  it('falls back to the default branch when the registry cannot be reached', async () => {
+    const ref = await templateRef(async () => { throw new Error('getaddrinfo ENOTFOUND registry.npmjs.org') })
+
+    // Offline is not a reason to refuse to scaffold. This is what shipped
+    // before the tag pin, so the fallback is the old behaviour rather than a
+    // degraded one.
+    expect(ref).toBeNull()
+  })
+
+  it('falls back to the default branch when the package has no release', async () => {
+    // No `latest` dist-tag means no release, and so no tag to scaffold from.
+    const ref = await templateRef(async () => ({ latest: undefined, versions: new Set<string>() }))
+
+    expect(ref).toBeNull()
+  })
+})
+
+describe('templateSpec', () => {
+  it('asks gitit for the tag when there is one', () => {
+    // gitit parses the ref off a `#` suffix, and its accepted charset covers a
+    // dotted version tag. Pinned here because the whole fix is this suffix.
+    expect(templateSpec('v0.73.3')).toBe('gh:stacksjs/stacks#v0.73.3')
+  })
+
+  it('asks for the default branch when there is not', () => {
+    expect(templateSpec(null)).toBe('gh:stacksjs/stacks')
+  })
+
+  it('keeps resolving the GitHub provider directly', () => {
+    // `gh:` is deliberate: the bare `stacks` name goes through gitit's template
+    // registry, which still points at the old org and only reaches us via a
+    // repo-transfer redirect. Adding a ref must not quietly drop the prefix.
+    for (const spec of [templateSpec(null), templateSpec('v1.2.3')])
+      expect(spec.startsWith('gh:stacksjs/stacks')).toBe(true)
+  })
+})


### PR DESCRIPTION
Addresses the last open item on #2322.

## What the issue asked for

> Worth a smoke job that scaffolds an app and runs `./buddy typecheck` on it, **so the template and the pinned framework can never disagree.**

I went after the second half rather than the first. A smoke job detects the disagreement; it does not stop it, and it would be red through no fault of whichever PR happened to trip it. The disagreement is structural and removable.

## The root cause

`download()` calls `downloadTemplate('gh:stacksjs/stacks', ...)` - the **default branch**. `unvendorFramework()` then pins the framework to the newest **published** version, because the vendored one routinely is not on npm yet.

Those are two different commits whenever a release has not happened, and the gap between them is userland written against framework changes the app cannot install.

## It was live while I was writing this

Not hypothetical, and not only the `MobileConfig` case in the issue. Six commits after `v0.73.3`, `e94b2c4d3b` (#2375) added `security.api` to **both** `config/security.ts` and `@stacksjs/types`. `config/security.ts` ships in the scaffold; the type does not exist in published `0.73.3`.

Typechecking each template against the published `@stacksjs/*@0.73.3`:

| template | result |
|---|---|
| default branch (what shipped) | **1 error** |
| `v0.73.3` tag (this PR) | **0 errors** |

```
config/security.ts(11,3): error TS2353: Object literal may only specify known properties,
and 'api' does not exist in type 'DeepPartial<SecurityOptions>'.
```

So on the day I picked this up, `buddy new` produced an app that failed `./buddy typecheck` out of the box. Third occurrence of the same shape.

## The fix

Ask the registry what `stacks` has published, and scaffold from the matching `v<version>` tag. gitit's input regex is `/^(?<repo>[\w.-]+\/[\w.-]+)(?<subdir>[^#]+)?(?<ref>#[\w./@-]+)?/`, so a dotted version tag is already in its accepted charset; verified end to end against `gh:stacksjs/stacks#v0.73.3` (~5s, no slower than the default branch).

The tag's core `package.json` carries the same version the registry named, so `unvendorFramework` pins exactly what the template was written against. They agree by construction.

**Two fallbacks, both to the previous behaviour rather than to a failure:**

- Registry unreachable, or a package with no release: no tag to resolve, scaffold the default branch. Being offline is not a reason to refuse to scaffold, and this is precisely what shipped before.
- The registry names a version GitHub has no tag for (a publish that landed without its tag): report it and scaffold the default branch, with a line saying that gap is the explanation if the app does not typecheck.

`fetchPublishedVersions` moves to `src/registry.ts`. Both scaffolding and unvendoring have to reconcile the checkout with what a user can install, and they were reconciling it differently - unvendor asked the registry, `buddy new` did not ask at all.

## Trade-off worth naming

A new app is now scaffolded from the last release rather than from main, so it does not pick up unreleased template changes. That is the point: the framework it installs is that release either way, and an app matching its framework beats an app that is newer than it. It also makes `buddy new` reproducible, which it was not.

`--with-core` takes the same path. An app keeping the vendored framework is self-consistent either way, and a released tree seemed the better default than an arbitrary main commit; happy to branch it if you would rather that case tracked main.

## Tests

6 new tests. `templateRef()` takes an injectable fetcher, so resolution and both fallbacks are covered without the network; `templateSpec()` pins the `#ref` suffix and that the `gh:` provider prefix survives (the bare `stacks` name goes through gitit's registry, which still points at the old org).

What they cannot cover is the download itself. That needs the network, and it is verified above by hand instead.

## Verification

- `bun test ./storage/framework/core/buddy/tests` - 575 pass, 0 fail
- `bun test ./storage/framework/core/actions/tests` - 460 pass, 0 fail
- `./buddy typecheck` and `bun run typecheck` clean (only the 4 pre-existing errors in gitignored `storage/framework/cache/models/*`)
- `./buddy lint` shows only the pre-existing untracked `storage/framework/libs/entries/web-components.ts` error

## On the smoke job

Still worth having as a backstop, since this fix depends on the tag existing and matching. If you want it, the cheap version is what I used to measure the above: install the published `@stacksjs/*` into a scratch dir, copy `config/` plus the scaffold overrides, run `tsc`. About 30 seconds, no clone needed, and it fails with the exact file and symbol. Say the word and I will add it as a follow-up.