### PR TITLE
feat(packages): resolve an installed package's models on the first boot

### DIFF
--- a/storage/framework/core/actions/src/dev/api.ts
+++ b/storage/framework/core/actions/src/dev/api.ts
@@ -42,6 +42,22 @@ const hostname = resolveApiHost()
 // "missing" alone was the other extreme, and left projects running a
 // manifest that still described files renamed or deleted months earlier.
 // initiateImports() handles live updates under the bundler plugin.
+//
+// Discovery runs FIRST. The barrel now includes the models an installed
+// package ships, so building it from a manifest written before the package
+// was installed produces a barrel missing them - and the staleness check
+// below is what decides whether to rebuild, so it has to be looking at a
+// current manifest when it does. Ordered the other way round, `bun add loghq`
+// needs two boots before its models resolve.
+try {
+  const { discoverPackages } = await import('../discover-packages')
+  await discoverPackages()
+}
+catch {
+  // A project without the actions package, or an unreadable pantry: the
+  // application's own models are unaffected and boot continues.
+}
+
 const modelsIndex = path.storagePath('framework/auto-imports/models.ts')
 if (!existsSync(modelsIndex) || autoImportsAreStale())
   await generateAutoImportFiles()

--- a/storage/framework/core/actions/tests/discovery-manifest-path.test.ts
+++ b/storage/framework/core/actions/tests/discovery-manifest-path.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Discovery and the auto-import staleness check must name the same manifest.
+ *
+ * `discoverPackages()` writes `storage/framework/discovered-packages.json`, and
+ * `autoImportsAreStale()` reads that file's mtime to decide whether the set of
+ * installed packages has moved since the auto-import barrel was built. That is
+ * the only signal it has: a package's own model files carry the mtimes from its
+ * tarball, so a freshly installed package's models are routinely OLDER than the
+ * barrel and never trip an mtime comparison.
+ *
+ * The two live in different packages and each names the path itself. If either
+ * moves, nothing throws - `existsSync` on the old path simply returns false, the
+ * staleness check stops firing, and `bun add loghq` goes back to needing two
+ * boots before its models resolve. Silent, and indistinguishable from a cache
+ * that happened to be warm.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const coreRoot = resolve(import.meta.dir, '../..')
+
+/** Every `storagePath('framework/…json')` literal a source file names. */
+function manifestPathsIn(relative: string): string[] {
+  const source = readFileSync(resolve(coreRoot, relative), 'utf8')
+  return [...source.matchAll(/storagePath\(\s*'(framework\/[^']*\.json)'\s*\)/g)].map(m => m[1])
+}
+
+describe('the discovery manifest path', () => {
+  test('is a single literal in the writer, which is what the reader must match', () => {
+    // Guards the regex: if the call shape changes so this matches nothing, the
+    // agreement test below would pass vacuously against an empty needle.
+    expect(manifestPathsIn('actions/src/discover-packages.ts'))
+      .toEqual(['framework/discovered-packages.json'])
+  })
+
+  test('is named by the staleness check too', () => {
+    const [written] = manifestPathsIn('actions/src/discover-packages.ts')
+
+    // `imports.ts` legitimately names several manifests - the server and
+    // browser auto-import ones - so this asks that the discovery manifest is
+    // among them, not that it is the only one.
+    expect(manifestPathsIn('server/src/imports.ts')).toContain(written)
+  })
+
+  test('is read by the staleness check itself, not merely mentioned in the file', () => {
+    const source = readFileSync(resolve(coreRoot, 'server/src/imports.ts'), 'utf8')
+    const start = source.indexOf('export function autoImportsAreStale')
+    expect(start).toBeGreaterThan(-1)
+
+    // Scoped to that function's body. The path appearing elsewhere in the file
+    // would satisfy the test above while the staleness check ignored it.
+    const body = source.slice(start, source.indexOf('\nexport ', start + 1))
+    expect(body).toContain('framework/discovered-packages.json')
+  })
+})

--- a/storage/framework/core/actions/tests/package-discovery.test.ts
+++ b/storage/framework/core/actions/tests/package-discovery.test.ts
@@ -16,7 +16,7 @@
  * not finding the package at all.
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { discoverPackages } from '../src/discover-packages'
@@ -188,5 +188,47 @@ describe('package discovery', () => {
     // `generated_at` moves on every run, so comparing whole manifests would
     // dirty a committed file on every boot.
     expect(second.generated_at).toBe(first.generated_at)
+  })
+
+  test('leaves the manifest file untouched when the set is unchanged', async () => {
+    // The returned manifest being equal is not the same claim as the file not
+    // being written. Rewriting identical bytes would satisfy the test above
+    // and still move the mtime - and `autoImportsAreStale()` reads that mtime
+    // to decide whether the package set moved, so a no-op rewrite here means
+    // every boot regenerates the whole auto-import barrel.
+    app({ name: 'my-app', dependencies: { loghq: '^1.0.0' } })
+    pkg('node_modules/loghq', { name: 'loghq', stacks: { name: 'loghq' } })
+    const manifestPath = join(project, 'manifest.json')
+
+    await discoverPackages({ projectRoot: project, manifestPath })
+
+    // Backdated rather than slept on, so the assertion cannot pass by two
+    // writes landing inside one filesystem timestamp tick.
+    const past = new Date(Date.now() - 60_000)
+    utimesSync(manifestPath, past, past)
+    const before = statSync(manifestPath).mtimeMs
+
+    await discoverPackages({ projectRoot: project, manifestPath })
+
+    expect(statSync(manifestPath).mtimeMs).toBe(before)
+  })
+
+  test('moves the manifest mtime when a package is installed', async () => {
+    // The other half: the mtime has to actually move when the set changes, or
+    // a newly installed package's models never reach the barrel.
+    app({ name: 'my-app', dependencies: { loghq: '^1.0.0' } })
+    pkg('node_modules/loghq', { name: 'loghq', stacks: { name: 'loghq' } })
+    const manifestPath = join(project, 'manifest.json')
+
+    await discoverPackages({ projectRoot: project, manifestPath })
+    const past = new Date(Date.now() - 60_000)
+    utimesSync(manifestPath, past, past)
+    const before = statSync(manifestPath).mtimeMs
+
+    app({ name: 'my-app', dependencies: { loghq: '^1.0.0', bughq: '^1.0.0' } })
+    pkg('node_modules/bughq', { name: 'bughq', stacks: { name: 'bughq' } })
+    await discoverPackages({ projectRoot: project, manifestPath })
+
+    expect(statSync(manifestPath).mtimeMs).toBeGreaterThan(before)
   })
 })

