### PR TITLE
feat(packages): let an installed package ship background jobs

### DIFF
--- a/docs/guide/package-discovery.md
+++ b/docs/guide/package-discovery.md
@@ -46,12 +46,15 @@ These are the fields the framework reads today.
 | `views` | `string \| string[]` | Template directories. Appended after the application's own, so nothing that already resolves changes. |
 | `migrations` | `string \| string[]` | SQL migration directories. Defaults to `database/migrations`. |
 | `components` | `string \| string[]` | stx component directories. **No default - must be declared.** |
+| `jobs` | `string \| string[]` | Background job directories. Defaults to `app/Jobs`. |
 | `name` | `string` | Stack extension name, for a package that provides whole top-level directories. |
 | `description` | `string` | Stack extension description. |
 | `directories` | `string[]` | Which top-level directories a stack extension provides. |
 
 **Models have no field.** A package that ships `app/Models` is found without
 declaring anything, because that is where every Stacks application puts them.
+Jobs work the same way through `app/Jobs`, and an application's own job of the
+same name keeps the name.
 
 `views` and `migrations` have defaults too, so a package that only ships views,
 migrations and models needs no more than `"stacks": {}`. Declaring them

--- a/storage/framework/core/config/src/discovered-resources.ts
+++ b/storage/framework/core/config/src/discovered-resources.ts
@@ -47,6 +47,7 @@ const IMPLIED_DIRS: Record<string, readonly string[] | undefined> = {
   views: ['resources/views'],
   models: ['app/Models'],
   migrations: ['database/migrations'],
+  jobs: ['app/Jobs'],
 }
 
 export interface PackageResourceOptions {
@@ -86,7 +87,7 @@ function readManifest(manifestPath: string): Record<string, DiscoveredEntry> {
  * shipping an optional subtree is not an error.
  */
 function resourceRoots(
-  field: 'views' | 'models' | 'migrations' | 'components',
+  field: 'views' | 'models' | 'migrations' | 'components' | 'jobs',
   options: PackageResourceOptions = {},
 ): PackageResourceRoot[] {
   const manifestPath = options.manifestPath ?? path.storagePath('framework/discovered-packages.json')
@@ -145,6 +146,18 @@ function resourceRoots(
  */
 export function packageMigrationRoots(options: PackageResourceOptions = {}): PackageResourceRoot[] {
   return resourceRoots('migrations', options)
+}
+
+/**
+ * Job directories each discovered package contributes.
+ *
+ * Conventional, like models, rather than opt-in like components. A job is
+ * reached by its exported name from the barrel and is inert until something
+ * dispatches or schedules it, so a package shipping `app/Jobs` it did not mean
+ * to publish costs a name in the barrel and nothing else.
+ */
+export function packageJobRoots(options: PackageResourceOptions = {}): PackageResourceRoot[] {
+  return resourceRoots('jobs', options)
 }
 
 /**

--- a/storage/framework/core/config/src/index.ts
+++ b/storage/framework/core/config/src/index.ts
@@ -12,7 +12,7 @@ export * from './config'
 export { FRAMEWORK_DEFAULTS } from './defaults'
 export { validateConfig, reportConfigIssues, type ConfigValidationIssue } from './validators'
 export { feature, enableFeature, disableFeature, resetFeature, listFeatures } from './features'
-export { packageComponentRoots, packageMigrationRoots, packageModelRoots, packageViewRoots, type PackageResourceOptions, type PackageResourceRoot } from './discovered-resources'
+export { packageComponentRoots, packageJobRoots, packageMigrationRoots, packageModelRoots, packageViewRoots, type PackageResourceOptions, type PackageResourceRoot } from './discovered-resources'
 export { resolveViewPatterns, type DefaultViewsSetting, type ViewPatternResolution } from './views'
 export {
   createRequestContext,

--- a/storage/framework/core/config/tests/discovered-views.test.ts
+++ b/storage/framework/core/config/tests/discovered-views.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, test } from 'bun:test'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { packageComponentRoots, packageMigrationRoots, packageModelRoots, packageViewRoots } from '../src/discovered-resources'
+import { packageComponentRoots, packageJobRoots, packageMigrationRoots, packageModelRoots, packageViewRoots } from '../src/discovered-resources'
 import { resolveViewPatterns } from '../src/views'
 
 function project(): string {
@@ -364,6 +364,46 @@ describe('package component roots', () => {
       // Otherwise a package could register the application's own components
       // and, depending on search order, answer for its tags.
       expect(packageComponentRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})
+
+
+describe('package job roots', () => {
+  test('a package that ships app/Jobs is found without declaring anything', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq/app/Jobs'), { recursive: true })
+      const file = manifest(root, { loghq: { root: 'node_modules/loghq' } })
+
+      // Conventional like models, not opt-in like components: a job is reached
+      // by name from the barrel and is inert until something dispatches it.
+      expect(packageJobRoots({ manifestPath: file, projectRoot: root }).map(r => r.dir))
+        .toEqual([join(root, 'node_modules/loghq/app/Jobs')])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('a package with no jobs contributes nothing', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/table/resources'), { recursive: true })
+      const file = manifest(root, { table: { root: 'node_modules/table' } })
+
+      expect(packageJobRoots({ manifestPath: file, projectRoot: root })).toEqual([])
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  test('honours an explicitly declared directory', () => {
+    const root = project()
+    try {
+      mkdirSync(join(root, 'node_modules/loghq/queue'), { recursive: true })
+      const file = manifest(root, { loghq: { root: 'node_modules/loghq', jobs: ['queue'] } })
+
+      expect(packageJobRoots({ manifestPath: file, projectRoot: root }).map(r => r.dir))
+        .toEqual([join(root, 'node_modules/loghq/queue')])
     }
     finally { rmSync(root, { recursive: true, force: true }) }
   })

--- a/storage/framework/core/server/src/imports.ts
+++ b/storage/framework/core/server/src/imports.ts
@@ -174,6 +174,26 @@ function packageModelDirs(): string[] {
 }
 
 /**
+ * The job directories that discovered packages contribute.
+ *
+ * Same shape and same failure rule as `packageModelDirs`: a boot that cannot
+ * read the manifest still has the application's own jobs, and refusing to
+ * build the barrel would take those away too.
+ */
+function packageJobDirs(): string[] {
+  try {
+    // eslint-disable-next-line ts/no-require-imports
+    const { packageJobRoots } = require('@stacksjs/config') as {
+      packageJobRoots: () => Array<{ package: string, dir: string }>
+    }
+    return packageJobRoots().map(root => root.dir)
+  }
+  catch {
+    return []
+  }
+}
+
+/**
  * Resolve the set of directories to scan for framework-default models.
  * Always returns the Models root itself (for top-level files), then includes
  * each opt-in subdir only if its gating config file exists in the project.
@@ -442,6 +462,7 @@ export function autoImportSourceDirs(): string[] {
     ...resolveDefaultModelDirs(),
     path.userJobsPath(),
     frameworkDefaultsDir('app/Jobs'),
+    ...packageJobDirs(),
     path.userControllersPath(),
     frameworkDefaultsDir('app/Controllers'),
     // The name registries. Left out, and the barrel that names an action or a
@@ -596,7 +617,7 @@ export async function generateAutoImportFiles(): Promise<void> {
   // `resolveJobFile` resolved every one of them - which made them unschedulable
   // by type and un-auto-imported at runtime, for no reason anyone chose.
   const jobsIndexPath = `${outputDir}/jobs.ts`
-  await generateDefineModelIndex(existingDirs([userJobsPath, frameworkDefaultsDir('app/Jobs')]), jobsIndexPath)
+  await generateDefineModelIndex(existingDirs([userJobsPath, frameworkDefaultsDir('app/Jobs'), ...packageJobDirs()]), jobsIndexPath)
 
   /*
    * Lazy indexes: the name-addressed registries.
@@ -761,8 +782,24 @@ export function initiateImports(): void {
     ...enabledSubdirs.flatMap(d => scanDefineModelExports(d)),
   ]
 
-  // Scan job definitions (default exports, same pattern as models)
-  const jobExports = scanDefineModelExports(userJobsPath)
+  // Scan job definitions (default exports, same pattern as models).
+  //
+  // Deduplicated first-wins, so an application's own job keeps the name when a
+  // package ships one called the same thing. Models were already deduped and
+  // jobs were not, which did not matter while jobs came from a single
+  // directory - two entries with the same `as` name produce a barrel that
+  // fails to load with "Cannot export a duplicate name", taking every job with
+  // it, not just the colliding one.
+  const seenJobs = new Set<string>()
+  const jobExports = [
+    ...scanDefineModelExports(userJobsPath),
+    ...packageJobDirs().flatMap(dir => scanDefineModelExports(dir)),
+  ].filter((exp) => {
+    if (seenJobs.has(exp.name))
+      return false
+    seenJobs.add(exp.name)
+    return true
+  })
 
   // Deduplicate: user models override framework models override defaults
   const seen = new Set<string>()


### PR DESCRIPTION
The last surface named in the pantry work. A package's `app/Jobs` now reaches the auto-import barrel and the generated declarations, so a job arriving with `bun add loghq` can be dispatched and scheduled like the application's own.

Three seams in `core/server/src/imports.ts`, mirroring what #2437 did for models: the staleness/scan directory list, the runtime barrel (`generateDefineModelIndex`), and the declarations scan.

## Conventional, not opt-in

| surface | default | why |
|---|---|---|
| models, jobs, views, migrations | yes | namespaced at point of use, inert until something asks |
| components | **no** | reached by bare tag name in every template rendered |

A job is reached by its exported name from the barrel and stays inert until something dispatches or schedules it, so a package shipping an `app/Jobs` it did not mean to publish costs a name in the barrel and nothing else. That is a different risk from #2441's components, which is why the two differ.

## A real bug this surfaced

**Jobs were never deduplicated.** Models are, immediately below:

```ts
const seen = new Set<string>()
const uniqueDefineModelExports = defineModelExports.filter(...)   // models
...
const jobImports = jobExports.map(...)                            // jobs, unfiltered
```

That was harmless while jobs came from a single directory. With a second source it is not: two entries carrying the same `as` name produce a barrel that fails to load with `Cannot export a duplicate name`, and **that takes every job down, not just the colliding one**. Now deduplicated first-wins, so an application's own job keeps the name when a package ships one called the same thing.

Worth admitting how this was found: I wrote a comment saying "the dedupe below is first-wins", then checked, and it was not true. The `seen` set immediately below is the models one and `jobExports` fed `jobImports` raw. The comment would have shipped as documentation of behaviour that did not exist.

## Also checked and deliberately NOT changed

`jobExports` scanned only `userJobsPath` while the barrel at `:620` scans user *and* framework defaults, and the comment above `:620` describes fixing exactly that asymmetry. It looked like the same bug left half-done, but the framework's nine jobs do appear in `server-auto-imports.d.ts` today, so there is no visible defect and I left it alone rather than change something I could not fully explain.

## Verification

- `core/server`: **178 pass / 0 fail**
- `core/config`: **25 pass / 0 fail** in the discovery suite (3 new)
- Cold-cache typecheck: 12 errors, same 12 as a clean tree, none in touched files
- `./buddy lint`: clean for these files
- Docs updated, no em-dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)