### PR TITLE
feat(database): let an installed package bring its models

### DIFF
--- a/storage/framework/core/database/src/index.ts
+++ b/storage/framework/core/database/src/index.ts
@@ -152,6 +152,7 @@ export * from './migration-ledger'
 // Model resolution for the generator: userland + framework defaults, flattened
 // because bun-query-builder's loadModels reads only the top level of a dir.
 export * from './model-sources'
+export * from './package-models'
 export * from './shadowed-models'
 
 // Database bootstrap: probe the target, and create it over a maintenance

--- a/storage/framework/core/database/src/model-sources.ts
+++ b/storage/framework/core/database/src/model-sources.ts
@@ -40,6 +40,8 @@ import process from 'node:process'
 import { config } from '@stacksjs/config'
 import { path } from '@stacksjs/path'
 import { plural, snakeCase } from '@stacksjs/strings'
+import { packageModelRoots } from './package-models'
+import type { PackageModelRoot } from './package-models'
 
 export interface ModelSource {
   /** Absolute path to the model file. */
@@ -47,7 +49,9 @@ export interface ModelSource {
   /** Basename without extension, used for collision resolution. */
   name: string
   /** Which root it came from. */
-  origin: 'user' | 'framework'
+  origin: 'user' | 'framework' | 'package'
+  /** For `origin: 'package'`, the package that shipped it. */
+  package?: string
 }
 
 /** A userland model that replaced a framework default of the same name. */
@@ -93,7 +97,7 @@ export interface ResolvedModelSources {
 }
 
 /** Collect model files recursively, skipping index barrels and dotfiles. */
-function collectModels(root: string, origin: ModelSource['origin']): ModelSource[] {
+function collectModels(root: string, origin: ModelSource['origin'], owner?: string): ModelSource[] {
   if (!existsSync(root))
     return []
 
@@ -122,12 +126,55 @@ function collectModels(root: string, origin: ModelSource['origin']): ModelSource
       if (entry.name.startsWith('.') || entry.name.startsWith('index'))
         continue
 
-      out.push({ file: full, name: entry.name.replace(/\.ts$/, ''), origin })
+      out.push({ file: full, name: entry.name.replace(/\.ts$/, ''), origin, package: owner })
     }
   }
 
   walk(root)
   return out
+}
+
+/**
+ * Refuse a package model set that cannot be merged safely.
+ *
+ * Models become server GLOBALS, so two of the same name are not a merge
+ * conflict that can be resolved by precedence: whichever loses is simply gone,
+ * and the table it owned is described by nothing. Both cases below are a
+ * packaging mistake with no correct silent outcome, so they stop the run and
+ * name the files rather than letting a schema quietly lose a table.
+ *
+ * Userland is deliberately not checked. An application overriding a model it
+ * installed is a supported customisation, and it already reports through
+ * {@link ResolvedModelSources.shadowed}.
+ */
+function assertPackageModelsAreUsable(packaged: ModelSource[], framework: ModelSource[]): void {
+  const seen = new Map<string, ModelSource>()
+  for (const model of packaged) {
+    const clash = seen.get(model.name)
+    if (clash) {
+      throw new Error(
+        `Two installed packages both ship a '${model.name}' model, and a model name is a global.\n`
+        + `  ${clash.package}: ${clash.file}\n`
+        + `  ${model.package}: ${model.file}\n`
+        + `Only one can win, so neither package can be trusted to own its table. `
+        + `Rename one, or have both depend on a shared package that owns the model.`,
+      )
+    }
+    seen.set(model.name, model)
+  }
+
+  const frameworkNames = new Set(framework.map(model => model.name))
+  for (const model of packaged) {
+    if (!frameworkNames.has(model.name))
+      continue
+
+    throw new Error(
+      `The package '${model.package}' ships a '${model.name}' model, which the framework already owns.\n`
+      + `  ${model.file}\n`
+      + `The framework's own code reads that table, so a package cannot redefine it. `
+      + `A package uses the host application's model instead: this is why a package never ships its own User.`,
+    )
+  }
 }
 
 /**
@@ -252,14 +299,25 @@ export function resolveModelSources(options: {
    * (stacksjs/stacks#2255).
    */
   forceStage?: boolean
