### PR TITLE
fix(generate): discover installed packages before regenerating barrels

### DIFF
--- a/.github/scripts/check-generated-barrels.ts
+++ b/.github/scripts/check-generated-barrels.ts
@@ -162,7 +162,9 @@ async function main(): Promise<void> {
   console.error('\nGenerated barrels do not match the source they describe:\n')
   for (const path of stale)
     console.error(`  ${path}`)
-  console.error('\nRun `buddy generate` and commit the result.\n')
+  console.error('\nRun `buddy generate` and commit the result.')
+  console.error('If a barrel is stale because a package was installed, `buddy generate`')
+  console.error('now discovers first, so it is still the right command.\n')
   process.exit(1)
 }
 

--- a/storage/framework/core/actions/src/generate/index.ts
+++ b/storage/framework/core/actions/src/generate/index.ts
@@ -62,6 +62,33 @@ export async function invoke(options?: GeneratorOptions): Promise<void> {
 async function generateEverything(options?: GeneratorOptions): Promise<void> {
   log.info('Generating types, entry points, component meta and the OpenAPI spec...')
 
+  /*
+   * Discover installed packages FIRST, because this command is the one place
+   * that could not see them.
+   *
+   * The auto-import barrels include the models and jobs a discovered package
+   * ships, read from the discovery manifest. Everywhere else that manifest is
+   * already current by the time generation runs: `buddy dev` discovers
+   * explicitly before it regenerates, and any command that goes through the
+   * preloader gets `discoverPackages()` on the way in.
+   *
+   * `generate` is a `fastCommand` (defaults/resources/plugins/preloader.ts),
+   * so it skips the preloader and got neither. That made it the only command
+   * whose regeneration was package-blind - and it is the command that
+   * `check-generated-barrels.ts` tells you to run when a barrel is stale, so
+   * the documented remedy could not fix a barrel that was stale for this
+   * reason. It could produce one: regenerating here dropped a package's jobs
+   * from `jobs.ts`, which CI then regenerated WITH, having discovered them.
+   */
+  try {
+    const { discoverPackages } = await import('../discover-packages')
+    await discoverPackages()
+  }
+  catch {
+    // An unreadable package tree is not a reason to refuse to regenerate the
+    // application's own artifacts, which is most of what this command does.
+  }
+
   // Types first: the name registries it refreshes are what the later
   // generators read, so the order is a dependency rather than a preference.
   await generateTypes({ ...options, types: true })

--- a/storage/framework/core/actions/tests/package-discovery.test.ts
+++ b/storage/framework/core/actions/tests/package-discovery.test.ts
@@ -291,6 +291,46 @@ describe('discovery at boot', () => {
       .toBeLessThan(server.indexOf('await injectGlobalAutoImports()'))
   })
 
+  test('buddy generate discovers before it regenerates the barrels', () => {
+    // `generate` is a fastCommand in the preloader, so it skips the
+    // preloader's discoverPackages() that every non-fast command gets. That
+    // made it the ONLY command whose regeneration was package-blind - and it
+    // is the command `check-generated-barrels.ts` tells you to run when a
+    // barrel is stale, so the documented remedy could not fix a barrel that
+    // was stale for this reason, only produce one.
+    const file = source('actions/src/generate/index.ts')
+
+    // Scoped to `generateEverything`'s own body: `generateTypes` is called
+    // from more than one function, and an unscoped search compares positions
+    // in unrelated code.
+    const start = file.indexOf('async function generateEverything')
+    expect(start).toBeGreaterThan(-1)
+    const body = file.slice(start, file.indexOf('\nasync function ', start + 1))
+
+    expect(body).toContain('await discoverPackages()')
+
+    // Before the generators, for the same reason `buddy dev` orders it that
+    // way: the manifest is what the barrels are built from.
+    expect(body.indexOf('await discoverPackages()'))
+      .toBeLessThan(body.indexOf('await generateTypes('))
+  })
+
+  test('generate is still a preloader fast command, which is why the above matters', () => {
+    // If `generate` ever leaves fastCommands it would get discovery from the
+    // preloader and the call above becomes redundant rather than load-bearing.
+    // Pinned so that change is a deliberate one and this comment gets revisited.
+    const preloader = readFileSync(
+      resolve(coreRoot, '../defaults/resources/plugins/preloader.ts'),
+      'utf8',
+    )
+    const fastCommands = preloader.slice(
+      preloader.indexOf('const fastCommands'),
+      preloader.indexOf(']', preloader.indexOf('const fastCommands')),
+    )
+
+    expect(fastCommands).toContain(`'generate'`)
+  })
+
   test('a failure warns instead of aborting the boot', async () => {
     // An application's own routes do not depend on discovery succeeding, and a
     // server that refuses to start because one dependency shipped an unreadable


### PR DESCRIPTION
`buddy generate` was the one command that could not see an installed package, and it is the command everything points you at.

## Why it was blind

- `generate` is a `fastCommand` (`defaults/resources/plugins/preloader.ts:33`), matched at `:45`, so it **skips the preloader**
- the preloader is what runs `discoverPackages()` for every other command (`preloader.ts:435`)
- `buddy dev` discovers explicitly (`dev/api.ts:52`)
- `generate/index.ts` had **zero** discovery calls

So every path to the barrels was package-aware except this one.

## The trap runs backwards from the obvious one

I reported this in #2445 under the assumption that CI has no manifest. **That was wrong**: CI invokes the check as `bun .github/scripts/check-generated-barrels.ts`, whose `argv.slice(2)` is empty, so `preloader.ts:45` does not skip and discovery *does* run there.

Which inverts the failure:

| | barrel contains package jobs? |
|---|---|
| developer runs `buddy generate` | **no** (skips preloader) |
| CI regenerates and compares | **yes** (preloader discovers) |

Result: red, with `check-generated-barrels.ts:165` printing *"Run `buddy generate` and commit the result"* - precisely the command that cannot produce the file CI wants.

This became reachable in #2443, which put `packageJobDirs()` into `jobs.ts`. That file is in `UNGATED_BARRELS`, whose own docstring promises its members are *"pure directory scans... a function of the source rather than of the machine"*. A manifest-dependent barrel is not, and `jobs.ts` was the first such member.

## Verified end to end, not by reading

With a real package installed that declares `stacks` and ships `app/Jobs`, running the same command on the same tree:

```
without this commit   0 occurrences in jobs.ts
with this commit      export { default as ProbeHqJob } from '../../../node_modules/probehq/app/Jobs/ProbeHqJob'
```

The probe package was removed and the tree restored afterwards.

## Nothing fires today

No installed package declares a top-level `stacks` object, so the manifest is `{"packages":{}}` and both paths produce identical bytes. This lands before that stops being true.

## Tests

- `buddy generate discovers before it regenerates the barrels` - scoped to `generateEverything`'s own body, since `generateTypes` is called from more than one function and an unscoped search compares positions in unrelated code
- `generate is still a preloader fast command, which is why the above matters` - if `generate` ever leaves `fastCommands` it gets discovery from the preloader and the new call becomes redundant rather than load-bearing; pinned so that change is deliberate

Confirmed red by removing the call.

## Verification

- `core/actions`: **521 pass / 0 fail**
- Cold-cache typecheck: **13 errors, and the clean-tree baseline is also 13** - main gained one from unrelated work today; this change adds none
- `./buddy lint`: clean for these files
- `check-generated-barrels.ts` cannot run locally (it refuses when `pantry/` and `node_modules` carry different versions); CI runs it

## Not this PR

#2445 itself - the committed barrel still is not regenerated on the deploy box. This makes the documented remedy actually work, which is a precondition for any fix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)