### PR TITLE
feat(packages): let an installed package ship stx components

### DIFF
--- a/docs/guide/package-discovery.md
+++ b/docs/guide/package-discovery.md
@@ -45,6 +45,7 @@ These are the fields the framework reads today.
 | `routeMiddleware` | `string \| string[]` | Middleware applied to every one of those routes. |
 | `views` | `string \| string[]` | Template directories. Appended after the application's own, so nothing that already resolves changes. |
 | `migrations` | `string \| string[]` | SQL migration directories. Defaults to `database/migrations`. |
+| `components` | `string \| string[]` | stx component directories. **No default - must be declared.** |
 | `name` | `string` | Stack extension name, for a package that provides whole top-level directories. |
 | `description` | `string` | Stack extension description. |
 | `directories` | `string[]` | Which top-level directories a stack extension provides. |
@@ -61,11 +62,31 @@ paths.
 to fall back to, and registering every `.ts` file under a package's `routes/`
 directory would register whatever a package happened to leave there.
 
+### Components are opt-in
+
+Every other surface here has a conventional default. `components` deliberately
+does not, and a package contributes none unless it declares them:
+
+```json
+{ "stacks": { "components": ["resources/components"] } }
+```
+
+The others are namespaced at the point of use. A view is reached by its path, a
+model by its name, a migration by its filename, so a directory picked up by
+convention stays inert until something asks for it. A component is reached by
+bare tag name across every template the process renders, so implying
+`resources/components` would enrol any package that happens to have that
+directory into global tag resolution.
+
+Package components are **additive**. The framework's own components are
+searched first, so a package answers for a tag nothing else defines and cannot
+replace one the framework already provides.
+
 ### Declared but not yet read
 
-`PackageStacksMeta` also accepts `providers`, `components`, `commands` and
-`middleware`. Nothing consumes them yet. They are reserved rather than
-functional, and a package that sets one today gets no behaviour from it.
+`PackageStacksMeta` also accepts `providers`, `commands` and `middleware`.
+Nothing consumes them yet. They are reserved rather than functional, and a
+package that sets one today gets no behaviour from it.
 
 ## The manifest
 

--- a/storage/framework/core/actions/tests/stx-components-plugin.test.ts
+++ b/storage/framework/core/actions/tests/stx-components-plugin.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The shipped stx components plugin, and the precedence it encodes.
+ *
+ * stx searches a plugin's `components` list in order and takes the FIRST
+ * match, so this array is the precedence rule for every bare tag in every
+ * template the process renders. Verified against real stx resolution:
+ * a package-only component resolves from the package, and a component that
+ * exists in both the framework defaults and a package resolves from the
+ * framework.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const pluginFile = resolve(import.meta.dir, '../../../defaults/stx-components-plugin.ts')
+
+describe('the stx components plugin', () => {
+  test('offers a list, not a single directory', () => {
+    // A single string is what it used to be, and it is what stx accepts too -
+    // so this regresses silently rather than failing to compile.
+    const source = readFileSync(pluginFile, 'utf8')
+    expect(source).toContain('components: [')
+  })
+
+  test('puts the framework defaults ahead of any package', () => {
+    const source = readFileSync(pluginFile, 'utf8')
+
+    const defaults = source.indexOf(`'resources/components'`)
+    const packages = source.indexOf('...packageDirs()')
+
+    expect(defaults).toBeGreaterThan(-1)
+    expect(packages).toBeGreaterThan(-1)
+
+    // This ordering is the entire guarantee that an installed package is
+    // ADDITIVE: it answers for tags nothing else defines, and cannot replace
+    // a framework component that templates already render.
+    expect(defaults).toBeLessThan(packages)
+  })
+
+  test('survives package resolution failing', () => {
+    // stx wraps plugin loading in its own try/catch, so an exception raised
+    // while resolving package directories would drop the WHOLE plugin - and
+    // this plugin supplies the dashboard sidebar. The failure has to be
+    // contained here, degrading to "no package components".
+    const source = readFileSync(pluginFile, 'utf8')
+    const fn = source.slice(source.indexOf('function packageDirs'))
+
+    expect(fn.slice(0, fn.indexOf('}\n'))).toContain('try {')
+    expect(fn).toContain('return []')
+  })
+
+  test('loads, and reports directories that exist', async () => {
+    const plugin = (await import(pluginFile)).default
+
+    expect(plugin.name).toBe('@stacksjs/components')
+    expect(Array.isArray(plugin.components)).toBe(true)
+    // The library and the framework defaults, at minimum. Package entries
+    // depend on what is installed, so they are not asserted here.
+    expect(plugin.components.length).toBeGreaterThanOrEqual(2)
+    expect(plugin.components).toContain('resources/components')
+  })
+})