--- a/storage/framework/core/server/src/imports.ts
+++ b/storage/framework/core/server/src/imports.ts
@@ -491,6 +491,20 @@ export function autoImportsAreStale(): boolean {
     return true
   }
 
+  // The set of installed packages is a source too, and the only one that is
+  // not a directory of .ts files. A package's own model files are no help
+  // here: package managers preserve the mtimes from the tarball, so a freshly
+  // installed package's models are routinely OLDER than the barrel and would
+  // never trip an mtime comparison. The discovery manifest is written by the
+  // framework at discovery time, and only when the discovered set actually
+  // changed, so its mtime is exactly "when the package set last moved".
+  const discovered = path.storagePath('framework/discovered-packages.json')
+  try {
+    if (existsSync(discovered) && statSync(discovered).mtimeMs > manifestTime)
+      return true
+  }
+  catch { /* unreadable manifest is not a reason to force a regenerate */ }
+
   // Directory mtimes catch adds, renames, and deletes; file mtimes catch
   // edits to a file's exports. A source newer than the manifest means the
   // manifest is describing a tree that has since changed.


### PR DESCRIPTION
Part of the HQ-in-the-pantry work: `bun add loghq` should bring its models, migrations, routes and views the way a Laravel package does.

The framework already resolves a discovered package's models into the auto-import barrel. This fixes the boot ordering that made that take **two** boots to take effect.

## Two ordering problems, one in each direction

**`dev/api.ts` decided staleness before discovering.** The barrel now includes the models an installed package ships, so building it from a manifest written before the package was installed produces a barrel missing them - and the staleness check is what decides whether to rebuild. Discovery now runs first.

**The staleness check could not see a package at all.** It compares source mtimes against the barrel, and a package's own model files are no help here:

> package managers restore the mtimes from the tarball, so a freshly installed package's models are routinely OLDER than the barrel and never trip the comparison

So it now also compares `storage/framework/discovered-packages.json`, which the framework writes itself, and only when the discovered set actually changed. Its mtime means *"when the package set last moved"*, not *"when discovery last ran"*.

## Why that last property is now tested on the file

It is what keeps this from regenerating the whole barrel on every boot, and the existing coverage did not reach it. `writes the manifest only when the discovered set changes` asserts `generated_at` is stable on the **returned object** - a rewrite of identical bytes satisfies that and still moves the mtime.

Verified by breaking it in both directions:

| break | `generated_at` test | new mtime test |
|---|---|---|
| write unconditionally | fails | fails |
| rewrite the unchanged manifest | **passes** | fails |

The second row is the one that matters: that regression is invisible to the existing suite and would mean a full barrel regenerate on every boot.

Backdated with `utimesSync` rather than slept on, so it cannot pass by two writes landing inside one filesystem timestamp tick.

## The cross-package seam

`discovery-manifest-path.test.ts` guards the join between `@stacksjs/actions` and `@stacksjs/server`. Each names the manifest path itself; if either moves, `existsSync` returns false, the staleness check stops firing, and this bug returns looking like a warm cache. Three assertions - the writer names it exactly once (so the agreement check cannot pass vacuously against an empty needle), the reader names it too, and it appears inside `autoImportsAreStale`'s own body rather than merely somewhere in the file. Confirmed all three go red on a rename.

## Verification

- `core/actions`: **509 pass / 0 fail**
- `core/server`: **178 pass / 0 fail**
- Cold-cache `bun run typecheck`: nothing in the touched files. What remains locally is the known dist-only subpath resolution (`@stacksjs/error-handling/*`, `@stacksjs/storage/uploaded-file`) that CI does not see.
- `./buddy lint`: clean for these files.

### A note on local verification

My local `node_modules` was serving `@stacksjs/bun-router` 0.1.8 against a `^0.1.11` requirement, because local Bun was 1.3.14 and could not read this repo's `lockfileVersion: 2`. That alone accounted for 49 phantom router failures. Re-synced with the pinned Bun 1.4.1 - the router suite went from 181 pass / 49 fail / 31 errors to **558 pass / 0 fail**, with the lockfile untouched. Worth knowing if anyone else is seeing failures that CI is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)