### PR TITLE
chore: regenerate the artifacts a 98th model made stale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Stacks resolves files from `app/` first and falls back to `storage/framework/def
 customize a framework default (e.g. a CMS action), create the same path under `app/`
 (`app/Actions/Cms/PostIndexAction.ts`) and it wins. New files you add under `app/` are available to
 the app (e.g. `app/Actions/MyAction.ts` is referenced as `'Actions/MyAction'` in routes). There are
-620 default actions and 97 built-in models you can use or override.
+620 default actions and 98 built-in models you can use or override.
 
 ---
 
@@ -190,7 +190,7 @@ module imported by that script must explicitly import every function, store,
 and type it uses; entry bindings do not leak into bundled module scope.
 
 **Server** (routes, `app/Actions/`, `app/Jobs/`, models) - injected into `globalThis`:
-- All 97 models (`User`, `Product`, `Order`, ...), so `await User.find(1)` works with no import.
+- All 98 models (`User`, `Product`, `Order`, ...), so `await User.find(1)` works with no import.
 - Everything exported from `app/Jobs/`, `app/Controllers/` and `resources/functions/`.
 
 Models only - **not** their `Model` / `Request` / `RequestModel` "variants". This used to

--- a/storage/framework/api/api-types.ts
+++ b/storage/framework/api/api-types.ts
@@ -14460,6 +14460,88 @@ export interface paths {
   }
     trace?: never
   }
+  "/api/personal-access-tokens": {
+    get: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      "200": { content: { "application/json": { "data": Array<{ "id": number; "name"?: string; "scopes"?: string; "revoked"?: boolean; "expires_at"?: string; "user_agent"?: string; "ip_address"?: string; "user_id"?: number; "created_at"?: string; "updated_at"?: string }> } } }
+      "422": { content: never }
+      "500": { content: never }
+    }
+  }
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/personal-access-tokens/bulk-delete": {
+    get?: never
+    put?: never
+    post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      "200": { content: { "application/json": Record<string, unknown> } }
+      "422": { content: never }
+      "500": { content: never }
+    }
+  }
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/personal-access-tokens/{id}": {
+    get: {
+    parameters: {
+      query?: never
+      header?: never
+      path: { "id": string }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      "200": { content: { "application/json": { "data": { "id": number; "name"?: string; "scopes"?: string; "revoked"?: boolean; "expires_at"?: string; "user_agent"?: string; "ip_address"?: string; "user_id"?: number; "created_at"?: string; "updated_at"?: string } } } }
+      "422": { content: never }
+      "500": { content: never }
+    }
+  }
+    put?: never
+    post?: never
+    delete: {
+    parameters: {
+      query?: never
+      header?: never
+      path: { "id": string }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      "200": { content: { "application/json": { "data": { "id": number; "name"?: string; "scopes"?: string; "revoked"?: boolean; "expires_at"?: string; "user_agent"?: string; "ip_address"?: string; "user_id"?: number; "created_at"?: string; "updated_at"?: string } } } }
+      "422": { content: never }
+      "500": { content: never }
+    }
+  }
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/pledges": {
     get: {
     parameters: {
@@ -22144,6 +22226,7 @@ export interface components {
     "Order": { "id": number; "uuid": string; "status"?: string; "total_amount"?: number; "currency"?: string; "tax_amount"?: number; "discount_amount"?: number; "delivery_fee"?: number; "tip_amount"?: number; "order_type"?: string; "delivery_address"?: string; "special_instructions"?: string; "estimated_delivery_time"?: string; "tracking_token"?: string; "delivery_latitude"?: number; "delivery_longitude"?: number; "applied_coupon_id"?: string; "customer_id"?: number; "coupon_id"?: number; "created_at"?: string; "updated_at"?: string }
     "Page": { "id": number; "uuid": string; "title": string; "slug"?: string; "path"?: string; "parent_id"?: number; "template": string; "blocks"?: unknown; "meta_description"?: string; "status"?: "draft" | "published" | "scheduled" | "archived"; "scheduled_at"?: unknown; "views"?: number; "published_at"?: unknown; "conversions"?: number; "author_id"?: number; "site_id"?: number; "created_at"?: string; "updated_at"?: string }
     "Payment": { "id": number; "uuid": string; "amount"?: number; "method"?: "cash" | "creditCard" | "debitCard" | "paypal" | "applePay" | "googlePay" | "bankTransfer" | "giftCard"; "status"?: "pending" | "processing" | "completed" | "failed" | "refunded" | "partiallyRefunded" | "succeeded"; "currency"?: string; "reference_number"?: string; "card_last_four"?: string; "card_brand"?: string; "billing_email"?: string; "transaction_id"?: string; "payment_provider"?: string; "refund_amount"?: number; "notes"?: string; "order_id"?: number; "customer_id"?: number; "created_at"?: string; "updated_at"?: string }
+    "PersonalAccessToken": { "id": number; "name"?: string; "scopes"?: string; "revoked"?: boolean; "expires_at"?: string; "user_agent"?: string; "ip_address"?: string; "user_id"?: number; "created_at"?: string; "updated_at"?: string }
     "Pledge": { "id": number; "uuid": string; "donor_name"?: string; "donor_email"?: string; "amount"?: number; "level"?: string; "status"?: "pending" | "confirmed" | "cancelled"; "auction_id"?: number; "customer_id"?: number; "created_at"?: string; "updated_at"?: string }
     "Post": { "id": number; "uuid": string; "title": string; "slug"?: string; "poster"?: string; "content": string; "excerpt"?: string; "focus_keyword"?: string; "meta_description"?: string; "canonical_url"?: string; "views"?: number; "published_at"?: unknown; "status": "published" | "draft" | "archived"; "is_featured"?: number; "author_id"?: number; "site_id"?: number; "created_at"?: string; "updated_at"?: string }
     "PrintDevice": { "id": number; "uuid": string; "name"?: string; "mac_address"?: string; "location"?: string; "terminal"?: string; "status"?: "online" | "offline" | "warning"; "last_ping"?: unknown; "print_count"?: number; "created_at"?: string; "updated_at"?: string }

--- a/storage/framework/api/client.ts
+++ b/storage/framework/api/client.ts
@@ -5427,6 +5427,34 @@ export function createClient(config: ClientConfig) {
   },
 
   /**
+   * GET /api/personal-access-tokens
+   */
+  getPersonalAccessTokens(options?: RequestOptions): Promise<ApiResult<{ "data": Array<{ "id": number; "name"?: string; "scopes"?: string; "revoked"?: boolean; "expires_at"?: string; "user_agent"?: string; "ip_address"?: string; "user_id"?: number; "created_at"?: string; "updated_at"?: string }> }>> {
+    return request(config, "GET", "/api/personal-access-tokens", {}, [], false, options)
+  },
+
+  /**
+   * POST /api/personal-access-tokens/bulk-delete
+   */
+  postPersonalAccessTokensBulkDelete(options?: RequestOptions): Promise<ApiResult<Record<string, unknown>>> {
+    return request(config, "POST", "/api/personal-access-tokens/bulk-delete", {}, [], false, options)
+  },
+
+  /**
+   * GET /api/personal-access-tokens/{id}
+   */
+  getPersonalAccessTokensId(input: { "id": string }, options?: RequestOptions): Promise<ApiResult<{ "data": { "id": number; "name"?: string; "scopes"?: string; "revoked"?: boolean; "expires_at"?: string; "user_agent"?: string; "ip_address"?: string; "user_id"?: number; "created_at"?: string; "updated_at"?: string } }>> {
+    return request(config, "GET", "/api/personal-access-tokens/{id}", input ?? {}, [], false, options)
+  },
+
+  /**
+   * DELETE /api/personal-access-tokens/{id}
+   */
+  deletePersonalAccessTokensId(input: { "id": string }, options?: RequestOptions): Promise<ApiResult<{ "data": { "id": number; "name"?: string; "scopes"?: string; "revoked"?: boolean; "expires_at"?: string; "user_agent"?: string; "ip_address"?: string; "user_id"?: number; "created_at"?: string; "updated_at"?: string } }>> {
+    return request(config, "DELETE", "/api/personal-access-tokens/{id}", input ?? {}, [], false, options)
+  },
+
+  /**
    * GET /api/pledges
    */
   getPledges(options?: RequestOptions): Promise<ApiResult<{ "data": Array<{ "id": number; "uuid": string; "donor_name"?: string; "donor_email"?: string; "amount"?: number; "level"?: string; "status"?: "pending" | "confirmed" | "cancelled"; "auction_id"?: number; "customer_id"?: number; "created_at"?: string; "updated_at"?: string }> }>> {

--- a/storage/framework/api/openapi.json
+++ b/storage/framework/api/openapi.json
@@ -39216,6 +39216,269 @@
         }
       }
     },
+    "/api/personal-access-tokens": {
+      "get": {
+        "summary": "/api/personal-access-tokens",
+        "operationId": "get__api_personal_access_tokens",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          "scopes": {
+                            "type": "string"
+                          },
+                          "revoked": {
+                            "type": "boolean"
+                          },
+                          "expires_at": {
+                            "type": "string"
+                          },
+                          "user_agent": {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          "ip_address": {
+                            "type": "string",
+                            "maxLength": 45
+                          },
+                          "user_id": {
+                            "type": "integer"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        },
+                        "required": [
+                          "id"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/personal-access-tokens/bulk-delete": {
+      "post": {
+        "summary": "/api/personal-access-tokens/bulk-delete",
+        "operationId": "post__api_personal_access_tokens_bulk_delete",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/personal-access-tokens/{id}": {
+      "delete": {
+        "summary": "/api/personal-access-tokens/{id}",
+        "operationId": "delete__api_personal_access_tokens__id_",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string",
+                          "maxLength": 255
+                        },
+                        "scopes": {
+                          "type": "string"
+                        },
+                        "revoked": {
+                          "type": "boolean"
+                        },
+                        "expires_at": {
+                          "type": "string"
+                        },
+                        "user_agent": {
+                          "type": "string",
+                          "maxLength": 255
+                        },
+                        "ip_address": {
+                          "type": "string",
+                          "maxLength": 45
+                        },
+                        "user_id": {
+                          "type": "integer"
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      },
+      "get": {
+        "summary": "/api/personal-access-tokens/{id}",
+        "operationId": "get__api_personal_access_tokens__id_",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string",
+                          "maxLength": 255
+                        },
+                        "scopes": {
+                          "type": "string"
+                        },
+                        "revoked": {
+                          "type": "boolean"
+                        },
+                        "expires_at": {
+                          "type": "string"
+                        },
+                        "user_agent": {
+                          "type": "string",
+                          "maxLength": 255
+                        },
+                        "ip_address": {
+                          "type": "string",
+                          "maxLength": 45
+                        },
+                        "user_id": {
+                          "type": "integer"
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation failed"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
     "/api/pledges": {
       "get": {
         "summary": "/api/pledges",
@@ -64678,6 +64941,49 @@
         "required": [
           "id",
           "uuid"
+        ]
+      },
+      "PersonalAccessToken": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "scopes": {
+            "type": "string"
+          },
+          "revoked": {
+            "type": "boolean"
+          },
+          "expires_at": {
+            "type": "string"
+          },
+          "user_agent": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "ip_address": {
+            "type": "string",
+            "maxLength": 45
+          },
+          "user_id": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id"
         ]
       },
       "Pledge": {

--- a/storage/framework/defaults/ai/skills/stacks-auto-imports/SKILL.md
+++ b/storage/framework/defaults/ai/skills/stacks-auto-imports/SKILL.md
@@ -66,7 +66,7 @@ globalThis.toggleDark = toggleDark
 - **Custom Functions**: From `resources/functions/` (counter, dark mode, GPX, geo utilities)
 
 ### Server Auto-Imports (100+)
-- **All ORM Models**: User, Post, Author, Product, Order, Payment, Customer, etc. (97 models)
+- **All ORM Models**: User, Post, Author, Product, Order, Payment, Customer, etc. (98 models)
 - **Request Models**: UserRequest, PostRequest, OrderRequest, etc.
 - **Actions**: Action types and helpers
 - **Schema**: validation schema builder

--- a/storage/framework/defaults/ai/skills/stacks-orm/SKILL.md
+++ b/storage/framework/defaults/ai/skills/stacks-orm/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Read Edit Write Bash Grep Glob
 ## Key Paths
 - Core ORM package: `storage/framework/core/orm/src/`
 - ORM implementation: `storage/framework/orm/`
-- Model definitions: `storage/framework/defaults/app/Models/` (97 models)
+- Model definitions: `storage/framework/defaults/app/Models/` (98 models)
 - Application models: `app/Models/`
 - Default model templates: `storage/framework/defaults/app/Models/`
 - ORM type globals: `storage/framework/types/orm-globals.d.ts`


### PR DESCRIPTION
`artifact-freshness` has been red on main since `62ee7bb923` added `PersonalAccessToken`, the 98th built-in model. Two of its steps fail, for the same underlying reason.

```
docs:agent-counts:check   AGENTS.md: says 97 built-in models, tree has 98   (x4 sites)
docs:artifacts:check      openapi.json / api-types.ts / client.ts are stale
```

Both are the mechanical regeneration their own failure messages ask for: `buddy docs:agent-counts` and `bun run docs:artifacts`.

## The API diff was audited, not assumed

Regenerating these locally has produced machine-specific diffs before, so I checked the shape rather than trusting the command:

- **417 lines added, 0 removed.** A pure addition is the expected shape for "a model was added"; any deletion would have meant drift from something else.
- **Exactly three new paths**, all the new model's: `/api/personal-access-tokens`, `/api/personal-access-tokens/{id}`, `/api/personal-access-tokens/bulk-delete`
- **Client additions are all its methods**: `getPersonalAccessTokens`, `getPersonalAccessTokensId`, `postPersonalAccessTokensBulkDelete`, `deletePersonalAccessTokensId`

Both checks pass afterwards: *"agent-facing counts are current (13 checked)"* and *"Generated API artifacts are current (714 paths)"*.

## CLAUDE.md is deliberately not in this diff

`buddy docs:agent-counts` rewrites it too, but it is generated from `defaults/ai/` by `buddy setup:ai` and is gitignored (`.gitignore:106`). `AGENTS.md` is the committed source of truth.

## Verification

- Cold-cache typecheck: **13 errors, and the clean-tree baseline is also 13** - none from this change
- `./buddy lint`: only the untracked `storage/framework/libs/entries/` artifact, which CI never sees

Not my change that broke this, and not blocking my own work either - #2471's own `Generated barrels are current` step passes. Fixing it because main should not stay red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)