### PR TITLE
fix(server): inject auto-imports in the production API server

### DIFF
--- a/storage/framework/core/actions/src/serve/api.ts
+++ b/storage/framework/core/actions/src/serve/api.ts
@@ -92,6 +92,25 @@ route.use(corsMiddleware.toRouterHandler())
 // and one uninstalled since could abort the boot.
 await ensureDiscoveredPackages()
 
+// Put models, jobs and framework primitives on `globalThis` before any route
+// file is imported.
+//
+// Every other entry did this and the production API did not, so an app that
+// followed the documented pattern - `await User.find(1)` with no import, which
+// `server-auto-imports.d.ts` declares and so typechecks clean - worked under
+// `buddy dev` and threw `ReferenceError: User is not defined` once its action
+// was served here (stacksjs/stacks#2442). Framework default actions were
+// unaffected throughout, because they import their models explicitly.
+//
+// Before `importRoutes()` for the same reason discovery is: route files pull in
+// the actions that read these names at module-evaluation time.
+//
+// Safe to call unconditionally. It is idempotent, it collects failures and
+// warns rather than throwing, and it puts a per-package timeout on every import
+// so one slow module cannot hold up a boot.
+const { injectGlobalAutoImports } = await import('@stacksjs/server')
+await injectGlobalAutoImports()
+
 // Import routes
 await route.importRoutes()
 

--- a/storage/framework/core/actions/tests/package-discovery.test.ts
+++ b/storage/framework/core/actions/tests/package-discovery.test.ts
@@ -263,6 +263,23 @@ describe('discovery at boot', () => {
       .toBeLessThan(api.indexOf('route.importRoutes()'))
   })
 
+  test('the production API entry injects auto-imports, after discovery', () => {
+    const api = source('actions/src/serve/api.ts')
+
+    // Every other entry did this and the production API did not, so an app
+    // using the documented `await User.find(1)` global worked in `buddy dev`
+    // and threw ReferenceError once served here (stacksjs/stacks#2442).
+    expect(api).toContain('injectGlobalAutoImports()')
+
+    // Discovery first, matching `buddy dev`: the manifest feeds what the
+    // barrel is built from. Injection before importRoutes, because route files
+    // pull in actions that read these names at module-evaluation time.
+    expect(api.indexOf('ensureDiscoveredPackages()'))
+      .toBeLessThan(api.indexOf('injectGlobalAutoImports()'))
+    expect(api.indexOf('injectGlobalAutoImports()'))
+      .toBeLessThan(api.indexOf('route.importRoutes()'))
+  })
+
   test('the production views server discovers before it reads the manifest', () => {
     const server = source('buddy/src/production-server.ts')
 


### PR DESCRIPTION
Closes #2442.

`storage/framework/core/actions/src/serve/api.ts` never called `injectGlobalAutoImports()`. Every other entry does:

| entry | injects |
|---|---|
| `core/actions/src/dev/api.ts` | yes |
| `core/actions/src/dev/views.ts` | yes |
| `core/buddy/src/production-server.ts:230` | yes |
| `core/buddy/src/commands/seed.ts:43` | yes |
| **`core/actions/src/serve/api.ts`** | **no** |

## Framework code was never affected

Default actions import their models explicitly. `Actions/Auth/LoginAction.ts` uses `User` on line 41 and imports it from `@stacksjs/orm` on line 3, which is the convention `AGENTS.md` states for framework code. I checked this before writing the issue, because "login is broken in production" was the obvious conclusion and it was wrong.

## Userland was affected, in the worst possible shape

The documented contract, from `AGENTS.md`:

> All 97 models (`User`, `Product`, `Order`, ...), so `await User.find(1)` works with no import.

`server-auto-imports.d.ts:108` declares `const User: typeof import(...)`. So an app following the documented pattern **typechecks clean**, **works under `buddy dev`**, and throws `ReferenceError: User is not defined` once its action is served by the production API.

A failure that appears only in production, only in app code, while the type system asserts it is fine.

## Placement

```
ensureDiscoveredPackages()   <- discovery first, as in `buddy dev`
injectGlobalAutoImports()    <- then globals
route.importRoutes()         <- then route files, which pull in the actions
```

Discovery first matches `dev/api.ts`, where the manifest feeds what the barrel is built from. Injection before `importRoutes()` because route files pull in actions that read these names at module-evaluation time. Both orderings are pinned by tests.

## Why it is safe to call unconditionally

The open question in #2442 was whether the barrel reaches the box, since `preStart` builds this entry there. It does: `storage/framework/auto-imports/` is **tracked** (14 files), not generated on deploy. And the function itself:

- is idempotent (guard at `imports.ts:1152`)
- collects failures and warns rather than throwing: *"Non-fatal - framework parts the project doesn't install can be missing"*
- puts a 4s per-package timeout on every import, so one slow module cannot hold a boot

## Verification

- root suite: **406 pass / 0 fail**
- `core/actions`: **519 pass / 0 fail** (1 new ordering test)
- Cold-cache typecheck: 12 errors, same 12 as a clean tree, none in touched files
- `./buddy lint`: clean for these files

## Known remaining limit

This injects the barrel as built. A package installed *after* the barrel was last generated still needs a regeneration step for its models and jobs to appear as globals in production; the barrel is not rebuilt on the box. That is a separate concern from this entry never injecting at all, and is worth its own issue if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)