### PR TITLE
fix(packages): rebuild a stale auto-import barrel at boot

### DIFF
--- a/storage/framework/core/actions/src/serve/api.ts
+++ b/storage/framework/core/actions/src/serve/api.ts
@@ -108,7 +108,38 @@ await ensureDiscoveredPackages()
 // Safe to call unconditionally. It is idempotent, it collects failures and
 // warns rather than throwing, and it puts a per-package timeout on every import
 // so one slow module cannot hold up a boot.
-const { injectGlobalAutoImports } = await import('@stacksjs/server')
+const { autoImportsAreStale, generateAutoImportFiles, injectGlobalAutoImports } = await import('@stacksjs/server')
+
+// Rebuild the barrels when the installed package set moved since they were
+// written (stacksjs/stacks#2445).
+//
+// `storage/framework/auto-imports/*.ts` is COMMITTED and nothing regenerates
+// it on the box, so a package added since the last `buddy generate` reached
+// production with its routes and migrations working and its models and jobs
+// missing from `globalThis` - silent until the first request touching one.
+//
+// `autoImportsAreStale()` compares the discovery manifest's mtime against the
+// barrel's. `deploy` is not a preloader fast command, so the manifest is
+// rewritten before the tarball is packed and tar preserves mtimes; on the box
+// the comparison is therefore true exactly when the package set moved. It also
+// covers restarts, rollbacks and a `bun add` performed on the server, none of
+// which a build-time step would catch.
+//
+// Declarations are deliberately not rewritten: `storage/framework/types declarations`
+// describes the tree for editors and `tsc`, nothing at runtime reads it, and a
+// release should not diverge from the commit it was built from.
+try {
+  if (autoImportsAreStale()) {
+    log.info('[Stacks API] Installed packages moved since the auto-import barrel was written; rebuilding it.')
+    await generateAutoImportFiles({ declarations: false })
+  }
+}
+catch (error) {
+  // Warn, never refuse to boot. A server that starts without one package's
+  // globals is better than one that does not start at all.
+  log.warn(`[Stacks API] Could not refresh the auto-import barrel: ${error instanceof Error ? error.message : String(error)}`)
+}
+
 await injectGlobalAutoImports()
 
 // Import routes

--- a/storage/framework/core/actions/tests/package-discovery.test.ts
+++ b/storage/framework/core/actions/tests/package-discovery.test.ts
@@ -331,6 +331,42 @@ describe('discovery at boot', () => {
     expect(fastCommands).toContain(`'generate'`)
   })
 
