### PR TITLE
fix(router): repair three type errors left by the perf series

### DIFF
--- a/storage/framework/core/router/src/stacks-router.ts
+++ b/storage/framework/core/router/src/stacks-router.ts
@@ -257,7 +257,7 @@ export function shouldUseNativeRoutesByDefault(routes: readonly Route[]): boolea
   return hasEligibleRoute
 }
 
-import { runWithRequestArguments } from './request-context'
+import { runWithRequestArgument, runWithRequestArguments } from './request-context'
 import { isApiRequest, JSON_CONTENT_TYPE } from './api-shape'
 import { createErrorResponse, createMiddlewareErrorResponse } from './error-handler'
 import { applySecurityHeaders, createJsonSecurityHeaders, secureSerializedJsonResponse } from './security-headers'
@@ -1992,6 +1992,12 @@ function createMiddlewareHandler(routeStates: Map<string, RouteRuntimeState>, ro
           const pathStart = schemeEnd === -1 ? 0 : req.url.indexOf('/', schemeEnd + 3)
           const q = req.url.indexOf('?', pathStart < 0 ? 0 : pathStart)
           const urlPath = pathStart < 0 ? '/' : req.url.slice(pathStart, q === -1 ? undefined : q)
+          // The method lives in the route key, which is where
+          // `routeCapabilityFlags` reads it from too. Derived inside the gate
+          // rather than hoisted alongside `routeFlags`: this log line is its
+          // only consumer, so a route serving requests with debug logging off
+          // should not pay to compute it.
+          const routeMethod = routeKey.slice(0, routeKey.indexOf(':')).toUpperCase()
           log.debug(`[middleware] Executing chain: [${middlewareEntries.join(', ')}] for ${routeMethod} ${urlPath}`)
         }
 
@@ -2410,13 +2416,13 @@ function createMiddlewareHandler(routeStates: Map<string, RouteRuntimeState>, ro
 
   const handleSynchronous = (req: EnhancedRequest): Response | Promise<Response> => {
     if (routeState?.middleware?.length || routeState?.rateLimit)
-      return runWithRequestArguments(req, handleAsyncInContext, req)
+      return runWithRequestArgument(req, handleAsyncInContext, req)
 
     const csrfHandledByOuter = (req as unknown as Record<symbol, unknown>)[CSRF_SEEDED_BY_HANDLE_REQUEST] === true
     if ((routeFlags & ROUTE_RENDERS_CSRF) !== 0 && !csrfHandledByOuter && requestMayRenderHtml(req)) {
       const renderTokenSeeding = seedCsrfTokenForRender(req as unknown as Request & { _csrfToken?: string })
       if (renderTokenSeeding)
-        return renderTokenSeeding.then(() => runWithRequestArguments(req, handleAsyncInContext, req))
+        return renderTokenSeeding.then(() => runWithRequestArgument(req, handleAsyncInContext, req))
     }
 
     if ((routeFlags & ROUTE_FORCES_JSON) !== 0)


### PR DESCRIPTION
`main` has been red on `typecheck` since `fec230e83f`. Three errors, all in `stacks-router.ts`, all left behind by the `perf(router)` series rather than wrong in it.

```
1995,92: error TS2304: Cannot find name 'routeMethod'.
2413,14: error TS2554: Expected 5 arguments, but got 3.
2419,46: error TS2554: Expected 5 arguments, but got 3.
```

### `routeMethod`

`perf(router): pack route capability flags` extracted `routeCapabilityFlags()`, and the method derivation went with it. The middleware debug log in `createMiddlewareHandler` still referenced `routeMethod`, which is now a local of a different function.

`routeKey` is a parameter of `createMiddlewareHandler`, so the same derivation is available. It is placed inside the existing `isDebugLogging()` gate rather than hoisted next to `routeFlags`, which keeps faith with that block's own stated rule: the log line is the string's only consumer, so a route serving requests with debug logging off should not pay to compute it.

### The two arity errors

`perf(router): avoid async context closures` added `runWithRequestArguments` for three-argument dispatch, next to the existing single-argument `runWithRequestArgument`. Two call sites that dispatch with one argument reached for the plural:

```ts
return runWithRequestArguments(req, handleAsyncInContext, req)
```

Both now use the singular, whose signature is what they match. `handleAsyncInContext`'s second and third parameters are optional with a default, so a one-argument dispatch was always the intent. The genuinely three-argument call at the end of `handleSynchronous` is untouched.

### Verification

- `bun run typecheck` on a cold cache: the three errors are gone. What remains locally is the usual dist-only subpath resolution noise (`@stacksjs/storage/uploaded-file`, `@stacksjs/error-handling/*`) that CI does not see - CI reported these three and nothing else.
- Router suite is **181 pass / 49 fail / 31 errors both with and without this commit**. Those failures are a locally stale `@stacksjs/bun-router` whose dist lacks `applyResponseCompression`; the `test` job was green on the same commit.
- `./buddy lint` reports nothing in this file.

No behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)