### PR TITLE
feat(packages): run the migrations an installed package ships

### DIFF
--- a/storage/framework/core/config/src/discovered-resources.ts
+++ b/storage/framework/core/config/src/discovered-resources.ts
@@ -27,12 +27,14 @@ export interface PackageResourceRoot {
 interface DiscoveredEntry {
   root?: string
   views?: string | string[]
+  migrations?: string | string[]
 }
 
 /** Directories a package is taken to provide when it declares no explicit list. */
 const IMPLIED_DIRS = {
   views: ['resources/views'],
   models: ['app/Models'],
+  migrations: ['database/migrations'],
 } as const
 
 export interface PackageResourceOptions {
@@ -72,7 +74,7 @@ function readManifest(manifestPath: string): Record<string, DiscoveredEntry> {
  * shipping an optional subtree is not an error.
  */
 function resourceRoots(
-  field: 'views' | 'models',
+  field: 'views' | 'models' | 'migrations',
   options: PackageResourceOptions = {},
 ): PackageResourceRoot[] {
   const manifestPath = options.manifestPath ?? path.storagePath('framework/discovered-packages.json')
@@ -115,6 +117,20 @@ function resourceRoots(
   // Sorted by package so two packages contributing the same kind of directory
   // resolve in the same order on every machine, rather than by manifest order.
   return roots.sort((a, b) => a.package.localeCompare(b.package))
+}
+
+/**
+ * Migration directories each discovered package contributes.
+ *
+ * These are read, never written. The migration runner deletes and rewrites
+ * files in the corpus it runs - SQLite preprocessing drops statements it
+ * cannot execute and prunes duplicate CREATEs - so a package's own directory
+ * is copied out of before any of that happens. Doing otherwise would have the
+ * framework mutating an installed package's files, which a reinstall silently
+ * undoes.
+ */
+export function packageMigrationRoots(options: PackageResourceOptions = {}): PackageResourceRoot[] {
+  return resourceRoots('migrations', options)
 }
 
 /** View directories each discovered package contributes. */

--- a/storage/framework/core/config/src/index.ts
+++ b/storage/framework/core/config/src/index.ts
@@ -12,7 +12,7 @@ export * from './config'
 export { FRAMEWORK_DEFAULTS } from './defaults'
 export { validateConfig, reportConfigIssues, type ConfigValidationIssue } from './validators'
 export { feature, enableFeature, disableFeature, resetFeature, listFeatures } from './features'
-export { packageModelRoots, packageViewRoots, type PackageResourceOptions, type PackageResourceRoot } from './discovered-resources'
+export { packageMigrationRoots, packageModelRoots, packageViewRoots, type PackageResourceOptions, type PackageResourceRoot } from './discovered-resources'
 export { resolveViewPatterns, type DefaultViewsSetting, type ViewPatternResolution } from './views'
 export {
   createRequestContext,

--- a/storage/framework/core/config/tests/discovered-views.test.ts
+++ b/storage/framework/core/config/tests/discovered-views.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, test } from 'bun:test'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { packageModelRoots, packageViewRoots } from '../src/discovered-resources'
+import { packageMigrationRoots, packageModelRoots, packageViewRoots } from '../src/discovered-resources'
 import { resolveViewPatterns } from '../src/views'
 
 function project(): string {
@@ -232,6 +232,64 @@ describe('package model roots', () => {
       const opts = { manifestPath: file, projectRoot: root }
       expect(packageModelRoots(opts).map(r => r.dir)).toEqual([join(root, 'node_modules/loghq/app/Models')])
       expect(packageViewRoots(opts).map(r => r.dir)).toEqual([join(root, 'node_modules/loghq/resources/views')])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})
+
+describe('package migration roots', () => {
+  test('a package that ships database/migrations is found without declaring anything', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq/database/migrations'), { recursive: true })
+      const file = manifest(root, { loghq: { root: 'node_modules/loghq' } })
+
+      const roots = packageMigrationRoots({ manifestPath: file, projectRoot: root })
+
+      expect(roots).toHaveLength(1)
+      expect(roots[0]?.dir).toBe(join(root, 'node_modules/loghq/database/migrations'))
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('honours an explicitly declared directory', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq/sql'), { recursive: true })
+      const file = manifest(root, {
+        loghq: { root: 'node_modules/loghq', migrations: ['sql'] },
+      })
+
+      expect(packageMigrationRoots({ manifestPath: file, projectRoot: root }).map(r => r.dir))
+        .toEqual([join(root, 'node_modules/loghq/sql')])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('refuses a path that escapes the package', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'database/migrations'), { recursive: true })
+      mkdirSync(join(root, 'node_modules/loghq'), { recursive: true })
+      const file = manifest(root, {
+        loghq: { root: 'node_modules/loghq', migrations: ['../../database/migrations'] },
+      })
+
+      // Otherwise a package could name the application's own corpus as its
+      // migrations directory, and staging would copy every file onto itself
+      // under a banded name.
+      expect(packageMigrationRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('a package with no migrations contributes nothing', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/table/resources'), { recursive: true })
+      const file = manifest(root, { table: { root: 'node_modules/table' } })
+
+      expect(packageMigrationRoots({ manifestPath: file, projectRoot: root })).toEqual([])
     }
     finally { rmSync(root, { recursive: true, force: true }) }
   })

--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -8,7 +8,7 @@
 import type { UnsafeRowsResult } from './utils'
 import type { Result } from '@stacksjs/error-handling'
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
-import { isPackageMigration } from './package-migrations'
+import { isPackageMigration, stagePackageMigrations } from './package-migrations'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { log as _log } from '@stacksjs/logging'
 
@@ -1541,6 +1541,37 @@ export async function runDatabaseMigration(): Promise<Result<string, Error>> {
     const dialect = getDialect()
     const lockDb = dialect === 'sqlite' ? null : createQueryBuilder()
     lockHandle = await acquireMigrationLock(dialect, lockDb)
+
+    /*
+     * Publish each installed package's migrations into the corpus.
+     *
+     * Between the lock and the preprocessing on purpose. After the lock for
+     * the same reason preprocessing is: two runners writing the corpus at once
+     * corrupt each other's disk state. Before the preprocessing because a
+     * package's SQL needs the same dialect treatment the application's gets -
+     * staging it afterwards would hand SQLite the Postgres-only DDL that
+     * `preprocessSqliteMigrations` exists to drop.
+     */
+    try {
+      // Imported dynamically, the way every other `@stacksjs/config` use in
+      // this file is: it does not resolve cleanly in every embedding, and a
+      // bare test that never installed a package should not fail to load.
+      const { packageMigrationRoots } = await import('@stacksjs/config')
+      const staged = stagePackageMigrations({
+        roots: packageMigrationRoots(),
+        corpusDir: migrationDirectory(dialect),
+      })
+      if (staged.length > 0) {
+        const packages = [...new Set(staged.map(s => s.package))].join(', ')
+        log.info(`Staged ${staged.length} migration(s) from ${packages}`)
+      }
+    }
+    catch (error) {
+      // An application's own migrations do not depend on this having worked,
+      // and refusing to migrate because a package shipped an unreadable
+      // directory would make one bad dependency block every deploy.
+      log.warn(`Could not stage package migrations: ${error instanceof Error ? error.message : String(error)}`)
+    }
 
     // Preprocess migrations for SQLite compatibility — runs *after*
     // the lock is held so concurrent processes can't corrupt each

--- a/storage/framework/core/database/src/package-migrations.ts
+++ b/storage/framework/core/database/src/package-migrations.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 /**
  * The ordinal band reserved for migrations a discovered package brings.
  *
@@ -47,4 +50,109 @@ export function isPackageMigration(file: string): boolean {
   //
   // Ten digits is what the band was always documented as.
   return value >= PACKAGE_MIGRATION_BAND && value <= PACKAGE_MIGRATION_BAND_END
+}
+
+/** One package migration copied into the corpus the runner executes. */
+export interface StagedPackageMigration {
+  /** The package that ships it. */
+  package: string
+  /** Absolute path inside the installed package. */
+  source: string
+  /** Basename it is staged under, which is what the ledger records. */
+  name: string
+}
+
+/**
+ * The name a package's migration is staged under.
+ *
+ * Every package migration shares the SAME band ordinal, and the package name
+ * and the file's original name break the tie. That is what makes the staged
+ * name stable: an ordinal handed out by position would renumber every file
+ * after the one that moved the moment another package was installed or
+ * removed, and the ledger keys on the bare basename, so those files would read
+ * as new and run a second time against tables they had already created.
+ *
+ * Sorting still lands where it has to, because the runner orders on the whole
+ * filename and only reaches the tie-break once the ordinals are equal:
+ *
+ *   0000000133-add-orthomosaic.sql          <- the application, always first
+ *   9000000000-bughq__0000000001-issues.sql <- then by package name
+ *   9000000000-loghq__0000000001-create.sql <- then by the package's own order
+ *   9000000000-loghq__0000000002-alter.sql
+ *
+ * The package's original ordinal is kept rather than stripped. A package
+ * declares its own internal order the same way the application does, and
+ * `create-…` before `alter-…` is not something alphabetical order preserves.
+ */
+export function stagedMigrationName(packageName: string, originalFile: string): string {
+  // `__` because a single `-` is already the ordinal separator, and package
+  // names contain `-` far more often than they contain `__`.
+  return `${PACKAGE_MIGRATION_BAND}-${packageName.replace(/[/\\]/g, '+')}__${originalFile}`
+}
+
+/**
+ * Copy each discovered package's migrations into the corpus that will run.
+ *
+ * Staged rather than run in place because the runner treats the corpus as
+ * writable: SQLite preprocessing deletes duplicate CREATEs and drops
+ * statements the dialect cannot execute, and both call `unlinkSync` on the
+ * file. Pointing that at `node_modules` would have the framework deleting an
+ * installed package's files, which the next install silently restores and the
+ * one after that deletes again.
+ *
+ * Returns what it staged, so the caller can report it. A package with no
+ * migrations directory contributes nothing and is not an error.
+ */
+export function stagePackageMigrations(options: {
+  roots: { package: string, dir: string }[]
+  corpusDir: string
+}): StagedPackageMigration[] {
+  const staged: StagedPackageMigration[] = []
+
+  for (const root of options.roots) {
+    let files: string[]
+    try {
+      files = readdirSync(root.dir).filter(f => f.endsWith('.sql')).sort()
+    }
+    catch {
+      continue // declared but absent, which `packageMigrationRoots` already filters
+    }
+
+    for (const file of files) {
+      const name = stagedMigrationName(root.package, file)
+      const source = join(root.dir, file)
+      const target = join(options.corpusDir, name)
+
+      // Overwrite only on a real difference. Rewriting an identical file would
+      // move its mtime on every migrate run for no reason, and the corpus is a
+      // directory other things watch.
+      let incoming: string
+      try {
+        incoming = readFileSync(source, 'utf8')
+      }
+      catch {
+        continue // unreadable file in the package: not the application's problem
+      }
+
+      let current: string | undefined
+      try {
+        current = readFileSync(target, 'utf8')
+      }
+      catch {
+        current = undefined
+      }
+
+      // A changed file is republished so that a fresh database builds the
+      // schema the installed version describes. It does NOT re-run on a
+      // database that already has it: the ledger keys on this basename, which
+      // is exactly why the name is stable. A package that needs to change an
+      // applied table ships another migration, the same as an application.
+      if (current !== incoming)
+        writeFileSync(target, incoming)
+
+      staged.push({ package: root.package, source, name })
+    }
+  }
+
+  return staged
 }

--- a/storage/framework/core/database/tests/package-migrations.test.ts
+++ b/storage/framework/core/database/tests/package-migrations.test.ts
@@ -11,7 +11,10 @@
  * today, so this is inert until the staging change arrives.
  */
 import { describe, expect, test } from 'bun:test'
-import { isPackageMigration, PACKAGE_MIGRATION_BAND } from '../src/package-migrations'
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { isPackageMigration, PACKAGE_MIGRATION_BAND, stagePackageMigrations } from '../src/package-migrations'
 
 describe('the reserved package migration band', () => {
   test('is ten digits, so lexicographic order still equals numeric order', () => {
@@ -46,5 +49,151 @@ describe('the reserved package migration band', () => {
     expect(isPackageMigration('create-users-table.sql')).toBe(false)
     expect(isPackageMigration('README.md')).toBe(false)
     expect(isPackageMigration('')).toBe(false)
+  })
+})
+
+/**
+ * Staging a package's migrations into the corpus that runs.
+ *
+ * The migration runner treats its corpus as writable - SQLite preprocessing
+ * calls `unlinkSync` on duplicates and on statements the dialect cannot run -
+ * so a package's own directory is copied out of rather than run in place.
+ */
+describe('staging a package migration', () => {
+  function project(): string {
+    return mkdtempSync(join(tmpdir(), 'stacks-stage-'))
+  }
+
+  /** Write `.sql` files into a package's migrations directory. */
+  function shipped(root: string, pkg: string, files: Record<string, string>): { package: string, dir: string } {
+    const dir = join(root, 'node_modules', pkg, 'database/migrations')
+    mkdirSync(dir, { recursive: true })
+    for (const [name, sql] of Object.entries(files))
+      writeFileSync(join(dir, name), sql)
+    return { package: pkg, dir }
+  }
+
+  test('copies the package files in under a banded name', () => {
+    const root = project()
+    try {
+      const corpusDir = join(root, 'database/migrations')
+      mkdirSync(corpusDir, { recursive: true })
+      const loghq = shipped(root, 'loghq', {
+        '0000000001-create-log-entries-table.sql': 'CREATE TABLE log_entries (id INTEGER);',
+      })
+
+      const staged = stagePackageMigrations({ roots: [loghq], corpusDir })
+
+      expect(staged).toHaveLength(1)
+      expect(staged[0]?.name).toBe('9000000000-loghq__0000000001-create-log-entries-table.sql')
+      expect(readFileSync(join(corpusDir, staged[0]!.name), 'utf8'))
+        .toBe('CREATE TABLE log_entries (id INTEGER);')
+      expect(isPackageMigration(staged[0]!.name)).toBe(true)
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('runs after the application, and in each package\'s own declared order', () => {
+    const root = project()
+    try {
+      const corpusDir = join(root, 'database/migrations')
+      mkdirSync(corpusDir, { recursive: true })
+      writeFileSync(join(corpusDir, '0000000133-add-orthomosaic.sql'), '')
+
+      stagePackageMigrations({
+        roots: [
+          shipped(root, 'loghq', { '0000000001-create.sql': 'a', '0000000002-alter.sql': 'b' }),
+          shipped(root, 'bughq', { '0000000001-issues.sql': 'c' }),
+        ],
+        corpusDir,
+      })
+
+      // This ordering IS the run order. A package's tables carry foreign keys
+      // into the application's and never the reverse, and `create` before
+      // `alter` is not something alphabetical order preserves on its own.
+      expect(readdirSync(corpusDir).sort()).toEqual([
+        '0000000133-add-orthomosaic.sql',
+        '9000000000-bughq__0000000001-issues.sql',
+        '9000000000-loghq__0000000001-create.sql',
+        '9000000000-loghq__0000000002-alter.sql',
+      ])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('names a package file the same whatever else is installed', () => {
+    // The ledger keys on the bare basename. An ordinal handed out by position
+    // would rename loghq's files the moment bughq was installed, and every one
+    // of them would read as new and run again against tables it had created.
+    const root = project()
+    try {
+      const corpusDir = join(root, 'database/migrations')
+      mkdirSync(corpusDir, { recursive: true })
+      const loghq = shipped(root, 'loghq', { '0000000001-create.sql': 'a' })
+
+      const alone = stagePackageMigrations({ roots: [loghq], corpusDir })
+      const alongside = stagePackageMigrations({
+        roots: [shipped(root, 'bughq', { '0000000001-issues.sql': 'c' }), loghq],
+        corpusDir,
+      })
+
+      expect(alongside.find(s => s.package === 'loghq')?.name).toBe(alone[0]?.name)
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('leaves an unchanged file alone rather than rewriting it', () => {
+    const root = project()
+    try {
+      const corpusDir = join(root, 'database/migrations')
+      mkdirSync(corpusDir, { recursive: true })
+      const loghq = shipped(root, 'loghq', { '0000000001-create.sql': 'CREATE TABLE a (id INT);' })
+
+      const [first] = stagePackageMigrations({ roots: [loghq], corpusDir })
+      const target = join(corpusDir, first!.name)
+      const past = new Date(Date.now() - 60_000)
+      utimesSync(target, past, past)
+      const before = statSync(target).mtimeMs
+
+      stagePackageMigrations({ roots: [loghq], corpusDir })
+
+      // The corpus is a directory other things watch, and migrate runs often.
+      expect(statSync(target).mtimeMs).toBe(before)
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('republishes a file the package changed', () => {
+    const root = project()
+    try {
+      const corpusDir = join(root, 'database/migrations')
+      mkdirSync(corpusDir, { recursive: true })
+      shipped(root, 'loghq', { '0000000001-create.sql': 'CREATE TABLE a (id INT);' })
+      const loghq = { package: 'loghq', dir: join(root, 'node_modules/loghq/database/migrations') }
+      stagePackageMigrations({ roots: [loghq], corpusDir })
+
+      writeFileSync(join(loghq.dir, '0000000001-create.sql'), 'CREATE TABLE a (id INT, name TEXT);')
+      const [again] = stagePackageMigrations({ roots: [loghq], corpusDir })
+
+      // So a fresh database builds what the installed version describes. An
+      // existing database does NOT re-run it - the ledger has this basename.
+      expect(readFileSync(join(corpusDir, again!.name), 'utf8')).toContain('name TEXT')
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('a package with no migrations directory contributes nothing', () => {
+    const root = project()
+    try {
+      const corpusDir = join(root, 'database/migrations')
+      mkdirSync(corpusDir, { recursive: true })
+
+      expect(stagePackageMigrations({
+        roots: [{ package: 'table', dir: join(root, 'node_modules/table/database/migrations') }],
+        corpusDir,
+      })).toEqual([])
+      expect(readdirSync(corpusDir)).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
   })
 })


### PR DESCRIPTION
The last framework piece of `bun add loghq` behaving like a Laravel package. Models landed in #2437, views and routes were already there. The migration band, the four guards that stop the application's generator renumbering or deleting a package's files, and the discovery manifest all landed earlier - **nothing ever filled the band.**

## Published into the corpus, not run in place

`bun-query-builder` 0.2.63+ can run a corpus assembled from several directories, and its own docs name this use case. That is not enough on its own, because the runner treats its corpus as **writable**:

```ts
// preprocessSqliteMigrations()
const deleteMigration = (file, filePath, reason) => { ... unlinkSync(filePath) }
```

Pointing that at `node_modules` would have the framework deleting files inside an installed package - which the next `bun install` restores and the one after that deletes again. So each package's `.sql` files are copied into the corpus first.

Staging happens **before** the dialect preprocessing and **inside** the migration lock. Before, so a package's SQL gets the same SQLite/Postgres treatment the application's does; otherwise SQLite is handed the Postgres-only DDL that `preprocessSqliteMigrations` exists to drop. Inside, for the same reason preprocessing is - two runners writing the corpus at once corrupt each other's disk state.

## The staged name is the part worth reviewing

Every package migration carries the **same** band ordinal. The package name and the file's original name break the tie:

```
0000000133-add-orthomosaic.sql             the application, always first
9000000000-bughq__0000000001-issues.sql    then by package
9000000000-loghq__0000000001-create.sql    then the package's own order
9000000000-loghq__0000000002-alter.sql
```

The alternative - handing out ordinals by position - is a **data-loss bug**. It renames every file after the one that moved as soon as another package is installed or removed, and the migration ledger keys on the bare basename. Those files read as new and run a second time against tables they had already created.

Verified by swapping the positional scheme back in: `names a package file the same whatever else is installed` fails, which is the whole reason that test exists.

The package's own ordinal is **kept** rather than stripped, because `create-…` before `alter-…` is not something alphabetical order preserves.

## Behaviour worth calling out

- **Unchanged files are not rewritten.** The corpus is a directory other things watch and `migrate` runs often, so an identical file keeps its mtime. Asserted with a backdated mtime rather than a sleep.
- **A changed file is republished**, so a fresh database builds what the installed version describes. It does *not* re-run on a database that already has it - the ledger holds that basename. A package needing to change an applied table ships another migration, exactly as an application does.
- **A declared path that escapes the package is refused**, so a package cannot name the application's own corpus as its migrations directory and have staging copy every file onto itself under a banded name.
- **Failure warns rather than throws.** One dependency shipping an unreadable directory should not block an application's own deploy.

## Verification

- `core/database`: **944 pass / 1 fail**, and that one failure (`sqlDateTime … across clock boundaries`) reproduces identically with this branch stashed, so it is pre-existing and local - CI's `test` job is green on it.
- `core/config`: **201 pass / 0 fail**
- Cold-cache `bun run typecheck`: 12 errors, the same 12 as a clean tree, none in the touched files. All are the dist-only subpath resolution CI does not see.
- `./buddy lint`: clean for these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)