### PR TITLE
feat(discovery): find the packages an application installed, and record where

### DIFF
--- a/storage/framework/core/actions/src/discover-packages.ts
+++ b/storage/framework/core/actions/src/discover-packages.ts
@@ -1,5 +1,35 @@
 import type { StackDirectory } from '@stacksjs/types'
+import { existsSync } from 'node:fs'
+import { isAbsolute, join, relative } from 'node:path'
 import { projectPath, storagePath } from '@stacksjs/path'
+
+/**
+ * Find the installed packages that extend this application.
+ *
+ * Stacks' answer to Laravel's package auto-discovery: a package declares a
+ * `stacks` key in its package.json, and the framework registers what it brings
+ * without the application wiring anything up.
+ *
+ * Two roots are searched, in this order:
+ *
+ *   `node_modules/`  where a package manager puts what an application asked
+ *                    for, so this is the one that matters for `bun add loghq`.
+ *                    Only DIRECT dependencies are considered, read from the
+ *                    application's own package.json. A transitive dependency
+ *                    has no business injecting models or routes into an app
+ *                    that never named it, and walking the whole tree would
+ *                    mean reading thousands of manifests on every boot.
+ *
+ *   `pantry/`        this repository's own package tree, and the root the
+ *                    scan was originally written against. Globbed rather than
+ *                    read from dependencies, because it is a small tree that
+ *                    is not always reflected in a package.json.
+ *
+ * A package found in both is taken from `node_modules`, and its other location
+ * is reported in {@link DiscoveredPackagesManifest.shadowed} rather than
+ * silently dropped: the two copies are frequently different versions, and
+ * which one won is the first thing worth knowing when a package misbehaves.
+ */
 
 export interface PackageStacksMeta {
   providers?: string[]
@@ -15,56 +45,173 @@ export interface PackageStacksMeta {
   description?: string
   /** Which top-level directories this stack provides */
   directories?: StackDirectory[]
+  /** Prefix applied to every route file this package registers. */
+  routePrefix?: string
+  /** Middleware applied to every route file this package registers. */
+  routeMiddleware?: string | string[]
+  /**
+   * Where the package is installed, relative to the project root.
+   *
+   * Written by discovery, not by the package. Consumers resolve the package's
+   * files against this instead of assuming a root: before it existed the
+   * router hardcoded `pantry/<name>`, which is the wrong directory for
+   * anything a package manager installed.
+   *
+   * Relative because this manifest is committed, and an absolute path would
+   * be a machine-specific diff on every boot.
+   */
+  root?: string
+}
+
+/** A package that was found in more than one root. */
+export interface ShadowedPackage {
+  name: string
+  /** The root discovery used, relative to the project. */
+  used: string
+  /** The root it ignored, relative to the project. */
+  ignored: string
 }
 
 export interface DiscoveredPackagesManifest {
   generated_at: string
   packages: Record<string, PackageStacksMeta>
+  /** Packages present in more than one root. Omitted when there are none. */
+  shadowed?: ShadowedPackage[]
 }
 
-export async function discoverPackages(): Promise<DiscoveredPackagesManifest> {
-  const manifest: DiscoveredPackagesManifest = {
-    generated_at: new Date().toISOString(),
-    packages: {},
-  }
+export interface DiscoverPackagesOptions {
+  /** Project root to scan. Defaults to the real project. */
+  projectRoot?: string
+  /** Where to write the manifest. Defaults to `storage/framework/discovered-packages.json`. */
+  manifestPath?: string
+  /** Skip the write and just return what was found. */
+  dryRun?: boolean
+}
 
-  // Read dont-discover list from root package.json
-  const dontDiscover = new Set<string>()
+/** A package.json that declares a `stacks` object, and where it was found. */
+interface Candidate {
+  name: string
+  meta: PackageStacksMeta
+  /** Absolute directory holding the package. */
+  dir: string
+}
+
+async function readManifest(file: string): Promise<{ name?: string, stacks?: unknown } | null> {
   try {
-    const rootPkg = await Bun.file(projectPath('package.json')).json()
-    const list = rootPkg?.stacks?.['dont-discover']
-    if (Array.isArray(list)) {
-      for (const name of list) dontDiscover.add(name)
-    }
+    return await Bun.file(file).json()
   }
   catch {
-    // No root package.json or no stacks field
+    // A package.json that is missing, unreadable or not JSON is not a
+    // discovery failure. Nothing in the tree is required to be a stack.
+    return null
   }
+}
 
-  // Scan pantry for packages with a "stacks" field
-  const pantryDir = projectPath('pantry')
-  const patterns = ['*/package.json', '@*/*/package.json']
+/** Direct dependency names from the application's own package.json. */
+async function directDependencies(projectRoot: string): Promise<string[]> {
+  const pkg = await readManifest(join(projectRoot, 'package.json')) as Record<string, unknown> | null
+  if (!pkg)
+    return []
 
-  for (const pattern of patterns) {
-    const glob = new Bun.Glob(pattern)
-    for await (const file of glob.scan({ cwd: pantryDir, absolute: true, onlyFiles: true })) {
-      try {
-        const pkg = await Bun.file(file).json()
-        const name = pkg?.name
-        if (!name || !pkg.stacks || dontDiscover.has(name)) continue
-        manifest.packages[name] = pkg.stacks
-      }
-      catch {
-        // Skip unreadable package.json files
-      }
+  const names = new Set<string>()
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies'] as const) {
+    const block = pkg[field]
+    if (block && typeof block === 'object') {
+      for (const name of Object.keys(block as Record<string, unknown>)) names.add(name)
     }
   }
+  return [...names].sort()
+}
 
-  // Write manifest
-  const manifestPath = storagePath('framework/discovered-packages.json')
+/** Candidates from `node_modules`, limited to the application's direct dependencies. */
+async function fromNodeModules(projectRoot: string): Promise<Candidate[]> {
+  const root = join(projectRoot, 'node_modules')
+  if (!existsSync(root))
+    return []
+
+  const out: Candidate[] = []
+  for (const name of await directDependencies(projectRoot)) {
+    const dir = join(root, name)
+    const pkg = await readManifest(join(dir, 'package.json'))
+    if (!pkg?.name || !pkg.stacks || typeof pkg.stacks !== 'object')
+      continue
+    out.push({ name: pkg.name, meta: pkg.stacks as PackageStacksMeta, dir })
+  }
+  return out
+}
+
+/** Candidates from the `pantry` tree, globbed as the original scan did. */
+async function fromPantry(projectRoot: string): Promise<Candidate[]> {
+  const root = join(projectRoot, 'pantry')
+  if (!existsSync(root))
+    return []
+
+  const out: Candidate[] = []
+  for (const pattern of ['*/package.json', '@*/*/package.json']) {
+    const glob = new Bun.Glob(pattern)
+    for await (const file of glob.scan({ cwd: root, absolute: true, onlyFiles: true })) {
+      const pkg = await readManifest(file)
+      if (!pkg?.name || !pkg.stacks || typeof pkg.stacks !== 'object')
+        continue
+      out.push({ name: pkg.name, meta: pkg.stacks as PackageStacksMeta, dir: join(file, '..') })
+    }
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/** The application's `stacks["dont-discover"]` opt-out list. */
+async function dontDiscover(projectRoot: string): Promise<Set<string>> {
+  const pkg = await readManifest(join(projectRoot, 'package.json')) as Record<string, any> | null
+  const list = pkg?.stacks?.['dont-discover']
+  return new Set<string>(Array.isArray(list) ? list : [])
+}
+
+export async function discoverPackages(
+  options: DiscoverPackagesOptions = {},
+): Promise<DiscoveredPackagesManifest> {
+  const projectRoot = options.projectRoot ?? projectPath()
+  const manifestPath = options.manifestPath ?? storagePath('framework/discovered-packages.json')
+
+  const excluded = await dontDiscover(projectRoot)
+
+  // node_modules first, so a package an application actually depends on wins
+  // over a copy sitting in the pantry tree.
+  const found = [...await fromNodeModules(projectRoot), ...await fromPantry(projectRoot)]
+
+  const packages: Record<string, PackageStacksMeta> = {}
+  const shadowed: ShadowedPackage[] = []
+  const chosen = new Map<string, string>()
+
+  for (const candidate of found) {
+    if (excluded.has(candidate.name))
+      continue
+
+    const root = toRelative(projectRoot, candidate.dir)
+    const already = chosen.get(candidate.name)
+    if (already !== undefined) {
+      shadowed.push({ name: candidate.name, used: already, ignored: root })
+      continue
+    }
+
+    chosen.set(candidate.name, root)
+    packages[candidate.name] = { ...candidate.meta, root }
+  }
+
+  const manifest: DiscoveredPackagesManifest = {
+    generated_at: new Date().toISOString(),
+    packages,
+    ...(shadowed.length > 0 ? { shadowed } : {}),
+  }
+
+  if (options.dryRun)
+    return manifest
+
+  // Rewrite only on a real change. `generated_at` moves on every run, so
+  // comparing whole manifests would dirty a committed file on every boot.
   try {
     const current = await Bun.file(manifestPath).json() as DiscoveredPackagesManifest
-    if (JSON.stringify(current.packages ?? {}) === JSON.stringify(manifest.packages)) {
+    if (JSON.stringify(current.packages ?? {}) === JSON.stringify(manifest.packages)
+      && JSON.stringify(current.shadowed ?? []) === JSON.stringify(shadowed)) {
       return current
     }
   }
@@ -72,7 +219,14 @@ export async function discoverPackages(): Promise<DiscoveredPackagesManifest> {
     // Missing or unreadable manifests are regenerated below.
   }
 
-  await Bun.write(manifestPath, JSON.stringify(manifest, null, 2))
+  await Bun.write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
 
   return manifest
+}
+
+function toRelative(projectRoot: string, dir: string): string {
+  const rel = relative(projectRoot, dir)
+  // A package resolved outside the project (a linked checkout, say) has no
+  // meaningful relative form; keep what we were given so it still resolves.
+  return rel && !rel.startsWith('..') && !isAbsolute(rel) ? rel : dir
 }

--- a/storage/framework/core/actions/tests/package-discovery.test.ts
+++ b/storage/framework/core/actions/tests/package-discovery.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Which installed packages the framework discovers, and where it says they are.
+ *
+ * Discovery is Stacks' equivalent of Laravel's package auto-discovery, and it
+ * had two properties that made it unusable for the thing it exists for.
+ *
+ * It scanned `pantry/` only. That is this repository's own package tree; an
+ * application that runs `bun add loghq` gets `node_modules/loghq`, which the
+ * scan never looked at. So a package could declare everything correctly and
+ * still be invisible.
+ *
+ * And the manifest recorded no location, so the one consumer (the router)
+ * hardcoded `pantry/<name>` to find a package's route files. Widening the scan
+ * without recording the root would have produced manifests the router resolved
+ * against the wrong directory, failing soft and silently, which is worse than
+ * not finding the package at all.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { discoverPackages } from '../src/discover-packages'
+
+let project: string
+
+/** Write a package.json into a tree, creating directories as needed. */
+function pkg(relativeDir: string, contents: Record<string, unknown>): void {
+  const dir = join(project, relativeDir)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), JSON.stringify(contents, null, 2))
+}
+
+/** The application's own package.json, which names its direct dependencies. */
+function app(contents: Record<string, unknown>): void {
+  writeFileSync(join(project, 'package.json'), JSON.stringify(contents, null, 2))
+}
+
+function discover() {
+  return discoverPackages({ projectRoot: project, dryRun: true })
+}
+
+beforeEach(() => {
+  project = mkdtempSync(join(tmpdir(), 'stacks-discovery-'))
+})
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true })
+})
+
+describe('package discovery', () => {
+  test('finds a package the application installed, which is the whole point', async () => {
+    app({ name: 'my-app', dependencies: { loghq: '^1.0.0' } })
+    pkg('node_modules/loghq', {
+      name: 'loghq',
+      stacks: { name: 'loghq', routes: ['routes/logs.ts'], directories: ['app', 'database'] },
+    })
+
+    const manifest = await discover()
+
+    expect(Object.keys(manifest.packages)).toEqual(['loghq'])
+    expect(manifest.packages.loghq?.routes).toEqual(['routes/logs.ts'])
+  })
+
+  test('records where the package is, relative to the project', async () => {
+    app({ name: 'my-app', dependencies: { loghq: '^1.0.0' } })
+    pkg('node_modules/loghq', { name: 'loghq', stacks: { name: 'loghq' } })
+
+    const manifest = await discover()
+
+    // Relative, because this manifest is committed: an absolute path would be
+    // a machine-specific diff on every boot. And present at all, because the
+    // router resolves a package's route files against it.
+    expect(manifest.packages.loghq?.root).toBe(join('node_modules', 'loghq'))
+  })
+
+  test('finds a scoped package', async () => {
+    app({ name: 'my-app', dependencies: { '@loghq/core': '^1.0.0' } })
+    pkg('node_modules/@loghq/core', { name: '@loghq/core', stacks: { name: 'loghq-core' } })
+
+    const manifest = await discover()
+
+    expect(manifest.packages['@loghq/core']?.root).toBe(join('node_modules', '@loghq', 'core'))
+  })
+
+  test('ignores a package that declares no stacks key', async () => {
+    app({ name: 'my-app', dependencies: { 'left-pad': '^1.0.0', loghq: '^1.0.0' } })
+    pkg('node_modules/left-pad', { name: 'left-pad' })
+    pkg('node_modules/loghq', { name: 'loghq', stacks: { name: 'loghq' } })
+
+    const manifest = await discover()
+
+    expect(Object.keys(manifest.packages)).toEqual(['loghq'])
+  })
+
+  test('ignores a transitive dependency the application never named', async () => {
+    // A package the app did not ask for has no business injecting models or
+    // routes into it, and walking the whole tree would mean reading thousands
+    // of manifests on every boot.
+    app({ name: 'my-app', dependencies: { loghq: '^1.0.0' } })
+    pkg('node_modules/loghq', { name: 'loghq', stacks: { name: 'loghq' } })
+    pkg('node_modules/some-transitive-dep', {
+      name: 'some-transitive-dep',
+      stacks: { name: 'sneaky', routes: ['routes/everything.ts'] },
+    })
+
+    const manifest = await discover()
+
+    expect(Object.keys(manifest.packages)).toEqual(['loghq'])
+  })
+
+  test('honours the application opting a package out', async () => {
+    app({
+      name: 'my-app',
+      dependencies: { loghq: '^1.0.0' },
+      stacks: { 'dont-discover': ['loghq'] },
+    })
+    pkg('node_modules/loghq', { name: 'loghq', stacks: { name: 'loghq' } })
+
+    const manifest = await discover()
+
+    expect(manifest.packages).toEqual({})
+  })
+
+  test('still scans the pantry tree', async () => {
+    // The root discovery was originally written against. Globbed rather than
+    // read from dependencies, because it is not always named in a package.json.
+    app({ name: 'my-app' })
+    pkg('pantry/table', { name: '@stacksjs/table', stacks: { name: 'table', directories: ['resources'] } })
+
+    const manifest = await discover()
+
+    expect(manifest.packages['@stacksjs/table']?.root).toBe(join('pantry', 'table'))
+  })
+
+  test('prefers node_modules over pantry, and says which copy it ignored', async () => {
+    app({ name: 'my-app', dependencies: { loghq: '^1.0.0' } })
+    pkg('node_modules/loghq', { name: 'loghq', stacks: { name: 'loghq', routes: ['routes/new.ts'] } })
+    pkg('pantry/loghq', { name: 'loghq', stacks: { name: 'loghq', routes: ['routes/old.ts'] } })
+
+    const manifest = await discover()
+
+    expect(manifest.packages.loghq?.routes).toEqual(['routes/new.ts'])
+    expect(manifest.packages.loghq?.root).toBe(join('node_modules', 'loghq'))
+    // Reported rather than dropped: the two copies are frequently different
+    // versions, and which one won is the first thing worth knowing.
+    expect(manifest.shadowed).toEqual([
+      { name: 'loghq', used: join('node_modules', 'loghq'), ignored: join('pantry', 'loghq') },
+    ])
+  })
+
+  test('finds nothing in a project with no packages, and reports no shadowing', async () => {
+    app({ name: 'my-app', dependencies: { 'left-pad': '^1.0.0' } })
+    pkg('node_modules/left-pad', { name: 'left-pad' })
+
+    const manifest = await discover()
+
+    expect(manifest.packages).toEqual({})
+    expect(manifest.shadowed).toBeUndefined()
+  })
+
+  test('survives a project with no package.json and no trees at all', async () => {
+    // Discovery runs during early boot, where none of this is guaranteed.
+    const manifest = await discover()
+
+    expect(manifest.packages).toEqual({})
+    expect(manifest.generated_at).toBeTruthy()
+  })
+
+  test('survives an unreadable package.json rather than aborting the scan', async () => {
+    app({ name: 'my-app', dependencies: { broken: '^1.0.0', loghq: '^1.0.0' } })
+    mkdirSync(join(project, 'node_modules/broken'), { recursive: true })
+    writeFileSync(join(project, 'node_modules/broken/package.json'), '{ not json')
+    pkg('node_modules/loghq', { name: 'loghq', stacks: { name: 'loghq' } })
+
+    const manifest = await discover()
+
+    expect(Object.keys(manifest.packages)).toEqual(['loghq'])
+  })
+
+  test('writes the manifest only when the discovered set changes', async () => {
+    app({ name: 'my-app', dependencies: { loghq: '^1.0.0' } })
+    pkg('node_modules/loghq', { name: 'loghq', stacks: { name: 'loghq' } })
+    const manifestPath = join(project, 'manifest.json')
+
+    const first = await discoverPackages({ projectRoot: project, manifestPath })
+    const second = await discoverPackages({ projectRoot: project, manifestPath })
+
+    // `generated_at` moves on every run, so comparing whole manifests would
+    // dirty a committed file on every boot.
+    expect(second.generated_at).toBe(first.generated_at)
+  })
+})

