### PR TITLE
fix(scheduler): return the overlap-guarded task's promise instead of detaching it

### DIFF
--- a/storage/framework/core/scheduler/src/schedule.ts
+++ b/storage/framework/core/scheduler/src/schedule.ts
@@ -30,10 +30,16 @@ import { acquireSchedulerLock } from './scheduler-lock'
  * The jobs an application has, for `schedule.job(…)` to be checked against.
  *
  * Empty here and augmented by the application's own declarations, which derive
- * it from the jobs barrel - see `storage/framework/types/scheduled.d.ts`. The
- * scheduler cannot name them itself: importing the barrel from this package
- * would drag every job module into every compilation that touches the
- * scheduler.
+ * it from the jobs registry - see the `declare module '@stacksjs/scheduler'`
+ * block in `storage/framework/types/registries.d.ts`. The scheduler cannot name
+ * them itself: importing the barrel from this package would drag every job
+ * module into every compilation that touches the scheduler.
+ *
+ * This used to point at `storage/framework/types/scheduled.d.ts`, the 1500-line
+ * generated union the registry replaced. That file is gone, and
+ * `name-registries.test.ts` asserts it stays gone, so the pointer sent anyone
+ * checking whether the guard was live to a file whose absence looked like the
+ * guard being dead.
  *
  * Empty means any string, so an application that declares nothing is unchanged.
  */