+  /**
+   * Model directories contributed by discovered packages.
+   *
+   * Defaults to whatever the discovery manifest names. Passed explicitly by
+   * tests, and by any caller that has already resolved them.
+   */
+  packageRoots?: PackageModelRoot[]
 } = {}): ResolvedModelSources | null {
   const userRoot = options.userRoot ?? path.userModelsPath()
   const frameworkRoot = options.frameworkRoot ?? path.frameworkPath('defaults/app/Models')
 
   const user = collectModels(userRoot, 'user')
   const framework = collectModels(frameworkRoot, 'framework')
+  const packaged = (options.packageRoots ?? packageModelRoots())
+    .flatMap(root => collectModels(root.dir, 'package', root.package))
 
-  if (user.length === 0 && framework.length === 0)
+  assertPackageModelsAreUsable(packaged, framework)
+
+  if (user.length === 0 && framework.length === 0 && packaged.length === 0)
     return null
 
   const merge = options.includeFrameworkDefaults ?? shouldIncludeFrameworkDefaults()
@@ -287,10 +345,13 @@ export function resolveModelSources(options: {
       shadowed.push({ name: model.name, userFile: model.file, frameworkFile: replaced.file })
   }
 
-  // Userland still overrides a framework model of the same name, which is what
-  // the merge path is for.
+  // Precedence, lowest to highest: framework defaults, then packages, then
+  // userland. A package's models are MERGED rather than treated as a fallback,
+  // because an application that installed the package asked for its schema.
+  // Userland still wins over both, which is how an app customises either.
   const byName = new Map<string, ModelSource>()
   for (const model of contributing) byName.set(model.name, model)
+  for (const model of packaged) byName.set(model.name, model)
   for (const model of user) byName.set(model.name, model)
 
   const models = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
@@ -298,6 +359,8 @@ export function resolveModelSources(options: {
   const roots: string[] = []
   if (user.length > 0)
     roots.push(userRoot)
+  for (const root of new Set(packaged.map(model => model.file.replace(/\/[^/]+$/, ''))))
+    roots.push(root)
   if (contributing.length > 0)
     roots.push(frameworkRoot)
 

--- a/storage/framework/core/database/src/package-models.ts
+++ b/storage/framework/core/database/src/package-models.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { isAbsolute, join } from 'node:path'
+import { path } from '@stacksjs/path'
+
+/**
+ * The model directories that discovered packages contribute.
+ *
+ * A package that declares a `stacks` key in its package.json can ship models
+ * the way it already ships routes, so `bun add loghq` brings LogHQ's schema
+ * with it rather than asking the application to copy files in.
+ *
+ * The manifest is READ, not imported. `discoverPackages()` lives in
+ * `@stacksjs/actions`, which depends on this package, so importing it here
+ * would close a cycle. The router resolves package routes the same way, from
+ * the same file, for the same reason.
+ */
+
+/** One package's model directory. */
+export interface PackageModelRoot {
+  /** The package name, used to name the package in a collision error. */
+  package: string
+  /** Absolute path to the package's `app/Models`. */
+  dir: string
+}
+
+interface DiscoveredEntry {
+  root?: string
+  directories?: string[]
+}
+
+/**
+ * Read the discovery manifest.
+ *
+ * Every failure here degrades to "no packages": a missing manifest is the
+ * normal state of an application that has never run discovery, and an
+ * unreadable one is not a reason to refuse to generate migrations from the
+ * models the application does have.
+ */
+function readManifest(manifestPath: string): Record<string, DiscoveredEntry> {
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      packages?: Record<string, DiscoveredEntry>
+    }
+    return parsed?.packages ?? {}
+  }
+  catch {
+    return {}
+  }
+}
+
+/**
+ * Resolve each discovered package's `app/Models`, skipping those that ship none.
+ *
+ * A package's `root` is recorded relative to the project so the committed
+ * manifest carries no machine-specific path. An absolute root is honoured
+ * anyway rather than joined onto the project, since that is what a manifest
+ * written by hand during a test is likely to hold.
+ */
+export function packageModelRoots(options: {
+  manifestPath?: string
+  projectRoot?: string
+} = {}): PackageModelRoot[] {
+  const manifestPath = options.manifestPath ?? path.storagePath('framework/discovered-packages.json')
+  const projectRoot = options.projectRoot ?? path.projectPath()
+
+  const roots: PackageModelRoot[] = []
+
+  for (const [name, meta] of Object.entries(readManifest(manifestPath))) {
+    const root = meta?.root
+    if (!root || typeof root !== 'string')
+      continue
+
+    const base = isAbsolute(root) ? root : join(projectRoot, root)
+    const dir = join(base, 'app', 'Models')
+    if (existsSync(dir))
+      roots.push({ package: name, dir })
+  }
+
+  // Sorted so a collision between two packages is reported the same way on
+  // every machine, rather than depending on manifest key order.
+  return roots.sort((a, b) => a.package.localeCompare(b.package))
+}

--- a/storage/framework/core/database/tests/package-models.test.ts
+++ b/storage/framework/core/database/tests/package-models.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Models that arrive with an installed package.
+ *
+ * A package declaring a `stacks` key can already ship routes, which the router
+ * registers from the package's own directory. Models were the gap: the
+ * generator read `app/Models` and the framework defaults and nothing else, so
+ * `bun add loghq` brought LogHQ's routes and none of the tables they query.
+ *
+ * Two properties matter more than the merge itself.
+ *
+ * An application with no packages must resolve exactly what it resolved
+ * before, including the fallback that makes the framework defaults stand in
+ * only when userland has no models of its own (stacksjs/stacks#2220).
+ *
+ * And a name collision has to stop the run. Models become server globals, so
+ * two of the same name are not a conflict precedence can settle: whichever
+ * loses is gone, and the table it owned is described by nothing.
+ */
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveModelSources } from '../src/model-sources'
+import { packageModelRoots } from '../src/package-models'
+
+/** A throwaway project tree. Every test gets its own. */
+function project(): string {
+  return mkdtempSync(join(tmpdir(), 'stacks-pkg-models-'))
+}
+
+/** Write model files into a directory, returning it. */
+function models(dir: string, names: string[]): string {
+  mkdirSync(dir, { recursive: true })
+  for (const name of names) {
+    writeFileSync(
+      join(dir, `${name}.ts`),
+      `export default defineModel({ name: '${name}' })\n`,
+    )
+  }
+  return dir
+}
+
+function manifest(root: string, packages: Record<string, { root: string }>): string {
+  const file = join(root, 'discovered-packages.json')
+  writeFileSync(file, JSON.stringify({ generated_at: '', packages }, null, 2))
+  return file
+}
+
+describe('package model roots', () => {
+  test('resolves a discovered package that ships models', () => {
+    const root = project()
+    try {
+      models(join(root, 'node_modules/loghq/app/Models'), ['LogEntry'])
+      const file = manifest(root, { loghq: { root: 'node_modules/loghq' } })
+
+      const roots = packageModelRoots({ manifestPath: file, projectRoot: root })
+
+      expect(roots).toHaveLength(1)
+      expect(roots[0]?.package).toBe('loghq')
+      expect(roots[0]?.dir).toBe(join(root, 'node_modules/loghq/app/Models'))
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('skips a discovered package that ships no models', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/table'), { recursive: true })
+      const file = manifest(root, { table: { root: 'node_modules/table' } })
+
+      expect(packageModelRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('a missing manifest is no packages, not a failure', () => {
+    const root = project()
+    try {
+      const roots = packageModelRoots({
+        manifestPath: join(root, 'nothing-here.json'),
+        projectRoot: root,
+      })
+      expect(roots).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('an unreadable manifest degrades rather than aborting a generate', () => {
+    const root = project()
+    try {
+      const file = join(root, 'broken.json')
+      writeFileSync(file, '{ not json')
+
+      expect(packageModelRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})
+
+describe('resolving models with packages installed', () => {
+  test('a package contributes its models alongside the application own', () => {
+    const root = project()
+    try {
+      const userRoot = models(join(root, 'app/Models'), ['Post'])
+      const frameworkRoot = models(join(root, 'defaults/Models'), ['User'])
+      const pkg = models(join(root, 'node_modules/loghq/app/Models'), ['LogEntry'])
+
+      const resolved = resolveModelSources({
+        userRoot,
+        frameworkRoot,
+        packageRoots: [{ package: 'loghq', dir: pkg }],
+      })
+
+      // Userland has models, so the framework defaults stay out (#2220). The
+      // package's models come in regardless, because the app asked for them.
+      expect(resolved?.models.map(m => m.name).sort()).toEqual(['LogEntry', 'Post'])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('userland still overrides a model a package shipped', () => {
+    const root = project()
+    try {
+      const userRoot = models(join(root, 'app/Models'), ['LogEntry'])
+      const frameworkRoot = models(join(root, 'defaults/Models'), ['User'])
+      const pkg = models(join(root, 'node_modules/loghq/app/Models'), ['LogEntry'])
+
+      const resolved = resolveModelSources({
+        userRoot,
+        frameworkRoot,
+        packageRoots: [{ package: 'loghq', dir: pkg }],
+      })
+
+      const entry = resolved?.models.find(m => m.name === 'LogEntry')
+      expect(entry?.origin).toBe('user')
+      expect(entry?.file.startsWith(userRoot)).toBe(true)
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('the framework fallback still turns on for an app with no models of its own', () => {
+    const root = project()
+    try {
+      const userRoot = join(root, 'app/Models')
+      const frameworkRoot = models(join(root, 'defaults/Models'), ['User'])
+      const pkg = models(join(root, 'node_modules/loghq/app/Models'), ['LogEntry'])
+
+      const resolved = resolveModelSources({
+        userRoot,
+        frameworkRoot,
+        packageRoots: [{ package: 'loghq', dir: pkg }],
+      })
+
+      // A package bringing models is not the app having models of its own, so
+      // the defaults still stand in. Removing them here would take User away
+      // from a fresh app the moment it installed anything.
+      expect(resolved?.models.map(m => m.name).sort()).toEqual(['LogEntry', 'User'])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('two packages shipping the same model name stop the run', () => {
+    const root = project()
+    try {
+      const userRoot = models(join(root, 'app/Models'), ['Post'])
+      const frameworkRoot = models(join(root, 'defaults/Models'), ['User'])
+      const loghq = models(join(root, 'node_modules/loghq/app/Models'), ['Project'])
+      const bughq = models(join(root, 'node_modules/bughq/app/Models'), ['Project'])
+
+      expect(() => resolveModelSources({
+        userRoot,
+        frameworkRoot,
+        packageRoots: [
+          { package: 'loghq', dir: loghq },
+          { package: 'bughq', dir: bughq },
+        ],
+      })).toThrow(/both ship a 'Project' model/)
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('a package shipping a framework model stops the run, which is the User rule', () => {
+    const root = project()
+    try {
+      const userRoot = models(join(root, 'app/Models'), ['Post'])
+      const frameworkRoot = models(join(root, 'defaults/Models'), ['User'])
+      const pkg = models(join(root, 'node_modules/loghq/app/Models'), ['User'])
+
+      expect(() => resolveModelSources({
+        userRoot,
+        frameworkRoot,
+        packageRoots: [{ package: 'loghq', dir: pkg }],
+      })).toThrow(/never ships its own User/)
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('no packages resolves exactly what it resolved before', () => {
+    const root = project()
+    try {
+      const userRoot = models(join(root, 'app/Models'), ['Post', 'Comment'])
+      const frameworkRoot = models(join(root, 'defaults/Models'), ['User'])
+
+      const before = resolveModelSources({ userRoot, frameworkRoot, packageRoots: [] })
+
+      expect(before?.models.map(m => m.name).sort()).toEqual(['Comment', 'Post'])
+      expect(before?.models.every(m => m.origin === 'user')).toBe(true)
+      expect(before?.excluded.map(m => m.name)).toEqual(['User'])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})


### PR DESCRIPTION
Second slice of the HQ-in-the-pantry work, following [#2423](https://github.com/stacksjs/stacks/pull/2423) which taught discovery to look in `node_modules` and record each package's `root`.

## The gap

Discovery finds a package that declares a `stacks` key, and the router registers its routes from wherever it was installed. Models were never wired up: the generator read `app/Models` and the framework defaults and nothing else. So `bun add loghq` brought LogHQ's routes and none of the tables those routes query.

## Package models merge, framework defaults still do not

The framework defaults are a **fallback** on purpose. Merging them made every application inherit the framework's demo schema (#2220), so they stand in only when userland has no models of its own.

A package is the opposite case. An application that ran `bun add loghq` asked for LogHQ's schema, so its models merge. Precedence runs framework, then packages, then userland, which leaves an app able to override either.

**The fallback condition is unchanged and still keyed on userland alone.** A package bringing models is not the application having models of its own, so a fresh app that installs one keeps the defaults it had before. Making packages satisfy the fallback would have taken `User` away from an app the moment it added a dependency. There's a test pinning that.

## Two collisions now stop the run

Models become server globals, so two of the same name are not a conflict precedence can settle: whichever loses is simply gone, and the table it owned is described by nothing.

- **Two packages, same model name.** A packaging mistake with no correct silent outcome. The error names both packages, both files, and suggests a shared package that owns the model, which is the open `Project` / `AlertChannel` question between LogHQ and BugHQ.
- **A package shipping a model the framework owns.** This is the `User` rule from the plan, enforced generally rather than by special-casing one name. The framework's own code reads those tables, so a package cannot redefine one.

Userland is deliberately not checked. An app overriding a model it installed is supported customisation, and it already reports through `ResolvedModelSources.shadowed`.

## Reading, not importing

`packageModelRoots()` reads `storage/framework/discovered-packages.json` directly. `discoverPackages()` lives in `@stacksjs/actions`, which depends on this package, so importing it would close a cycle. The router reads the same file for the same reason. Every failure degrades to "no packages": a missing manifest is the normal state of an app that has never run discovery, and an unreadable one is not a reason to refuse to generate from the models the app does have.

## Verification

- 10 new tests, including one pinning that an app with no packages resolves exactly what it did before
- existing `model-sources.test.ts` green, 18 pass, which is the #2220 contract
- `core/database`: 875 pass, 1 fail; that failure is present on clean main too (865 pass, 1 fail there)
- root suite: 402 pass, 0 fail
- framework typecheck: 4 errors, all `@stacksjs/tlsx` in `server.ts`, identical on clean main
- `./buddy lint` clean apart from the pre-existing untracked `storage/framework/libs/entries/`

## Next

Migrations and STX views are the remaining two loaders. Registry entries wait on the packages publishing, and the naming is settled in [#2424](https://github.com/stacksjs/stacks/issues/2424).

🤖 Generated with [Claude Code](https://claude.com/claude-code)