### PR TITLE
feat(config): serve the views an installed package ships

### DIFF
--- a/storage/framework/core/config/src/discovered-resources.ts
+++ b/storage/framework/core/config/src/discovered-resources.ts
@@ -1,0 +1,106 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { isAbsolute, join } from 'node:path'
+import { path } from '@stacksjs/path'
+
+/**
+ * The view directories that discovered packages contribute.
+ *
+ * A package declaring a `stacks` key already has its route files registered by
+ * the router. This is the same idea for templates, so a package can ship the
+ * pages that its routes render rather than asking the application to copy them
+ * in.
+ *
+ * The manifest is READ, not imported. `discoverPackages()` lives in
+ * `@stacksjs/actions`, which depends on this package, so importing it here
+ * would close a cycle. The router and the model resolver both read the same
+ * file for the same reason.
+ */
+
+/** One directory a discovered package contributes. */
+export interface PackageResourceRoot {
+  /** The package that declared it, so a bad path can be attributed. */
+  package: string
+  /** Absolute directory. */
+  dir: string
+}
+
+interface DiscoveredEntry {
+  root?: string
+  views?: string | string[]
+}
+
+export interface PackageResourceOptions {
+  manifestPath?: string
+  projectRoot?: string
+  exists?: (candidate: string) => boolean
+}
+
+/**
+ * Read the discovery manifest.
+ *
+ * Every failure degrades to "no packages". A missing manifest is the normal
+ * state of an application that has never run discovery, and an unreadable one
+ * is not a reason to refuse to serve the application's own views.
+ */
+function readManifest(manifestPath: string): Record<string, DiscoveredEntry> {
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      packages?: Record<string, DiscoveredEntry>
+    }
+    return parsed?.packages ?? {}
+  }
+  catch {
+    return {}
+  }
+}
+
+/**
+ * Resolve each discovered package's declared view directories.
+ *
+ * A package's `root` is recorded relative to the project, so the committed
+ * manifest carries no machine-specific path. An absolute root is honoured as
+ * written, which is what a manifest built inside a test holds.
+ *
+ * A declared directory that is not on disk is skipped rather than fatal: stx
+ * would glob it and find nothing anyway, just more slowly, and a package
+ * shipping an optional subtree is not an error.
+ */
+export function packageViewRoots(options: PackageResourceOptions = {}): PackageResourceRoot[] {
+  const manifestPath = options.manifestPath ?? path.storagePath('framework/discovered-packages.json')
+  const projectRoot = options.projectRoot ?? path.projectPath()
+  const exists = options.exists ?? existsSync
+
+  const roots: PackageResourceRoot[] = []
+
+  for (const [name, meta] of Object.entries(readManifest(manifestPath))) {
+    const declared = meta?.views
+    if (!declared)
+      continue
+
+    const root = meta.root
+    if (!root || typeof root !== 'string')
+      continue
+
+    const base = isAbsolute(root) ? root : join(projectRoot, root)
+
+    for (const entry of Array.isArray(declared) ? declared : [declared]) {
+      if (typeof entry !== 'string' || !entry)
+        continue
+
+      // A leading slash or a `..` segment would escape the package and
+      // register a directory the application never installed. The same guard
+      // `resolveViewPatterns` applies to the framework's own default subtrees.
+      const cleaned = entry.replace(/^[/\\]+/, '')
+      if (!cleaned || cleaned.split(/[/\\]/).includes('..'))
+        continue
+
+      const dir = join(base, cleaned)
+      if (exists(dir))
+        roots.push({ package: name, dir })
+    }
+  }
+
+  // Sorted by package so two packages contributing views resolve in the same
+  // order on every machine, rather than by whatever order the manifest holds.
+  return roots.sort((a, b) => a.package.localeCompare(b.package))
+}

--- a/storage/framework/core/config/src/index.ts
+++ b/storage/framework/core/config/src/index.ts
@@ -12,6 +12,7 @@ export * from './config'
 export { FRAMEWORK_DEFAULTS } from './defaults'
 export { validateConfig, reportConfigIssues, type ConfigValidationIssue } from './validators'
 export { feature, enableFeature, disableFeature, resetFeature, listFeatures } from './features'