@@ -536,38 +542,57 @@ export class Schedule implements UntimedSchedule {
 
   // --- Task wrapping ---
 
-  private wrapTask(originalTask: () => void): () => void {
+  private wrapTask(originalTask: () => void): () => unknown {
     const taskName = this.options.name || 'unnamed-task'
-    let wrappedTask = originalTask
+    let wrappedTask: () => unknown = originalTask
 
     if (this.shouldPreventOverlap || this.shouldRunOnOneServer) {
       const self = this
       const innerTask = wrappedTask
-      // Lock acquisition is async now (DB advisory lock can require a
-      // round-trip) but cron ticks are sync. Run the lock acquire in
-      // the background and gate execution behind it — if acquire
-      // fails, log + skip; if it succeeds, run + release in finally.
-      wrappedTask = () => {
-        void (async () => {
-          const acquired = await self.acquireLock(taskName)
-          if (!acquired) {
-            log.info(`Skipping overlapping task: ${taskName}`)
-            return
+      // Lock acquisition is async (a DB advisory lock can require a round-trip)
+      // while cron ticks are sync, so the guarded body has to be a Promise.
+      //
+      // It is RETURNED rather than discarded, which is the whole of
+      // stacksjs/stacks#2403. This used to be `void (async () => {…})()`, so
+      // every caller expecting to await the task got `undefined`: the runner's
+      // `if (result?.then) await result` never fired, `withErrorHandler` never
+      // saw a guarded task fail, and `Schedule.runNow()` resolved in ~0ms while
+      // the task was still running and about to throw. Three behaviours, one
+      // missing `return`, and only for tasks that chain `.withoutOverlapping()`
+      // or `.onOneServer()` - which is the combination the framework's own docs
+      // put in their worked example.
+      wrappedTask = () => (async () => {
+        // Deliberately NOT in a try: a lock layer that cannot answer is a
+        // failure to run, and the runner is what decides what that means.
+        // Previously it sat in a detached promise, so an unwritable lock
+        // directory (`ENOTDIR`, a full disk, a read-only mount) surfaced as an
+        // unhandled rejection, which terminates the process under Bun's
+        // default policy.
+        const acquired = await self.acquireLock(taskName)
+        if (!acquired) {
+          log.info(`Skipping overlapping task: ${taskName}`)
+          return
+        }
+        try {
+          const result: unknown = innerTask()
+          if (result && typeof result === 'object' && typeof (result as { finally?: unknown }).finally === 'function') {
+            await (result as Promise<unknown>)
           }
+        }
+        finally {
+          // Swallowed on purpose, and only here. A throw from `finally`
+          // REPLACES the task's own error, so an unguarded release would hide
+          // the failure the operator actually needs to see behind a lock-file
+          // complaint - and it is already too late to do anything about the
+          // release.
           try {
-            const result: unknown = innerTask()
-            if (result && typeof result === 'object' && typeof (result as { finally?: unknown }).finally === 'function') {
-              await (result as Promise<unknown>)
-            }
-          }
-          catch (error) {
-            log.error(`[scheduler] task ${taskName} threw: ${error instanceof Error ? error.message : String(error)}`)
-          }
-          finally {
             await self.releaseLock(taskName)
           }
-        })()
-      }
+          catch (error) {
+            log.error(`[scheduler] releasing the lock for ${taskName} failed: ${error instanceof Error ? error.message : String(error)}`)
+          }
+        }
+      })()
     }
 
     if (this.shouldRunInBackground) {
@@ -757,7 +782,7 @@ export class Schedule implements UntimedSchedule {
           this.options.catch(error as Error)
         }
         else {
-          log.error(`[scheduler] task ${taskName} failed (no .catch handler installed): ${error instanceof Error ? error.message : String(error)}`)
+          log.error(`[scheduler] task ${taskName} failed (no withErrorHandler() installed): ${error instanceof Error ? error.message : String(error)}`)
         }
         throw error
       }

--- a/storage/framework/core/scheduler/tests/overlap-guard-promise.test.ts
+++ b/storage/framework/core/scheduler/tests/overlap-guard-promise.test.ts
@@ -1,0 +1,153 @@
+/**
+ * What `.withoutOverlapping()` / `.onOneServer()` do to the task's promise.
+ *
+ * The guarded body has to be async - a DB advisory lock can require a
+ * round-trip while cron ticks are sync - and it used to be launched as a
+ * detached `void (async () => {…})()`. Every caller expecting to await the task
+ * got `undefined` instead, which broke three separate things at once
+ * (stacksjs/stacks#2403):
+ *
+ *   - `withErrorHandler` never fired for a guarded task, because the runner's
+ *     `if (result?.then) await result` had nothing to await and never saw the
+ *     rejection. The framework's own docs put `.withoutOverlapping(30)` and
+ *     `.withErrorHandler(...)` in the same worked example.
+ *   - `Schedule.runNow()` resolved in ~0ms while the task was still running and
+ *     about to throw, so any "run now" affordance reported green for a red job.
+ *   - A lock-layer failure became an unhandled rejection from a detached
+ *     promise, which terminates the process under Bun's default policy. A full
+ *     disk or a read-only mount on a deployed box reaches it.
+ *
+ * So these are mostly about a guarded task behaving exactly like an unguarded
+ * one, and each has the unguarded control beside it.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { Schedule } from '../src/schedule'
+
+const directories: string[] = []
+
+/** A writable lock directory, since these tests exercise the locking path. */
+function useLockDir(path?: string): void {
+  if (!path) {
+    const directory = mkdtempSync(join(tmpdir(), 'stacks-scheduler-lock-'))
+    directories.push(directory)
+    path = directory
+  }
+  ;(Schedule as unknown as { lockDir: string }).lockDir = path
+}
+
+const originalLockDir = (Schedule as unknown as { lockDir: string }).lockDir
+
+/** Register a task and wait for the deferred `start()` microtask to run. */
+async function register(name: string, task: () => unknown, guarded: boolean): Promise<void> {
+  const schedule = new Schedule(task as () => void)
+  if (guarded) schedule.withoutOverlapping()
+  // `yearly()` so no timer fires during the test; `runNow` drives it instead.
+  schedule.withName(name).yearly()
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+afterEach(() => {
+  ;(Schedule as unknown as { lockDir: string }).lockDir = originalLockDir
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+describe('a guarded task that throws', () => {
+  it('reaches withErrorHandler, exactly as an unguarded one does', async () => {
+    useLockDir()
+    const seen: string[] = []
+
+    const guarded = new Schedule(() => { throw new Error('guarded boom') })
+    guarded.withoutOverlapping().withName('GuardedThrows')
+      .withErrorHandler(error => seen.push(`guarded:${error.message}`)).yearly()
+
+    const plain = new Schedule(() => { throw new Error('plain boom') })
+    plain.withName('PlainThrows')
+      .withErrorHandler(error => seen.push(`plain:${error.message}`)).yearly()
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await expect(Schedule.runNow('GuardedThrows')).rejects.toThrow('guarded boom')
+    await expect(Schedule.runNow('PlainThrows')).rejects.toThrow('plain boom')
+
+    // The control is the point: the handler fired for the plain task the whole
+    // time, which is what made the guarded one's silence look like the task
+    // simply working.
+    expect(seen).toEqual(['guarded:guarded boom', 'plain:plain boom'])
+  })
+
+  it('rejects runNow() rather than reporting success', async () => {
+    useLockDir()
+    await register('GuardedRunNow', () => { throw new Error('still broken') }, true)
+
+    await expect(Schedule.runNow('GuardedRunNow')).rejects.toThrow('still broken')
+  })
+
+  it('releases the lock, so the next run is not skipped as an overlap', async () => {
+    // The release sits in a `finally`, and the throw path is the one that
+    // matters: a lock left behind by a failing run would make every later run
+    // skip, turning one visible failure into permanent silence.
+    useLockDir()
+    let runs = 0
+    await register('GuardedReleases', () => { runs++; throw new Error('every time') }, true)
+
+    await expect(Schedule.runNow('GuardedReleases')).rejects.toThrow('every time')
+    await expect(Schedule.runNow('GuardedReleases')).rejects.toThrow('every time')
+
+    expect(runs).toBe(2)
+  })
+})
+
+describe('runNow() on a guarded task', () => {
+  it('waits for the task instead of resolving past it', async () => {
+    // The reported symptom was `RESOLVED in 0ms` while the task was still
+    // running. Ordering is asserted rather than duration, which would be a
+    // timing test.
+    useLockDir()
+    const order: string[] = []
+    await register('GuardedSlow', async () => {
+      await new Promise(resolve => setTimeout(resolve, 25))
+      order.push('task finished')
+    }, true)
+
+    await Schedule.runNow('GuardedSlow')
+    order.push('runNow returned')
+
+    expect(order).toEqual(['task finished', 'runNow returned'])
+  })
+
+  it('resolves for a task that succeeds', async () => {
+    // Returning the promise must not turn every guarded run into a rejection.
+    useLockDir()
+    let ran = 0
+    await register('GuardedOk', () => { ran++ }, true)
+
+    await expect(Schedule.runNow('GuardedOk')).resolves.toBeUndefined()
+    expect(ran).toBe(1)
+  })
+})
+
+describe('when the lock layer itself fails', () => {
+  it('routes the failure to the error handler instead of detaching it', async () => {
+    // `/dev/null` is a file, so creating a directory under it is ENOTDIR - the
+    // shape a full disk or a read-only mount takes on a deployed box. This used
+    // to escape as an unhandled rejection from a promise nothing held.
+    useLockDir('/dev/null/stacks-locks')
+    const seen: Error[] = []
+    let ran = 0
+
+    const guarded = new Schedule(() => { ran++ })
+    guarded.withoutOverlapping().withName('LockUnwritable')
+      .withErrorHandler(error => seen.push(error)).yearly()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    await expect(Schedule.runNow('LockUnwritable')).rejects.toThrow(/ENOTDIR|ENOENT|EACCES/)
+
+    expect(seen).toHaveLength(1)
+    // Not being able to tell whether the task is already running is a failure
+    // to run, so the task must not have run.
+    expect(ran).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes #2403.

## The line

`wrapTask()` launched the overlap/one-server branch as a detached `void (async () => {…})()`. The promise was thrown away, so every caller expecting to await the task got `undefined` - and three unrelated behaviours broke together, but only for tasks chaining `.withoutOverlapping()` or `.onOneServer()`.

## Reproduced before fixing, each with its unguarded control

```
                     handlerCalls              runNow(guarded)
before   guarded 0,  plain 3                   RESOLVED in 1ms
after    guarded 3,  plain 3                   REJECTED
```

The control is what made this hard to see: the handler fired for the plain task the whole time, so the guarded task's silence looked like the task simply working.

With the lock directory unwritable (`/dev/null/stacks-locks`, i.e. `ENOTDIR` - the shape a full disk or read-only mount takes on a deployed box):

```
before   unhandledRejections 3,  handlerCalls 0,  runNow RESOLVED
after    unhandledRejections 0,  handlerCalls 3,  runNow REJECTED
```

Those rejections come from a promise nothing holds, which terminates the process under Bun's default policy.

## The fix, and two decisions inside it

Return the IIFE, and let the task error propagate to the runner - which already knows what to do with it: route to `options.catch`, log if none is installed, rethrow so `runNow` rejects. That deletes the branch's private `[scheduler] task X threw:` path, which was the thing diverting errors away from the handler.

**`acquireLock` is deliberately left unguarded.** Not being able to tell whether the task is already running is a failure to run, so it belongs in front of the operator rather than in a log line. It now reaches `withErrorHandler` / `runNow` like any other failure instead of escaping as an unhandled rejection.

**Only the release is swallowed.** A throw from `finally` *replaces* the task's own error, so an unguarded release would hide the failure the operator needs behind a lock-file complaint - and by then it is too late to act on the release anyway.

## Two documentation defects in the same file

Both pointed at things that do not exist, which is the trap I was in when I filed this:

- The advisory on an uncaught failure read `(no .catch handler installed)`. There is no `.catch()` on `Schedule`; the setter is `withErrorHandler()`.
- `SchedulableJobs` was documented as augmented from `storage/framework/types/scheduled.d.ts`.

**A correction to the issue on that second one.** I claimed the job-name type guard was inert because that file does not exist. It does not - but it was *replaced* by the jobs registry, and `registries.d.ts:129-131` augments `SchedulableJobs` from it. The guard is live, verified:

```
app/Jobs/GuardCheck.ts(6,14): error TS2345: Argument of type '"Inpsire"'
is not assignable to parameter of type 'keyof SchedulableJobs'.
```

`registries.d.ts` is also git-tracked, so a scaffolded app gets it. So the issue's second smaller point is wrong, and what was actually broken is the comment: `name-registries.test.ts` asserts `scheduled.d.ts` stays absent, so anyone checking whether the guard was live found nothing where the comment said to look. Repointed at the registry, with a note on why the old path is gone.

## Tests

6 new tests, each pairing the guarded case with its unguarded control, driven through `runNow` with `.yearly()` so no timer fires and nothing depends on wall-clock timing. They cover the handler firing, `runNow` rejecting, `runNow` *waiting* (asserted by ordering, not duration), the lock being released after a throw so the next run is not skipped as an overlap, and the lock-layer failure reaching the handler with the task not having run.

**5 of the 6 fail on the unfixed source.** The sixth is the control - a guarded task that succeeds still resolves - and passes on both, so the fix cannot have turned every guarded run into a rejection.

## Not fixed here

The issue's last note: `defaults/app/Scheduler.ts` schedules `Inspire`, and `defaults/app/Jobs/` ships no such job (it ships `app/Commands/Inspire.ts`, a command). Confirmed still true. It is a scaffold-content bug rather than a scheduler one, and it wants deciding - add the job, or change the example to one that exists - so I left it out of a fix about promise handling.

## Verification

- `bun test ./storage/framework/core/scheduler/tests` - 154 pass, 0 fail
- `queue` 322 pass, `cli` 48 pass, 0 fail
- `./buddy typecheck` and `bun run typecheck` clean (only the 4 pre-existing errors in gitignored `storage/framework/cache/models/*`)
- `./buddy lint` shows only the pre-existing untracked `storage/framework/libs/entries/web-components.ts` error