--- a/storage/framework/core/config/src/discovered-resources.ts
+++ b/storage/framework/core/config/src/discovered-resources.ts
@@ -28,14 +28,26 @@ interface DiscoveredEntry {
   root?: string
   views?: string | string[]
   migrations?: string | string[]
+  components?: string | string[]
 }
 
-/** Directories a package is taken to provide when it declares no explicit list. */
-const IMPLIED_DIRS = {
+/**
+ * Directories a package is taken to provide when it declares no explicit list.
+ *
+ * `components` is deliberately absent, which makes it the one opt-in surface.
+ * The others are namespaced at the point of use - a view is reached by its
+ * path, a model by its name, a migration by its filename - and a package
+ * contributing one it did not mean to is inert until something asks for it.
+ * Components are reached by BARE TAG NAME across every template in the process,
+ * so implying `resources/components` would enrol any package that happens to
+ * have that directory into global tag resolution. A package has to say
+ * `"components": [...]` and mean it.
+ */
+const IMPLIED_DIRS: Record<string, readonly string[] | undefined> = {
   views: ['resources/views'],
   models: ['app/Models'],
   migrations: ['database/migrations'],
-} as const
+}
 
 export interface PackageResourceOptions {
   manifestPath?: string
@@ -74,7 +86,7 @@ function readManifest(manifestPath: string): Record<string, DiscoveredEntry> {
  * shipping an optional subtree is not an error.
  */
 function resourceRoots(
-  field: 'views' | 'models' | 'migrations',
+  field: 'views' | 'models' | 'migrations' | 'components',
   options: PackageResourceOptions = {},
 ): PackageResourceRoot[] {
   const manifestPath = options.manifestPath ?? path.storagePath('framework/discovered-packages.json')
@@ -87,6 +99,8 @@ function resourceRoots(
     // Models have no manifest key of their own, so a package that ships them
     // is taken to put them where every Stacks application does. Views keep
     // their explicit key, which a package uses to ship more than one subtree.
+    // Components have no implied directory at all, so a package that does not
+    // declare them contributes none - see IMPLIED_DIRS.
     const declared = (meta as Record<string, unknown>)?.[field] ?? IMPLIED_DIRS[field]
     if (!declared)
       continue
@@ -131,6 +145,23 @@ function resourceRoots(
  */
 export function packageMigrationRoots(options: PackageResourceOptions = {}): PackageResourceRoot[] {
   return resourceRoots('migrations', options)
+}
+
+/**
+ * Component directories each discovered package contributes.
+ *
+ * Opt-in, unlike every other surface here: a package contributes components
+ * only by declaring `"components"` in its `stacks` key. Components resolve by
+ * bare tag name across every template in the process, so a directory picked up
+ * by convention would silently enter that namespace.
+ *
+ * The caller decides precedence. Placing these AFTER the framework's own
+ * component directories makes a package purely additive, which is what the
+ * shipped stx plugin does - stx searches its component list in order and takes
+ * the first match.
+ */
+export function packageComponentRoots(options: PackageResourceOptions = {}): PackageResourceRoot[] {
+  return resourceRoots('components', options)
 }
 
 /** View directories each discovered package contributes. */

--- a/storage/framework/core/config/src/index.ts
+++ b/storage/framework/core/config/src/index.ts
@@ -12,7 +12,7 @@ export * from './config'
 export { FRAMEWORK_DEFAULTS } from './defaults'
 export { validateConfig, reportConfigIssues, type ConfigValidationIssue } from './validators'
 export { feature, enableFeature, disableFeature, resetFeature, listFeatures } from './features'
-export { packageMigrationRoots, packageModelRoots, packageViewRoots, type PackageResourceOptions, type PackageResourceRoot } from './discovered-resources'
+export { packageComponentRoots, packageMigrationRoots, packageModelRoots, packageViewRoots, type PackageResourceOptions, type PackageResourceRoot } from './discovered-resources'
 export { resolveViewPatterns, type DefaultViewsSetting, type ViewPatternResolution } from './views'
 export {
   createRequestContext,

--- a/storage/framework/core/config/tests/discovered-views.test.ts
+++ b/storage/framework/core/config/tests/discovered-views.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, test } from 'bun:test'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { packageMigrationRoots, packageModelRoots, packageViewRoots } from '../src/discovered-resources'
+import { packageComponentRoots, packageMigrationRoots, packageModelRoots, packageViewRoots } from '../src/discovered-resources'
 import { resolveViewPatterns } from '../src/views'
 
 function project(): string {
@@ -290,6 +290,80 @@ describe('package migration roots', () => {
       const file = manifest(root, { table: { root: 'node_modules/table' } })
 
       expect(packageMigrationRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})
+
+
+/**
+ * Components are the one OPT-IN surface.
+ *
+ * Views, models and migrations are namespaced at the point of use: a view is
+ * reached by path, a model by name, a migration by filename, so a package
+ * contributing one it did not intend to is inert until something asks for it.
+ * A component is reached by BARE TAG NAME across every template in the
+ * process. Implying `resources/components` would enrol any package that
+ * happens to have that directory into global tag resolution.
+ */
+describe('package component roots', () => {
+  test('a package that declares components contributes them', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq/resources/components'), { recursive: true })
+      const file = manifest(root, {
+        loghq: { root: 'node_modules/loghq', components: ['resources/components'] },
+      })
+
+      expect(packageComponentRoots({ manifestPath: file, projectRoot: root }).map(r => r.dir))
+        .toEqual([join(root, 'node_modules/loghq/resources/components')])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('a package with a components directory it did NOT declare contributes nothing', () => {
+    const root = project()
+    try {
+      // The whole point. This directory exists and is conventionally named,
+      // and it still must not enter global tag resolution unasked.
+      mkdirSync(join(root, 'node_modules/table/resources/components'), { recursive: true })
+      const file = manifest(root, { table: { root: 'node_modules/table' } })
+
+      expect(packageComponentRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('views and migrations keep their implied directories', () => {
+    // Guards the asymmetry above: the opt-in rule is specific to components,
+    // and must not be generalised to the surfaces that rely on convention.
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq/resources/views'), { recursive: true })
+      mkdirSync(join(root, 'node_modules/loghq/database/migrations'), { recursive: true })
+      mkdirSync(join(root, 'node_modules/loghq/resources/components'), { recursive: true })
+      const file = manifest(root, { loghq: { root: 'node_modules/loghq' } })
+
+      const opts = { manifestPath: file, projectRoot: root }
+      expect(packageViewRoots(opts)).toHaveLength(1)
+      expect(packageMigrationRoots(opts)).toHaveLength(1)
+      expect(packageComponentRoots(opts)).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('refuses a declared path that escapes the package', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'resources/components'), { recursive: true })
+      mkdirSync(join(root, 'node_modules/loghq'), { recursive: true })
+      const file = manifest(root, {
+        loghq: { root: 'node_modules/loghq', components: ['../../resources/components'] },
+      })
+
+      // Otherwise a package could register the application's own components
+      // and, depending on search order, answer for its tags.
+      expect(packageComponentRoots({ manifestPath: file, projectRoot: root })).toEqual([])
     }
     finally { rmSync(root, { recursive: true, force: true }) }
   })

--- a/storage/framework/defaults/stx-components-plugin.ts
+++ b/storage/framework/defaults/stx-components-plugin.ts
@@ -19,7 +19,48 @@ const candidates = [
   join(process.cwd(), 'node_modules/@stacksjs/components/src/ui'),
 ].filter((dir): dir is string => Boolean(dir))
 
+const library = candidates.find(dir => existsSync(dir)) ?? candidates[candidates.length - 1]
+
+/**
+ * Component directories contributed by installed packages.
+ *
+ * Wrapped on its own rather than left to the plugin loader's catch. stx wraps
+ * plugin loading in `try { … } catch { console.warn(…) }`, so an exception
+ * raised here would drop the WHOLE plugin - and this plugin is what supplies
+ * the dashboard's sidebar. Degrading to "no package components" keeps the
+ * library and the framework defaults working.
+ *
+ * `@stacksjs/config` is imported for the resolution rather than re-implemented,
+ * because it carries the guard that refuses a path escaping the package.
+ */
+function packageDirs(): string[] {
+  try {
+    // eslint-disable-next-line ts/no-require-imports
+    const { packageComponentRoots } = require('@stacksjs/config')
+    return packageComponentRoots().map((root: { dir: string }) => root.dir)
+  }
+  catch {
+    return []
+  }
+}
+
 export default {
   name: '@stacksjs/components',
-  components: candidates.find(dir => existsSync(dir)) ?? candidates[candidates.length - 1],
+  /*
+   * Order is the precedence, because stx searches this list and takes the
+   * first match.
+   *
+   * The framework's own components are listed explicitly, ahead of any
+   * package's. They already resolve today through stx's fallback directory, so
+   * naming them here changes nothing on its own - what it does is put a floor
+   * under the package roots, making an installed package purely ADDITIVE. A
+   * package shipping its own `Button.stx` gets it used where nothing else
+   * defines `<Button />`, and cannot quietly replace the framework's.
+   */
+  components: [
+    library,
+    // Relative to this file, which is what stx resolves plugin entries against.
+    'resources/components',
+    ...packageDirs(),
+  ],
 }


### PR DESCRIPTION
The last surface. A package declaring `"components"` contributes its component directories to tag resolution, so `<LogTable />` from `loghq` renders in an application's own templates.

## No upstream stx change was needed

I claimed twice that this was blocked on adding `componentDirs?: string[]` to stx's `ServeOptions`. **That was wrong.** `node_modules/@stacksjs/stx/dist/plugin-system.d.ts:166` already declares:

```ts
/**
 * An array lets one package register several roots — @stacksjs/components
 * ships src/ui and src/components as siblings (#1823).
 */
components?: string | string[];
```

Entries resolve through `path.resolve(pluginDir, entry)`, and Stacks already ships `storage/framework/defaults/stx-components-plugin.ts` wired in through `config/ui.ts:32`. Nothing was blocked.

## Opt-in, unlike every other surface

| surface | default directory |
|---|---|
| views | `resources/views` |
| models | `app/Models` |
| migrations | `database/migrations` |
| **components** | **none - must be declared** |

Views, models and migrations are namespaced at the point of use: a view is reached by its path, a model by its name, a migration by its filename. One contributed unintentionally is inert until something asks for it.

A component is reached by **bare tag name in every template the process renders**. An implied `resources/components` would enrol any package that happens to have that directory into global tag resolution. So a package has to say `"components": [...]` and mean it. There is a test asserting that a package with an undeclared `resources/components/` contributes nothing, and another asserting views and migrations keep their implied directories, so the asymmetry cannot be "tidied up" later.

## Additive, never shadowing

The framework's own component directory is now named explicitly in the plugin list, ahead of the package roots. It already resolved through stx's fallback directory, so naming it changes nothing on its own; what it does is put a floor under the package roots.

**Verified against real stx resolution, not by reading types.** With a fake package shipping both a package-only `Zonly.stx` and a rival `Container.stx`:

```
Zonly      -> PACKAGE      <div class="zonly">package-only component</div>
Container  -> FRAMEWORK    <div data-stx-scope="stx_Container_1_…"> …
```

A package answers for a tag nothing else defines, and cannot replace one the framework already provides.

## Failure is contained

stx wraps plugin loading in `try { … } catch { console.warn(…) }`. An exception raised while resolving package directories would therefore drop the **whole plugin** - and this plugin is what supplies the dashboard's macOS-style sidebar. Package resolution is wrapped on its own and degrades to "no package components", leaving the library and framework defaults working. Pinned by a test.

## Verification

- `core/config`: **205 pass / 0 fail** (4 new)
- `core/actions`: **518 pass / 0 fail** (4 new)
- Cold-cache typecheck: 12 errors, same 12 as a clean tree, none in touched files
- `./buddy lint`: clean for these files
- Docs updated, no em-dashes

Builds on #2440, without which this would have worked in `buddy dev` and silently not in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)