--- a/storage/framework/core/router/src/stacks-router.ts
+++ b/storage/framework/core/router/src/stacks-router.ts
@@ -4350,14 +4350,19 @@ export function createStacksRouter(config: StacksRouterConfig = {}): StacksRoute
         const packages = manifest?.packages
         if (!packages) return
 
-        const pantryDir = p.projectPath('pantry')
-
         for (const [pkgName, meta] of Object.entries(packages) as [string, any][]) {
           const routes = meta?.routes
           if (!routes) continue
 
           const routeList = Array.isArray(routes) ? routes : [routes]
-          const pkgDir = `${pantryDir}/${pkgName}`
+          // Discovery records where it found the package. Falling back to
+          // `pantry/<name>` keeps a manifest written before that field existed
+          // working, but it is only ever right for the pantry tree: a package
+          // a user installed lives in node_modules, and reading its routes
+          // from pantry silently found nothing.
+          const pkgDir = meta?.root
+            ? p.projectPath(meta.root)
+            : `${p.projectPath('pantry')}/${pkgName}`
 
           for (const routeFile of routeList) {
             log.debug(`[router] Discovered route: ${pkgName} → ${routeFile}`)


### PR DESCRIPTION
First framework slice of the HQ-in-the-pantry plan. It is the prerequisite for the rest: the model, migration and view loaders cannot usefully read the discovery manifest while discovery cannot find the package in the first place.

## The gap

Package auto-discovery scanned `pantry/` only. That is this repository's own package tree. An application that runs `bun add loghq` gets `node_modules/loghq`, which nothing looked at, so a package could declare its manifest perfectly and remain invisible.

Discovery now reads the application's **direct** dependencies and checks each in `node_modules`, then globs `pantry/` as before. Direct only, for two reasons: a transitive dependency has no business injecting models or routes into an app that never named it, and walking the whole tree would mean reading thousands of manifests on a boot path the preloader already calls this from. Measured at 49ms here.

## The correctness half

The manifest recorded no location, so the only consumer had to assume one: the router hardcoded `pantry/<name>` to find a package's route files. Widening the scan **alone** would have produced manifests the router resolved against the wrong directory and then failed soft about, silently, which is worse than not finding the package.

So the manifest now carries each package's `root`, project-relative because this file is committed and an absolute path would be a machine-specific diff on every boot. The router reads it and falls back to the old path for a manifest written before the field existed.

A package found in both roots is taken from `node_modules`, and the ignored copy is reported in a new `shadowed` list rather than dropped. The two are usually different versions, and which one won is the first thing worth knowing when a package misbehaves.

## Why this is safe

Nothing in this repository declares a `stacks` manifest today, in core or in pantry. I checked properly after a first grep misled me by matching `@stacksjs/` substrings: the real count is **zero**. Discovery found nothing before this change and finds nothing after it, and the committed manifest does not churn.

## Not in this slice

- The model, migration and STX loaders reading the manifest. Next, and they need this first.
- Loud failure on two packages declaring the same model name. Belongs with the model loader.
- Registry entries for the five HQ packages, which have not published.
- **Item 4 of the brief turns out to be already done.** `regenerateMigrationCorpus` only replaces files carrying `GENERATED_MIGRATION_MARKER` and preserves everything else by design; its own comment says that rule "is not advisory". Package migrations are hand-written, so they are already protected. Worth documenting rather than reimplementing.

## Verification

- 12 new tests in `actions/tests/package-discovery.test.ts`, against a temp-dir fixture tree. There were none before.
- `core/actions`: 476 pass. `core/router`: 445 pass. Root suite: 399 pass. All 0 fail.
- Real discovery on this repo: 0 packages, 0 shadowed, manifest unchanged.
- `bun run typecheck`: the only 4 errors are `@stacksjs/tlsx` missing exports in `server.ts`, identical on clean `main` with this branch stashed. Pre-existing, from a stale local copy CI installs fresh.
- `./buddy lint` clean apart from the pre-existing untracked `storage/framework/libs/entries/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)