+export { packageViewRoots, type PackageResourceOptions, type PackageResourceRoot } from './discovered-resources'
 export { resolveViewPatterns, type DefaultViewsSetting, type ViewPatternResolution } from './views'
 export {
   createRequestContext,

--- a/storage/framework/core/config/src/views.ts
+++ b/storage/framework/core/config/src/views.ts
@@ -1,5 +1,7 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { packageViewRoots } from './discovered-resources'
+import type { PackageResourceRoot } from './discovered-resources'
 
 /**
  * Whether an app serves the framework's default views, and which of them.
@@ -42,23 +44,36 @@ export interface ViewPatternResolution {
  *
  * `exists` is injectable so the resolution is testable without a fixture tree;
  * it defaults to the real filesystem.
+ *
+ * Views a discovered package ships are appended LAST, after everything above.
+ * stx's `getRoute()` returns the first pattern whose relative path matches, so
+ * anything appended after the existing roots cannot change the answer for a
+ * path that already resolves. That is what makes this additive for an app with
+ * no packages, and for every pre-existing route in an app with them.
+ *
+ * `defaultViews` is not consulted for packages. That setting decides whether
+ * the app serves the FRAMEWORK's demo views; an application that installed a
+ * package asked for that package's pages either way.
  */
 export function resolveViewPatterns(
   userViewsPath: string,
   defaultViewsPath: string,
   setting: DefaultViewsSetting | undefined,
   exists: (path: string) => boolean = existsSync,
+  packageViews: PackageResourceRoot[] = packageViewRoots({ exists }),
 ): ViewPatternResolution {
+  const fromPackages = packageViews.map(root => root.dir)
+
   // Absent means unset, which must keep behaving exactly as before. Only an
   // explicit `false` or a list opts out.
   if (setting === undefined || setting === true)
-    return { patterns: [userViewsPath, defaultViewsPath], missing: [] }
+    return { patterns: [userViewsPath, defaultViewsPath, ...fromPackages], missing: [] }
 
   if (setting === false)
-    return { patterns: [userViewsPath], missing: [] }
+    return { patterns: [userViewsPath, ...fromPackages], missing: [] }
 
   if (!Array.isArray(setting))
-    return { patterns: [userViewsPath, defaultViewsPath], missing: [] }
+    return { patterns: [userViewsPath, defaultViewsPath, ...fromPackages], missing: [] }
 
   const patterns = [userViewsPath]
   const missing: string[] = []
@@ -76,6 +91,8 @@ export function resolveViewPatterns(
     else
       missing.push(cleaned)
   }
+
+  patterns.push(...fromPackages)
 
   return { patterns, missing }
 }

--- a/storage/framework/core/config/tests/discovered-views.test.ts
+++ b/storage/framework/core/config/tests/discovered-views.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Views that arrive with an installed package.
+ *
+ * The router already registers a discovered package's route files. Those routes
+ * had nowhere to render from: view lookup was the application's `resources/views`
+ * and the framework defaults, and nothing else, so a package could ship a page
+ * and a route to it and the request would 404.
+ *
+ * The property that makes this safe is positional. stx's `getRoute()` returns
+ * the FIRST pattern whose relative path matches, so appending package roots
+ * after the existing two cannot change the answer for any path that already
+ * resolves. Every assertion below about ordering is really an assertion about
+ * that.
+ */
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { packageViewRoots } from '../src/discovered-resources'
+import { resolveViewPatterns } from '../src/views'
+
+function project(): string {
+  return mkdtempSync(join(tmpdir(), 'stacks-pkg-views-'))
+}
+
+function manifest(root: string, packages: Record<string, unknown>): string {
+  const file = join(root, 'discovered-packages.json')
+  writeFileSync(file, JSON.stringify({ generated_at: '', packages }, null, 2))
+  return file
+}
+
+describe('package view roots', () => {
+  test('resolves a declared views directory that exists', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq/resources/views'), { recursive: true })
+      const file = manifest(root, {
+        loghq: { root: 'node_modules/loghq', views: ['resources/views'] },
+      })
+
+      const roots = packageViewRoots({ manifestPath: file, projectRoot: root })
+
+      expect(roots).toHaveLength(1)
+      expect(roots[0]?.package).toBe('loghq')
+      expect(roots[0]?.dir).toBe(join(root, 'node_modules/loghq/resources/views'))
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('accepts a single string as well as a list', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq/views'), { recursive: true })
+      const file = manifest(root, { loghq: { root: 'node_modules/loghq', views: 'views' } })
+
+      expect(packageViewRoots({ manifestPath: file, projectRoot: root })).toHaveLength(1)
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('skips a declared directory that is not on disk', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq'), { recursive: true })
+      const file = manifest(root, {
+        loghq: { root: 'node_modules/loghq', views: ['resources/views'] },
+      })
+
+      expect(packageViewRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('refuses a path that escapes the package', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'secrets'), { recursive: true })
+      mkdirSync(join(root, 'node_modules/loghq'), { recursive: true })
+      const file = manifest(root, {
+        loghq: { root: 'node_modules/loghq', views: ['../../secrets'] },
+      })
+
+      // A package registering a directory outside itself would serve files the
+      // application never installed.
+      expect(packageViewRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('a package that declares no views contributes nothing', () => {
+    const root = project()
+    try {
+      const file = manifest(root, { loghq: { root: 'node_modules/loghq' } })
+      expect(packageViewRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('a missing or unreadable manifest is no packages, not a failure', () => {
+    const root = project()
+    try {
+      expect(packageViewRoots({ manifestPath: join(root, 'absent.json'), projectRoot: root })).toEqual([])
+
+      const broken = join(root, 'broken.json')
+      writeFileSync(broken, '{ not json')
+      expect(packageViewRoots({ manifestPath: broken, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('orders by package name, so two packages resolve the same everywhere', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq/views'), { recursive: true })
+      mkdirSync(join(root, 'node_modules/bughq/views'), { recursive: true })
+      const file = manifest(root, {
+        loghq: { root: 'node_modules/loghq', views: ['views'] },
+        bughq: { root: 'node_modules/bughq', views: ['views'] },
+      })
+
+      const roots = packageViewRoots({ manifestPath: file, projectRoot: root })
+      expect(roots.map(r => r.package)).toEqual(['bughq', 'loghq'])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})
+
+describe('view patterns with packages installed', () => {
+  const pkg = (dir: string) => [{ package: 'loghq', dir }]
+
+  test('package views come last, so nothing that resolves today changes', () => {
+    const resolution = resolveViewPatterns(
+      'resources/views',
+      '/defaults/views',
+      undefined,
+      () => true,
+      pkg('/node_modules/loghq/resources/views'),
+    )
+
+    expect(resolution.patterns).toEqual([
+      'resources/views',
+      '/defaults/views',
+      '/node_modules/loghq/resources/views',
+    ])
+  })
+
+  test('an app that turned the framework defaults off still gets package views', () => {
+    // `defaultViews: false` is about the framework's demo pages. It says
+    // nothing about a package the application chose to install.
+    const resolution = resolveViewPatterns(
+      'resources/views',
+      '/defaults/views',
+      false,
+      () => true,
+      pkg('/node_modules/loghq/resources/views'),
+    )
+
+    expect(resolution.patterns).toEqual([
+      'resources/views',
+      '/node_modules/loghq/resources/views',
+    ])
+  })
+
+  test('package views append after a selected subtree list', () => {
+    const resolution = resolveViewPatterns(
+      'resources/views',
+      '/defaults/views',
+      ['errors'],
+      () => true,
+      pkg('/node_modules/loghq/resources/views'),
+    )
+
+    expect(resolution.patterns).toEqual([
+      'resources/views',
+      '/defaults/views/errors',
+      '/node_modules/loghq/resources/views',
+    ])
+    expect(resolution.missing).toEqual([])
+  })
+
+  test('no packages resolves exactly what it resolved before', () => {
+    for (const setting of [undefined, true, false, ['errors']] as const) {
+      const before = resolveViewPatterns('resources/views', '/defaults/views', setting, () => true, [])
+      const expected = setting === false
+        ? ['resources/views']
+        : Array.isArray(setting)
+          ? ['resources/views', '/defaults/views/errors']
+          : ['resources/views', '/defaults/views']
+
+      expect(before.patterns).toEqual(expected)
+    }
+  })
+})


### PR DESCRIPTION
Third slice of the HQ-in-the-pantry work, after [#2423](https://github.com/stacksjs/stacks/pull/2423) (discovery finds installed packages) and [#2427](https://github.com/stacksjs/stacks/pull/2427) / [#2428](https://github.com/stacksjs/stacks/pull/2428) (models).

## The gap

The router already registers a discovered package's route files. Those routes had nowhere to render from: view lookup was the app's `resources/views` plus the framework defaults and nothing else. A package could ship a page and a route to it and the request would still 404.

## Why appending last is the whole safety argument

`resolveViewPatterns` is the single function both the dev server and the production server compose their patterns through, shared on purpose so the two cannot drift. Extending it wires both at once.

stx's `getRoute()` returns the **first** pattern whose relative path matches. So anything appended after the existing roots cannot change the answer for a path that already resolves. That is a positional guarantee rather than a promise, and it holds for an app with no packages *and* for every pre-existing route in an app with them. The twelve existing `view-patterns.test.ts` cases still pass unchanged, which is the proof.

## Decisions worth reviewing

- **`defaultViews` is not consulted for packages.** That setting decides whether the app serves the framework's demo pages. An application that installed a package asked for that package's pages either way, so `defaultViews: false` still gets them.
- **A missing directory is skipped, not fatal.** stx would glob it and find nothing anyway, and a package shipping an optional subtree is not an error.
- **A path escaping the package is refused.** `../../secrets` would otherwise serve files the app never installed. Same guard `resolveViewPatterns` already applies to the framework's own default subtrees.
- **Ordered by package name**, so two packages resolve identically on every machine rather than by manifest key order.

## Components are deliberately not covered

They resolve through `componentsDir` and `fallbackComponentsDir`, both single strings, both already taken by the app and the framework defaults. stx's resolver does read an array, `_pluginComponentDirs`, but `bun-plugin-stx` populates it only from its own config file, which this repo does not have. Wiring components needs an upstream `componentDirs?: string[]` on `ServeOptions`, so it belongs in its own change rather than widening this one.

Two other things the mapping turned up, recorded so they are not rediscovered: the dashboard hand-rolls its own patterns and does not go through `resolveViewPatterns` at all, and `SitemapAction` keeps a third independent list of view roots, so package pages will serve but not appear in `sitemap.xml`.

## Verification

- 11 new tests, plus the 12 existing `view-patterns.test.ts` cases passing unchanged
- `core/config`: 194 pass, 0 fail
- root suite: 402 pass, 0 fail
- framework typecheck: 4 errors, all pre-existing `@stacksjs/tlsx` in `server.ts`
- `./buddy lint` clean apart from the pre-existing untracked `storage/framework/libs/entries/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)