### PR TITLE
fix(database): keep package models out of the migration generator's scope

### DIFF
--- a/storage/framework/core/database/src/model-sources.ts
+++ b/storage/framework/core/database/src/model-sources.ts
@@ -317,7 +317,7 @@ export function resolveModelSources(options: {
 
   assertPackageModelsAreUsable(packaged, framework)
 
-  if (user.length === 0 && framework.length === 0 && packaged.length === 0)
+  if (user.length === 0 && framework.length === 0)
     return null
 
   const merge = options.includeFrameworkDefaults ?? shouldIncludeFrameworkDefaults()
@@ -345,13 +345,18 @@ export function resolveModelSources(options: {
       shadowed.push({ name: model.name, userFile: model.file, frameworkFile: replaced.file })
   }
 
-  // Precedence, lowest to highest: framework defaults, then packages, then
-  // userland. A package's models are MERGED rather than treated as a fallback,
-  // because an application that installed the package asked for its schema.
-  // Userland still wins over both, which is how an app customises either.
+  // Packages are deliberately NOT here. A package owns its tables through the
+  // hand-written SQL it ships, so putting its models in the generator's scope
+  // would emit a second CREATE TABLE for each one. Those duplicates then meet
+  // the earliest-filename-wins pruning in `preprocessSqliteMigrations`, which
+  // deletes the loser - and the loser can be the package's own file, which is
+  // the one thing a package's migrations must never suffer.
+  //
+  // They are reported through `excludedTables` instead, so the generator knows
+  // those tables exist and has no authority to drop them. Being a global is a
+  // separate question, answered by the auto-import barrel rather than here.
   const byName = new Map<string, ModelSource>()
   for (const model of contributing) byName.set(model.name, model)
-  for (const model of packaged) byName.set(model.name, model)
   for (const model of user) byName.set(model.name, model)
 
   const models = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
@@ -359,12 +364,13 @@ export function resolveModelSources(options: {
   const roots: string[] = []
   if (user.length > 0)
     roots.push(userRoot)
-  for (const root of new Set(packaged.map(model => model.file.replace(/\/[^/]+$/, ''))))
-    roots.push(root)
   if (contributing.length > 0)
     roots.push(frameworkRoot)
 
-  const excludedTables = [...new Set(excluded.map(declaredTableName))].sort()
+  // A package's tables are out of the generator's scope for the same reason an
+  // excluded framework default's are: something else owns them, and "not mine
+  // to generate" is not "safe to drop".
+  const excludedTables = [...new Set([...excluded, ...packaged].map(declaredTableName))].sort()
 
   // Fast path: a single root whose models are all top level needs no staging,
   // so the common userland-only project keeps reading its own directory.

--- a/storage/framework/core/database/tests/package-models.test.ts
+++ b/storage/framework/core/database/tests/package-models.test.ts
@@ -98,7 +98,7 @@ describe('package model roots', () => {
 })
 
 describe('resolving models with packages installed', () => {
-  test('a package contributes its models alongside the application own', () => {
+  test('a package model stays OUT of the generator scope, and its table is protected', () => {
     const root = project()
     try {
       const userRoot = models(join(root, 'app/Models'), ['Post'])
@@ -111,14 +111,18 @@ describe('resolving models with packages installed', () => {
         packageRoots: [{ package: 'loghq', dir: pkg }],
       })
 
-      // Userland has models, so the framework defaults stay out (#2220). The
-      // package's models come in regardless, because the app asked for them.
-      expect(resolved?.models.map(m => m.name).sort()).toEqual(['LogEntry', 'Post'])
+      // The package owns log_entries through the SQL it ships, so generating a
+      // second CREATE TABLE for it would produce a duplicate that the pruning
+      // resolves by deleting a file, possibly the package's own.
+      expect(resolved?.models.map(m => m.name).sort()).toEqual(['Post'])
+
+      // But the generator must know the table exists, or it proposes a DROP.
+      expect(resolved?.excludedTables).toContain('log_entries')
     }
     finally { rmSync(root, { recursive: true, force: true }) }
   })
 
-  test('userland still overrides a model a package shipped', () => {
+  test('a userland model of the same name is the one that generates', () => {
     const root = project()
     try {
       const userRoot = models(join(root, 'app/Models'), ['LogEntry'])
@@ -154,7 +158,8 @@ describe('resolving models with packages installed', () => {
       // A package bringing models is not the app having models of its own, so
       // the defaults still stand in. Removing them here would take User away
       // from a fresh app the moment it installed anything.
-      expect(resolved?.models.map(m => m.name).sort()).toEqual(['LogEntry', 'User'])
+      expect(resolved?.models.map(m => m.name).sort()).toEqual(['User'])
+      expect(resolved?.excludedTables).toContain('log_entries')
     }
     finally { rmSync(root, { recursive: true, force: true }) }
   })


### PR DESCRIPTION
Corrects [#2427](https://github.com/stacksjs/stacks/pull/2427), which I merged earlier today. It put package models on the wrong side of the framework.

## What was wrong

`resolveModelSources()` feeds `prepareMigrationModelsDir()`, which is the migration generator's model directory. So merging package models there meant `generate:migrations` would emit a CREATE TABLE for every table a package already ships hand-written SQL for.

That duplicate is not harmless. `preprocessSqliteMigrations` prunes duplicate create-table files by keeping the **earliest filename** and calling `deleteMigration()` on the rest:

```
deleteMigration(file, filePath, `duplicate create-table for "${tableName}" (kept ${earliest})`)
```

Once package migrations are staged into the corpus, the file that loses that comparison can be the package's own. The plan's one standing constraint on this work is that the generator must never delete a package's migration, and the merged version walked into it.

## The correction

Package models report through `excludedTables` rather than joining the generated set. That field already means "something else owns this table", and it already feeds `protectedTables`, which suppresses a generated DROP. It is the same mechanism excluded framework defaults use, for the same reason, so this reuses an existing path rather than adding one.

The collision guards are untouched and still earn their place: two packages shipping the same model name, or a package shipping a model the framework owns, both still stop the run.

## What this deliberately does not do

A package model is still not on `globalThis`. Globals come from the auto-import barrel in `@stacksjs/server`, not from here, and that wiring is its own change with its own hazards:

- **Boot ordering.** `preloader.ts` runs `loadAutoImports()` and then `discoverPackages()`, so the first boot after installing a package builds the barrel from a manifest that does not list it.
- **Staleness is mtime-based.** `autoImportsAreStale()` compares mtimes, and package managers preserve tarball mtimes, so an installed package's models are routinely older than the manifest and will not trip it.
- **`export *` in the barrel is load-bearing.** One duplicate export name makes the module fail to link and nothing reaches `globalThis`.

Those deserve their own slice rather than being rushed in behind a correction.

## Verification

- `package-models.test.ts`: 10 pass, updated to the corrected contract, including that a package's table lands in `excludedTables`
- `core/database`: 875 pass, 1 fail; that failure is on clean main too
- root suite: 402 pass, 0 fail
- framework typecheck: 4 errors, all pre-existing `@stacksjs/tlsx` in `server.ts`
- `./buddy lint` clean apart from the pre-existing untracked `storage/framework/libs/entries/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)