### PR TITLE
fix(database): run the migrations directory, not the models directory

### DIFF
--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -1554,7 +1554,12 @@ export async function runDatabaseMigration(): Promise<Result<string, Error>> {
       makeMigrationsIdempotent()
     }
 
-    const modelsDir = path.userModelsPath()
+    // The corpus to run, which is NOT the models directory. bun-query-builder
+    // declared this argument and then ignored it, resolving `migrationDir` from
+    // its own config, so passing `app/Models` here was wrong and silent. 0.2.63
+    // honours it (stacksjs/bun-query-builder#1137), which turned that into
+    // `Migration directory not found: <app>/app/Models` on every deploy.
+    const corpusDir = migrationDirectory(dialect)
 
     /*
      * Some older generated migration corpora rebuild or normalize framework
@@ -1593,8 +1598,8 @@ export async function runDatabaseMigration(): Promise<Result<string, Error>> {
     const appliedBefore = await countAppliedMigrations()
 
     // Execute existing migration files
-    log.debug(`[migration] Running migrations from: ${modelsDir}`)
-    await qbExecuteMigration(modelsDir)
+    log.debug(`[migration] Running migrations from: ${corpusDir}`)
+    await qbExecuteMigration(corpusDir)
 
     // Complete the guarantee after the model batch. This creates tables absent
     // from both the corpus and the preflight, and validates existing shapes.

--- a/storage/framework/core/database/tests/migrate-corpus-directory.test.ts
+++ b/storage/framework/core/database/tests/migrate-corpus-directory.test.ts
@@ -1,0 +1,57 @@
+/**
+ * `buddy migrate` runs the migrations directory, not the models directory.
+ *
+ * bun-query-builder declared `executeMigration(dir)` and then ignored it,
+ * resolving `migrationDir` from its own config instead. Stacks passed
+ * `app/Models`, which was wrong the whole time and invisible because the value
+ * was discarded.
+ *
+ * 0.2.63 honours the argument (stacksjs/bun-query-builder#1137). Every
+ * production deploy then failed with
+ * `Migration directory not found: <app>/app/Models`, and a project that HAS an
+ * `app/Models` would have been worse: the directory exists, holds no `.sql`,
+ * so the run would report success having applied nothing.
+ *
+ * Pinned at the source because the failure needs a real database and a real
+ * corpus to reproduce, and the thing worth protecting is one argument.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const source = readFileSync(resolve('storage/framework/core/database/src/migrations.ts'), 'utf8')
+
+/** The body of `runDatabaseMigration`, up to the next exported function. */
+function runDatabaseMigrationBody(): string {
+  const start = source.indexOf('export async function runDatabaseMigration')
+  expect(start).toBeGreaterThan(-1)
+  const next = source.indexOf('\nexport ', start + 1)
+  return source.slice(start, next === -1 ? undefined : next)
+}
+
+describe('the migration corpus handed to bun-query-builder', () => {
+  test('is the migrations directory, resolved for the dialect', () => {
+    const body = runDatabaseMigrationBody()
+
+    expect(body).toContain('migrationDirectory(dialect)')
+    expect(body).toContain('qbExecuteMigration(corpusDir)')
+  })
+
+  test('is never the models directory', () => {
+    const body = runDatabaseMigrationBody()
+
+    expect(body).not.toContain('qbExecuteMigration(modelsDir)')
+    expect(body).not.toContain('userModelsPath()')
+  })
+
+  test('resetDatabase still gets the models directory, which it does want', () => {
+    // It drops the tables the models declare, so `app/Models` is correct there
+    // and guarded by its own existsSync. Named here so a future sweep for
+    // `userModelsPath` does not "fix" it too.
+    const start = source.indexOf('export async function resetDatabase')
+    const body = source.slice(start, source.indexOf('\nexport ', start + 1))
+
+    expect(body).toContain('path.userModelsPath()')
+    expect(body).toContain('qbResetDatabase(modelsDir')
+  })
+})

--- a/storage/framework/core/database/tests/migrate-corpus-directory.test.ts
+++ b/storage/framework/core/database/tests/migrate-corpus-directory.test.ts
@@ -17,9 +17,13 @@
  */
 import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
-const source = readFileSync(resolve('storage/framework/core/database/src/migrations.ts'), 'utf8')
+// Resolved from this file, not the working directory. `storage/framework/...`
+// is framework-owned: it is relative to wherever the framework is installed,
+// which has nothing to do with where the process was started, and
+// `framework-paths-are-not-cwd-relative.test.ts` fails a source file that
+// forgets it.
+const source = readFileSync(new URL('../src/migrations.ts', import.meta.url), 'utf8')
 
 /** The body of `runDatabaseMigration`, up to the next exported function. */
 function runDatabaseMigrationBody(): string {


### PR DESCRIPTION
**Production deploys are failing on `main` right now:**

```
Migration failed: Migration directory not found: /var/www/stacks-main/releases/537fcd1/app/Models
```

## What happened

`runDatabaseMigration` has always passed `path.userModelsPath()` to bun-query-builder's `executeMigration`. That was wrong from the day it was written and cost nothing, because the function declared the argument and then discarded it, resolving `migrationDir` from its own config instead.

[stacksjs/bun-query-builder#1137](https://github.com/stacksjs/bun-query-builder/issues/1137), which this repo filed yesterday asking for multi-directory support, shipped in `0.2.63` and honours the argument. The existing `^0.2.62` range already resolves it in the lockfile, so a wrong argument became a live failure with **no change on this side at all**.

Its own release note called this out: *"a caller that was passing something other than a migrations directory, the models directory was the common one, will see that directory enumerated instead."* We were that caller.

## The fix

Pass `migrationDirectory(dialect)`, which every other reader of the corpus in this file already uses and which resolves the per-dialect layout rather than assuming the flat directory.

Verified locally: it now resolves `database/migrations` (exists), where before it passed `app/Models`, which does not exist in this repo at all, matching the deploy error exactly.

## The failure mode worth naming

The deploy crash is the *benign* case. In an application that **has** an `app/Models`, the directory exists, contains no `.sql`, and the run reports success having applied nothing. A silent no-op migration on a production deploy is considerably worse than a hard error.

## Deliberately untouched

`resetDatabase` still hands the models directory to `qbResetDatabase`, on purpose: it drops the tables those models declare, and it guards on the directory existing. A test names it explicitly so a later sweep for `userModelsPath` does not "fix" that too.

## Verification

- 3 new tests pinning the argument at the source, since reproducing needs a real database and a real corpus and the thing worth protecting is one argument
- `core/database`: 880 pass, 1 fail; that failure is on clean main too
- root suite: 402 pass, 0 fail
- framework typecheck: 4 pre-existing `@stacksjs/tlsx` errors
- `./buddy lint` clean apart from the pre-existing untracked `storage/framework/libs/entries/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)