+  test('both production entries rebuild a stale barrel before injecting', () => {
+    // The barrels are COMMITTED and nothing regenerates them on the box, so a
+    // package added since the last `buddy generate` reached production with
+    // its routes working and its models and jobs missing from globalThis
+    // (stacksjs/stacks#2445).
+    for (const [label, rel] of [
+      ['api', 'actions/src/serve/api.ts'],
+      ['views', 'buddy/src/production-server.ts'],
+    ]) {
+      const text = source(rel)
+
+      expect(text).toContain('autoImportsAreStale()')
+      expect(text).toContain('generateAutoImportFiles({ declarations: false })')
+
+      // Rebuild before injecting, or the process injects the barrel it just
+      // decided was out of date.
+      expect(text.indexOf('autoImportsAreStale()'), label)
+        .toBeLessThan(text.indexOf('await injectGlobalAutoImports()'))
+
+      // And after discovery, since the manifest is the staleness signal.
+      expect(text.indexOf('ensureDiscoveredPackages()'), label)
+        .toBeLessThan(text.indexOf('autoImportsAreStale()'))
+    }
+  })
+
+  test('the box never rewrites the TypeScript declarations', () => {
+    // `storage/framework/types/*.d.ts` describes the tree for editors and
+    // `tsc`; nothing at runtime reads it. Rewriting it on a server makes the
+    // release differ from the commit it was built from, for no benefit.
+    for (const rel of ['actions/src/serve/api.ts', 'buddy/src/production-server.ts']) {
+      const text = source(rel)
+      expect(text).toContain('declarations: false')
+      expect(text).not.toContain('generateAutoImportFiles()')
+    }
+  })
+
   test('a failure warns instead of aborting the boot', async () => {
     // An application's own routes do not depend on discovery succeeding, and a
     // server that refuses to start because one dependency shipped an unreadable

--- a/storage/framework/core/buddy/src/production-server.ts
+++ b/storage/framework/core/buddy/src/production-server.ts
@@ -235,6 +235,21 @@ export async function startProductionServer(options?: { port?: string | number, 
   const { stxPageAuthMiddleware } = await import('@stacksjs/auth')
   const { enhanceRequest, loadMiddlewareHandlers } = await import('@stacksjs/router')
   const pageMiddleware = await loadMiddlewareHandlers()
+  // Rebuild the barrels when the installed package set moved since they were
+  // written (stacksjs/stacks#2445). Same guard as the API entry; see the
+  // comment there for why the manifest mtime is the right trigger. Warns
+  // rather than throws, and leaves `storage/framework/types declarations` alone.
+  try {
+    const { autoImportsAreStale, generateAutoImportFiles } = await import('@stacksjs/server')
+    if (autoImportsAreStale()) {
+      log.info('[server] Installed packages moved since the auto-import barrel was written; rebuilding it.')
+      await generateAutoImportFiles({ declarations: false })
+    }
+  }
+  catch (error) {
+    log.warn(`[server] Could not refresh the auto-import barrel: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
   await injectGlobalAutoImports()
 
       // Resolve the stx `serve` implementation.

--- a/storage/framework/core/server/src/imports.ts
+++ b/storage/framework/core/server/src/imports.ts
@@ -1,5 +1,5 @@
 import type { AutoImportsOptions } from 'bun-plugin-auto-imports'
-import { existsSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, renameSync, statSync, unlinkSync } from 'node:fs'
 import { dirname, relative, resolve as resolvePath } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { plugin } from 'bun'
@@ -180,6 +180,37 @@ function packageModelDirs(): string[] {
  * read the manifest still has the application's own jobs, and refusing to
  * build the barrel would take those away too.
  */
+/**
+ * Write a generated file so a reader never sees half of it.
+ *
+ * The barrels are read by `injectGlobalAutoImports()` at boot, and since
+ * stacksjs/stacks#2440 the production entries discover packages at boot too -
+ * so a regeneration can now overlap with a process starting up. A torn barrel
+ * is the worst failure this system has: nothing it exports is available, and
+ * the symptom is a template rendering empty rather than an error naming the
+ * file.
+ *
+ * `rename` within a directory is atomic, so a reader gets the old file or the
+ * new one. Mirrors what `discoverPackages()` already does for the manifest
+ * next door, for the same reason.
+ */
+async function writeGeneratedFile(outputPath: string, contents: string): Promise<void> {
+  const temp = `${outputPath}.${process.pid}.tmp`
+  try {
+    await Bun.write(temp, contents)
+    renameSync(temp, outputPath)
+  }
+  catch (error) {
+    try {
+      unlinkSync(temp)
+    }
+    catch {
+      // Already gone, or never created.
+    }
+    throw error
+  }
+}
+
 function packageJobDirs(): string[] {
   try {
     // eslint-disable-next-line ts/no-require-imports
@@ -336,7 +367,7 @@ async function generateDefineModelIndex(entries: ScanEntry[], outputPath: string
     }
   }
 
-  await Bun.write(outputPath, lines.join('\n') + '\n')
+  await writeGeneratedFile(outputPath, `${lines.join('\n')}\n`)
 }
 
 /**
@@ -445,7 +476,7 @@ async function generatePathIndex(
     '',
   ]
 
-  await Bun.write(outputPath, lines.join('\n'))
+  await writeGeneratedFile(outputPath, lines.join('\n'))
 }
 
 /**
@@ -557,7 +588,22 @@ export function autoImportsAreStale(): boolean {
  * This creates index files that can be imported to get all auto-imports,
  * including defineModel()-based model definitions and resource functions.
  */
-export async function generateAutoImportFiles(): Promise<void> {
+export interface GenerateAutoImportOptions {
+  /**
+   * Also rewrite the TypeScript declarations. Default true.
+   *
+   * A deployed server regenerates the barrels at boot when an installed
+   * package moved (stacksjs/stacks#2445), and it must not touch
+   * `storage/framework/types declarations` while doing it. Those describe the tree
+   * for editors and `tsc`, nothing at runtime reads them, and rewriting them
+   * on the box makes the release differ from the commit it was built from for
+   * no benefit. `invalidateTypeScriptBuildInfo()` is skipped with them, since
+   * there is no TypeScript build on a server.
+   */
+  declarations?: boolean
+}
+
+export async function generateAutoImportFiles(options: GenerateAutoImportOptions = {}): Promise<void> {
   const userFunctionsPath = path.resourcesPath('functions')
   // Framework-default functions (e.g. defaults/functions/commerce/coupons.ts →
   // useCoupons) are also auto-importable so dashboard pages can call them
@@ -675,7 +721,7 @@ export * from './models'
 export * from './jobs'
 export * from './controllers'
 `
-  await Bun.write(`${outputDir}/index.ts`, combinedContent)
+  await writeGeneratedFile(`${outputDir}/index.ts`, combinedContent)
 
   // Generate globals injection script
   const globalsPath = `${outputDir}/globals.ts`
@@ -691,19 +737,21 @@ export * from './controllers'
    * - which is exactly how it came to describe a different set than the one
    * that gets injected.
    */
-  await generateServerAutoImportTypes()
+  if (options.declarations !== false) {
+    await generateServerAutoImportTypes()
 
-  // The browser declaration is pruned rather than written: which names are
-  // ambient in a template is the stx plugin's decision, and it does not export
-  // that list. What can be established here is that a declared name resolves.
-  const pruned = await pruneBrowserAutoImportTypes()
-  if (pruned.length > 0)
-    log.debug(`[auto-imports] dropped ${pruned.length} browser globals that resolve to nothing`)
+    // The browser declaration is pruned rather than written: which names are
+    // ambient in a template is the stx plugin's decision, and it does not export
+    // that list. What can be established here is that a declared name resolves.
+    const pruned = await pruneBrowserAutoImportTypes()
+    if (pruned.length > 0)
+      log.debug(`[auto-imports] dropped ${pruned.length} browser globals that resolve to nothing`)
 
-  // Everything above rewrote inputs that other TypeScript projects compile
-  // against, so any incremental state describing them is now a description of
-  // files that no longer exist.
-  await invalidateTypeScriptBuildInfo()
+    // Everything above rewrote inputs that other TypeScript projects compile
+    // against, so any incremental state describing them is now a description of
+    // files that no longer exist.
+    await invalidateTypeScriptBuildInfo()
+  }
 
   log.debug('Auto-import files generated successfully')
 }
@@ -936,7 +984,7 @@ export async function generateServerAutoImportTypes(): Promise<void> {
   }
 
   lines.push('}', '')
-  await Bun.write(outputPath, lines.join('\n'))
+  await writeGeneratedFile(outputPath, lines.join('\n'))
 
   /*
    * The eslint globals manifest, from the same filtered list.


### PR DESCRIPTION
Closes #2445.

The auto-import barrels are **committed**, and nothing regenerated them on the box - the API site's `preStart` is `bun install`, `mkdir`, `bun build`, with no generate step (`config/cloud.ts:827-835`). So a package installed since someone last ran `buddy generate` reached production with its routes, views and migrations working and its **models and jobs missing from `globalThis`**, silent until the first request that touched one.

## The trigger already existed

`autoImportsAreStale()` (`imports.ts:515`) already compared the discovery manifest's mtime, with a comment explaining that package managers preserve tarball mtimes so nothing else would trip it. It had exactly one caller: the dev server.

It is the right signal for the deploy case. `deploy` is not a preloader fast command, so the manifest is rewritten before the tarball is packed (`deploy.ts:2850`), and tar preserves mtimes - on the box the comparison is true precisely when the package set moved. It also covers restarts, rollbacks and a `bun add` performed on the server, none of which a `preStart` step would reach.

Both entries now rebuild before injecting, after discovering:

```
ensureDiscoveredPackages()  ->  autoImportsAreStale()  ->  generateAutoImportFiles({declarations:false})  ->  injectGlobalAutoImports()
```

Pinned by tests in both files, since rebuilding *after* injecting would inject the barrel it had just decided was out of date.

## Two prerequisites, both included

**The box must not rewrite declarations.** `generateAutoImportFiles` now takes `{ declarations?: boolean }`, gating `generateServerAutoImportTypes`, the browser prune, and `invalidateTypeScriptBuildInfo`. Nothing at runtime reads the types tree, and a release should not diverge from the commit it was built from. There is no TypeScript build on a server to invalidate.

**Barrel writes are now atomic.** They were a bare `await Bun.write(outputPath, …)`. Boot-time regeneration puts a writer next to a reader for the first time, and a torn barrel is the worst failure this system has: nothing it exports is available, and it presents as a template rendering empty rather than an error naming the file. Now temp-file-plus-rename, mirroring what `discoverPackages()` already does for the manifest next door.

## Verified against a real package

Installed one shipping `app/Jobs` after the barrel was written:

```
barrel BEFORE contains GuardHqJob: 0
autoImportsAreStale() -> true
barrel AFTER  contains GuardHqJob: 1
storage/framework/types/ -> untouched
```

## A trap worth recording

`stx-source.test.ts` strips block comments before asserting on the code, and my first draft of the comment wrote the types path as a glob - which contains the two characters that open a block comment. The strip then swallowed a chunk of `production-server.ts`, failing an unrelated test about stx resolution. Reworded rather than escaped. Prose in these files can break source-pinning tests.

## Verification

- `core/actions`: **523 pass / 0 fail** (2 new)
- `core/server`: **178 pass / 0 fail**
- `core/buddy`: **828 pass / 3 fail** - the 3 are the known dist-only `package manifests` checks, identical on a clean tree
- root suite: **406 pass / 0 fail**
- Cold-cache typecheck: 13 errors, same as the clean-tree baseline, none in touched files
- `./buddy lint`: clean for these files

## Remaining limit

`main` and `api` get separate `/var/www/<slug>-<site>` trees (`deploy.ts:1228-1238`), so this has one writer per tree and the two systemd units cannot race each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)