### PR TITLE
docs(db): correct why the pre-migration backup's config await is untested

### DIFF
--- a/storage/framework/core/buddy/src/commands/db.ts
+++ b/storage/framework/core/buddy/src/commands/db.ts
@@ -46,13 +46,29 @@ const DEFAULT_RETAIN = 7
  * backup and therefore the deploy, which is a worse failure than the one it
  * would be reporting. The validator has already printed the issues itself.
  *
- * Deliberately untested, which is worth stating rather than hiding. In this
- * repo `database.default` comes from `DB_CONNECTION` in the environment,
- * available synchronously, so early and late reads agree and no assertion can
- * tell them apart - measured over three runs, and an ordering assertion also
- * passed with the barrier removed. Reproducing the divergence needs a
- * `config/database.ts` that is not env-derived or that carries a top-level
- * await. A test that passes either way would only look like coverage.
+ * Deliberately untested, which is worth stating rather than hiding - but not
+ * for the reason recorded here before. That reason was that early and late
+ * reads agree in this repo, because `database.default` comes from
+ * `DB_CONNECTION` and the environment is available synchronously. They do not
+ * agree: the framework default is a hardcoded `'sqlite'` that never consults
+ * the environment, and only `config/database.ts` reads `DB_CONNECTION`, so the
+ * two differ whenever that variable says anything else. Measured directly against the config layer:
+ *
+ *     early: {"dbDefault":"sqlite"}
+ *     late:  {"dbDefault":"postgres"}
+ *
+ * What is true is the observation that an ordering assertion passes with this
+ * barrier removed, and the reason is the boot sequence rather than the value.
+ * `bunfig.toml` preloads the framework's own preloader, so the config load is
+ * already in flight before `main()` runs and has settled long before commands
+ * are registered, let alone run. Instrumented on both edges:
+ * `atRegistration=settled`, `atHandlerEntry=already-settled` - with the await
+ * here removed.
+ *
+ * So this await is defence against a boot sequence that stops winning that
+ * race, not against `DB_CONNECTION` being synchronous. Cheap enough to keep on
+ * a path where being wrong means restoring from a backup of the wrong database,
+ * and a test could only assert an ordering the preload already guarantees.
  */
 export async function backupTarget(): Promise<BackupTarget | null> {
   const { config, overridesReady } = await import('@stacksjs/config')


### PR DESCRIPTION
Refs #2313. Comment-only, no behaviour change.

## What was wrong

`backupTarget()` explained why it is untested like this:

> In this repo `database.default` comes from `DB_CONNECTION` in the environment, available synchronously, so early and late reads agree and no assertion can tell them apart.

They do not agree. The framework default is a hardcoded `'sqlite'` that never consults the environment (`config/src/defaults.ts:237`); only `config/database.ts` reads `DB_CONNECTION`, and that file loads asynchronously like every other config module. So the two differ whenever `DB_CONNECTION` says anything but sqlite. Measured against the config layer directly:

```
early: {"dbDefault":"sqlite"}
late:  {"dbDefault":"postgres"}
```

## What is actually true

The observation the comment was built on still holds - an ordering assertion passes with the await removed - but the cause is the **boot sequence**, not the value. `bunfig.toml` preloads the framework's preloader, so the config load is already in flight before `main()` runs and has settled before commands are even registered. Instrumented on both edges, with the await removed:

```
atRegistration=settled
atHandlerEntry=already-settled
```

## Why this is worth a commit on its own

The old reasoning invites the wrong generalisation. "The env var is synchronous, so early and late reads agree" reads as a licence to skip the await elsewhere. "The preload wins the race" does not, and it names exactly what would have to change for this to start mattering.

I went looking because of my own note on #2313, which flagged `db.ts` as possibly resolving its dump target from framework defaults. It does not - but not for the reason written down.

## What I did not ship

I built a general barrier first: `await overridesReady` in `cli.ts` before dispatch, so no command could read config early, plus tests. Then I measured it, and it is **inert** - the preload has already settled config at both registration and handler entry. Shipping it would have implied a protection story that is not the real one, so I threw it away rather than pad the diff. Twenty of the twenty-two buddy modules that read config do not await readiness, and on this evidence none of them need to.

## Verification

- `bun test ./storage/framework/core/buddy/tests` - 575 pass, 0 fail
- `./buddy lint` shows only the pre-existing untracked `storage/framework/libs/entries/web-components.ts` error