### PR TITLE
fix(bench): retain and validate every routing measurement sample

### DIFF
--- a/bench/routing/README.md
+++ b/bench/routing/README.md
@@ -137,6 +137,20 @@ all repeats, return valid measurements without request errors, include a server
 CPU reading, retain a complete and stable parity fingerprint for every repeat,
 and stay within the 10% throughput stability range.
 
+Every repeat is validated individually, not just the aggregate row. A median
+can hide one invalid latency, and a repeat that served no requests used to
+contribute a zero error rate to the mean. Each repeat is retained with the CPU
+reading taken during it and its run ordinal, so an issue names the run whose
+raw output should be read.
+
+Missing evidence stays missing. A latency percentile the load tool did not
+report is `null` rather than `0`, and the report renders it as `-`. An
+aggregate is `null` unless every repeat measured it. `measurements.json`
+carries `schemaVersion: 2` to mark these rules: `errorRate` is pooled errors
+over pooled requests rather than the mean of per-repeat rates, `cpuPercent`
+requires every repeat to have reported one, and `runs` counts the repeats
+retained rather than the number requested.
+
 Use the Bun version requested by `package.json`'s `engines.bun` for the baseline.
 The runner records that requirement beside the actual runtime version and warns
 when they differ. Alternate runtimes are allowed for explicit runtime comparisons:

--- a/bench/routing/drivers.test.ts
+++ b/bench/routing/drivers.test.ts
@@ -135,3 +135,83 @@ describe('autocannon load isolation', () => {
     }
   })
 })
+
+/**
+ * A percentile the tool did not report must stay absent (stacksjs/stacks#2470).
+ *
+ * The oha adapter used `?? 0`, so a missing p99 became 0 ms - the best
+ * possible latency - and every downstream check passed it. The fixture in the
+ * request-counting tests above omits `latencyPercentiles` entirely, which is
+ * exactly why the substitution went unnoticed for so long.
+ *
+ * The key path and units here were taken from real captured oha output
+ * (routing diagnostic run 34196555986): `latencyPercentiles` holds seconds,
+ * so 0.000407146 is 0.407 ms.
+ */
+describe('latency percentiles preserve absence', () => {
+  const runOha = async (json: unknown) => {
+    const spawn = spyOn(Bun, 'spawn').mockReturnValue({
+      stdout: new Response(JSON.stringify(json)).body,
+      stderr: new Response('').body,
+      exited: Promise.resolve(0),
+    } as unknown as ReturnType<typeof Bun.spawn>)
+    try {
+      const driver = DRIVERS.find(d => d.name === 'oha')!
+      return await driver.run({
+        url: 'http://127.0.0.1:39400/bench/json',
+        method: 'GET',
+        headers: {},
+        connections: 8,
+        warmupSeconds: 0,
+        durationSeconds: 1,
+      })
+    }
+    finally {
+      spawn.mockRestore()
+    }
+  }
+
+  const base = {
+    summary: { requestsPerSec: 100 },
+    statusCodeDistribution: { 200: 100 },
+  }
+
+  it('converts real oha seconds into milliseconds', async () => {
+    const result = await runOha({
+      ...base,
+      latencyPercentiles: { p50: 0.000407146, p90: 0.00050315, p99: 0.00076389 },
+    })
+
+    expect(result.latencyMs.p50).toBeCloseTo(0.407146, 6)
+    expect(result.latencyMs.p90).toBeCloseTo(0.50315, 6)
+    expect(result.latencyMs.p99).toBeCloseTo(0.76389, 6)
+  })
+
+  it('reports an absent percentile as null, never as zero latency', async () => {
+    const result = await runOha({ ...base, latencyPercentiles: { p50: 0.0004, p90: 0.0005 } })
+
+    expect(result.latencyMs.p50).toBeCloseTo(0.4, 6)
+    expect(result.latencyMs.p99).toBeNull()
+  })
+
+  it('reports an explicitly null percentile as null', async () => {
+    const result = await runOha({ ...base, latencyPercentiles: { p50: null, p90: null, p99: null } })
+
+    expect(result.latencyMs).toEqual({ p50: null, p90: null, p99: null })
+  })
+
+  it('reports a missing percentile block as null rather than three zeroes', async () => {
+    const result = await runOha(base)
+
+    expect(result.latencyMs).toEqual({ p50: null, p90: null, p99: null })
+  })
+
+  it('rejects a non-numeric percentile instead of producing NaN', async () => {
+    // `'fast' * 1000` is NaN, which is finite-checked nowhere upstream and
+    // renders as NaN in the report.
+    const result = await runOha({ ...base, latencyPercentiles: { p50: 'fast', p90: 0.0005, p99: 0.0007 } })
+
+    expect(result.latencyMs.p50).toBeNull()
+    expect(result.latencyMs.p90).toBeCloseTo(0.5, 6)
+  })
+})

--- a/bench/routing/drivers.ts
+++ b/bench/routing/drivers.ts
@@ -31,12 +31,25 @@ export interface LoadRequest {
   requestRate?: number
 }
 
+/**
+ * Latency percentiles, where a percentile the tool did not report is `null`.
+ *
+ * Never `0`. A tool that omits `p99` is saying it has no evidence, and zero is
+ * the best possible latency - so coercing one to the other turns missing
+ * evidence into a perfect result, which then passes every downstream check.
+ */
+export interface LatencyPercentiles {
+  p50: number | null
+  p90: number | null
+  p99: number | null
+}
+
 export interface LoadResult {
   /** Requests per second over the measured window. */
   rpsMean: number
   /** Median of the per-second request counts. `null` when the tool omits it. */
   rpsP50: number | null
-  latencyMs: { p50: number, p90: number, p99: number }
+  latencyMs: LatencyPercentiles
   requests: number
   errors: number
   /** Raw stdout from the tool, committed alongside the report. */
@@ -113,6 +126,17 @@ function methodArgs(req: LoadRequest, methodFlag: string, bodyFlag: string, head
   return args
 }
 
+/*
+ * Unit converters that preserve absence.
+ *
+ * Each returns `null` for anything that is not a finite number, so a tool that
+ * omits a percentile, reports it as null, or emits a string is recorded as
+ * "not measured" rather than as zero latency or as NaN.
+ */
+const millis = (value: unknown): number | null => typeof value === 'number' && Number.isFinite(value) ? value : null
+const seconds = (value: unknown): number | null => typeof value === 'number' && Number.isFinite(value) ? value * 1000 : null
+const micros = (value: unknown): number | null => typeof value === 'number' && Number.isFinite(value) ? value / 1000 : null
+
 /** `oha` — the preferred tool. Percentiles come straight out of its JSON. */
 const oha: Driver = {
   name: 'oha',
@@ -140,9 +164,9 @@ const oha: Driver = {
       rpsMean: json.summary.requestsPerSec,
       rpsP50: json.rps?.percentiles?.['p50'] ?? null,
       latencyMs: {
-        p50: (json.latencyPercentiles?.p50 ?? 0) * 1000,
-        p90: (json.latencyPercentiles?.p90 ?? 0) * 1000,
-        p99: (json.latencyPercentiles?.p99 ?? 0) * 1000,
+        p50: seconds(json.latencyPercentiles?.p50),
+        p90: seconds(json.latencyPercentiles?.p90),
+        p99: seconds(json.latencyPercentiles?.p99),
       },
       // Failed connections have no status code, but still belong in the
       // denominator. Otherwise a wholly failed run can report 0% errors.
@@ -173,9 +197,9 @@ const bombardier: Driver = {
       rpsMean: r.rps?.mean ?? 0,
       rpsP50: r.rps?.percentiles?.['50'] ?? null,
       latencyMs: {
-        p50: (pct['50'] ?? 0) / 1000,
-        p90: (pct['90'] ?? 0) / 1000,
-        p99: (pct['99'] ?? 0) / 1000,
+        p50: micros(pct['50']),
+        p90: micros(pct['90']),
+        p99: micros(pct['99']),
       },
       requests: ok + bad,
       errors: bad,
@@ -206,9 +230,9 @@ const autocannon: Driver = {
       rpsMean: json.requests?.average ?? 0,
       rpsP50: json.requests?.p50 ?? null,
       latencyMs: {
-        p50: json.latency?.p50 ?? 0,
-        p90: json.latency?.p90 ?? 0,
-        p99: json.latency?.p99 ?? 0,
+        p50: millis(json.latency?.p50),
+        p90: millis(json.latency?.p90),
+        p99: millis(json.latency?.p99),
       },
       // Autocannon's total counts HTTP responses only. Its errors already
       // include timeouts, so add that count once to include failed attempts.
@@ -255,7 +279,7 @@ const builtin: Driver = {
 
     const latencies: number[] = results.flatMap(r => r.samples as number[])
     latencies.sort((a, b) => a - b)
-    const pick = (q: number) => latencies.length === 0 ? 0 : latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * q))]!
+    const pick = (q: number) => latencies.length === 0 ? null : latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * q))]!
 
     const seconds = Math.max(...results.map(r => (r.perSecond as number[]).length))
     const perSecond = Array.from({ length: seconds }, (_, i) =>

--- a/bench/routing/publication.test.ts
+++ b/bench/routing/publication.test.ts
@@ -159,3 +159,116 @@ describe('routing benchmark publication profile', () => {
     )).toContain('stacks:static-json did not retain 3 required parity check(s)')
   })
 })
+
+/**
+ * Missing evidence must not become a valid aggregate (stacksjs/stacks#2470).
+ *
+ * The three holes were: the oha adapter substituting 0 for an absent latency
+ * percentile, the runner dropping null CPU readings before taking a median,
+ * and publication validating only the aggregate row. Each is covered here
+ * against a row that would otherwise look publishable.
+ */
+describe('per-repeat publication gating', () => {
+  const target = [{ id: 'stacks' }]
+  const scenario = [{ id: 'static-json' }]
+
+  /** A row that passes every aggregate check, so only the repeats can fail. */
+  const row = (over = {}) => ({
+    targetId: 'stacks',
+    scenarioId: 'static-json',
+    rpsMean: 100,
+    rpsP50: 99,
+    latencyMs: { p50: 1, p90: 2, p99: 3 },
+    errorRate: 0,
+    cpuPercent: 98,
+    spread: { min: 98, max: 102 },
+    rangeRatio: 0.04,
+    runs: 3,
+    ...over,
+  })
+
+  const repeat = (run: number, over = {}) => ({
+    targetId: 'stacks',
+    scenarioId: 'static-json',
+    run,
+    rpsMean: 100,
+    rpsP50: 99,
+    latencyMs: { p50: 1, p90: 2, p99: 3 },
+    requests: 1000,
+    errors: 0,
+    cpuPercent: 98,
+    rawBytes: 512,
+    ...over,
+  })
+
+  const check = (rows: unknown[], repeats: unknown[]) =>
+    routingMeasurementPublicationIssues(
+      target as never,
+      scenario as never,
+      rows as never,
+      3,
+      parityChecks('stacks', 'static-json'),
+      repeats as never,
+    )
+
+  it('accepts three complete valid repeats', () => {
+    expect(check([row()], [repeat(1), repeat(2), repeat(3)])).toEqual([])
+  })
+
+  it('rejects a repeat with no CPU reading, which the aggregate hides', () => {
+    // The aggregate row still carries a CPU number, because the old runner
+    // medianed the readings it had. The repeat is the only place the gap shows.
+    expect(check([row()], [repeat(1), repeat(2, { cpuPercent: null }), repeat(3)]))
+      .toContain('stacks:static-json run 2 has no valid server CPU reading')
+  })
+
+  it('rejects a repeat with an absent latency percentile', () => {
+    expect(check([row()], [repeat(1, { latencyMs: { p50: 1, p90: 2, p99: null } }), repeat(2), repeat(3)]))
+      .toContain('stacks:static-json run 1 is missing a latency percentile')
+  })
+
+  it('rejects a repeat that served no requests', () => {
+    // This is the one that used to contribute a free 0% error rate.
+    expect(check([row()], [repeat(1), repeat(2), repeat(3, { requests: 0 })]))
+      .toContain('stacks:static-json run 3 recorded no requests')
+  })
+
+  it('rejects a repeat whose raw output was not preserved', () => {
+    expect(check([row()], [repeat(1, { rawBytes: 0 }), repeat(2), repeat(3)]))
+      .toContain('stacks:static-json run 1 preserved no raw output')
+  })
+
+  it('rejects a malformed throughput measurement in one repeat', () => {
+    expect(check([row()], [repeat(1), repeat(2, { rpsMean: Number.NaN }), repeat(3)]))
+      .toContain('stacks:static-json run 2 has an invalid throughput measurement')
+  })
+
+  it('rejects more errors than requests', () => {
+    expect(check([row()], [repeat(1, { requests: 10, errors: 11 }), repeat(2), repeat(3)]))
+      .toContain('stacks:static-json run 1 has an invalid error count')
+  })
+
+  it('requires complete unique run identities', () => {
+    // Two repeats both claiming run 1 is two measurements of one scheduled
+    // run, or one measurement counted twice. Either way the set is not three.
+    expect(check([row()], [repeat(1), repeat(1), repeat(3)]))
+      .toContain('stacks:static-json did not retain 3 identified repeat(s)')
+    expect(check([row()], [repeat(1), repeat(2)]))
+      .toContain('stacks:static-json did not retain 3 identified repeat(s)')
+    expect(check([row()], [repeat(1), repeat(2), repeat(4)]))
+      .toContain('stacks:static-json did not retain 3 identified repeat(s)')
+  })
+
+  it('names a null aggregate rather than treating it as zero', () => {
+    expect(check([row({ errorRate: null })], [repeat(1), repeat(2), repeat(3)]))
+      .toContain('stacks:static-json recorded no requests, so it has no error rate')
+    expect(check([row({ latencyMs: { p50: 1, p90: null, p99: 3 } })], [repeat(1), repeat(2), repeat(3)]))
+      .toContain('stacks:static-json is missing a latency percentile')
+  })
+
+  it('stays backward compatible when no repeats are supplied', () => {
+    // The argument is optional so the existing call sites and tests keep
+    // working; supplying none means the aggregate checks alone apply.
+    expect(check([row()], [])).toEqual([])
+  })
+})

--- a/bench/routing/publication.ts
+++ b/bench/routing/publication.ts
@@ -1,5 +1,5 @@
 import type { BusyProcess } from './host-load'
-import type { Measurement } from './report'
+import type { Measurement, RoutingRepeat } from './report'
 import type { RuntimeRequirement } from './runtime-version'
 import type { ScenarioParityEvidence } from './runtime'
 import type { SourceState } from './source'
@@ -101,6 +101,7 @@ export function routingMeasurementPublicationIssues(
   measurements: Measurement[],
   expectedRuns: number,
   parityChecks: RoutingParityCheck[],
+  repeats: RoutingRepeat[] = [],
 ): string[] {
   const issues: string[] = []
   for (const target of targets) {
@@ -122,16 +123,62 @@ export function routingMeasurementPublicationIssues(
         || (row.rpsP50 != null && (!Number.isFinite(row.rpsP50) || row.rpsP50 < 0))
         || !Number.isFinite(row.spread.min) || row.spread.min <= 0
         || !Number.isFinite(row.spread.max) || row.spread.max < row.spread.min
-        || !Object.values(row.latencyMs).every(value => Number.isFinite(value) && value >= 0)
-        || !Number.isFinite(row.errorRate) || row.errorRate < 0 || row.errorRate > 1
+        || !Object.values(row.latencyMs).every(value => value == null || (Number.isFinite(value) && value >= 0))
+        || (row.errorRate != null && (!Number.isFinite(row.errorRate) || row.errorRate < 0 || row.errorRate > 1))
         || (row.rangeRatio != null && (!Number.isFinite(row.rangeRatio) || row.rangeRatio < 0)))
         issues.push(`${key} contains an invalid measurement`)
-      if (row.errorRate > 0)
+      // Distinguished from "no errors". A row with no requests has no error
+      // rate to report, and reading that as 0% is how a wholly failed run
+      // passed the gate.
+      if (row.errorRate == null)
+        issues.push(`${key} recorded no requests, so it has no error rate`)
+      else if (row.errorRate > 0)
         issues.push(`${key} recorded request errors`)
+      if (Object.values(row.latencyMs).some(value => value == null))
+        issues.push(`${key} is missing a latency percentile`)
       if (row.cpuPercent == null || !Number.isFinite(row.cpuPercent) || row.cpuPercent < 0)
         issues.push(`${key} has no valid server CPU reading`)
       if (measurementRange(row) > MAX_STABLE_RANGE)
         issues.push(`${key} exceeded the 10% throughput stability range`)
+
+      /*
+       * Every repeat, not just the aggregate.
+       *
+       * A median hides an individual invalid latency, and a repeat that served
+       * no requests used to contribute a zero error rate to the mean. The run
+       * ordinal is named so the raw output for the offending repeat can be
+       * found on disk (stacksjs/stacks#2470).
+       */
+      const runs = repeats.filter(r => r.targetId === target.id && r.scenarioId === scenario.id)
+      if (repeats.length > 0) {
+        // Same completeness predicate the parity checks below already use:
+        // the right count, no duplicates, and every ordinal in range.
+        const completeRepeats = runs.length === expectedRuns
+          && new Set(runs.map(r => r.run)).size === expectedRuns
+          && runs.every(r => Number.isSafeInteger(r.run) && r.run >= 1 && r.run <= expectedRuns)
+        if (!completeRepeats) {
+          issues.push(`${key} did not retain ${expectedRuns} identified repeat(s)`)
+        }
+        else {
+          for (const repeat of runs) {
+            const at = `${key} run ${repeat.run}`
+            if (!Number.isFinite(repeat.rpsMean) || repeat.rpsMean <= 0)
+              issues.push(`${at} has an invalid throughput measurement`)
+            if (Object.values(repeat.latencyMs).some(value => value == null || !Number.isFinite(value) || value < 0))
+              issues.push(`${at} is missing a latency percentile`)
+            if (repeat.cpuPercent == null || !Number.isFinite(repeat.cpuPercent) || repeat.cpuPercent < 0)
+              issues.push(`${at} has no valid server CPU reading`)
+            if (!Number.isSafeInteger(repeat.requests) || repeat.requests <= 0)
+              issues.push(`${at} recorded no requests`)
+            if (!Number.isSafeInteger(repeat.errors) || repeat.errors < 0 || repeat.errors > repeat.requests)
+              issues.push(`${at} has an invalid error count`)
+            // Raw output is the only way to audit a disputed repeat, and an
+            // empty capture means there is nothing to audit.
+            if (!Number.isSafeInteger(repeat.rawBytes) || repeat.rawBytes <= 0)
+              issues.push(`${at} preserved no raw output`)
+          }
+        }
+      }
 
       const checks = parityChecks.filter(check => check.targetId === target.id && check.scenarioId === scenario.id)
       const completeRuns = checks.length === expectedRuns

--- a/bench/routing/report.ts
+++ b/bench/routing/report.ts
@@ -6,6 +6,7 @@
  * argued with, and this repo does not publish numbers like that.
  */
 
+import type { LatencyPercentiles } from './drivers'
 import type { Scenario } from './scenarios'
 import type { SourceState } from './source'
 import type { RelativeThroughput } from './statistics'
@@ -17,15 +18,43 @@ import { formatSourceState } from './source'
 import { MAX_STABLE_RANGE } from './statistics'
 import { formatRuntimeRequirement, runtimeMismatchWarning } from './runtime-version'
 
+/**
+ * One measured repeat, retained with the CPU reading taken during it.
+ *
+ * Repeats used to be reduced to an aggregate immediately, and null CPU
+ * readings were dropped before the median was taken - so a repeat that
+ * produced no CPU evidence left no trace, and the quality gate saw a complete
+ * row (stacksjs/stacks#2470). Retaining them lets publication check each one
+ * and name the run that failed.
+ */
+export interface RoutingRepeat {
+  targetId: string
+  scenarioId: string
+  /** 1-based scheduled run ordinal, so a missing repeat is identifiable. */
+  run: number
+  rpsMean: number
+  rpsP50: number | null
+  latencyMs: LatencyPercentiles
+  requests: number
+  errors: number
+  /** `null` when no CPU evidence was captured during this repeat. */
+  cpuPercent: number | null
+  /** Bytes of raw tool output recorded for this repeat. */
+  rawBytes: number
+}
+
 export interface Measurement {
   targetId: string
   scenarioId: string
   /** Median of the repeated runs. */
   rpsMean: number
   rpsP50: number | null
-  latencyMs: { p50: number, p90: number, p99: number }
-  errorRate: number
-  /** CPU time as a percentage of one core during measured load, excluding warmup. */
+  /** Median across the repeats. A percentile is `null` unless every repeat measured it. */
+  latencyMs: LatencyPercentiles
+  /** Pooled errors over pooled requests. `null` when no requests were recorded. */
+  errorRate: number | null
+  /** CPU as a percentage of one core during measured load, excluding warmup.
+   * `null` unless EVERY repeat produced a reading. */
   cpuPercent: number | null
   /** Lowest and highest rps across the repeats, so spread is visible. */
   spread: { min: number, max: number }
@@ -185,12 +214,16 @@ export function renderReport(input: ReportInput): string {
           ? `${fmt(relative.median * 100, 1)}% (${fmt(relative.spread.min * 100, 1)}%-${fmt(relative.spread.max * 100, 1)}%)`
           : '-')
       }
+      // A metric nothing measured renders as `-`, the same as the CPU column
+      // already did. Rendering a null as 0.00 would put the best possible
+      // latency in the table for a run that produced no latency evidence.
+      const measured = (value: number | null, digits: number) => value == null ? '-' : fmt(value, digits)
       cells.push(
-        fmt(row.latencyMs.p50, 2),
-        fmt(row.latencyMs.p90, 2),
-        fmt(row.latencyMs.p99, 2),
-        `${(row.errorRate * 100).toFixed(2)}%`,
-        row.cpuPercent == null ? '-' : `${fmt(row.cpuPercent)}%`,
+        measured(row.latencyMs.p50, 2),
+        measured(row.latencyMs.p90, 2),
+        measured(row.latencyMs.p99, 2),
+        row.errorRate == null ? '-' : `${(row.errorRate * 100).toFixed(2)}%`,
+        measured(row.cpuPercent, 0),
         '',
       )
       lines.push(cells.join(' | ').trim())

--- a/bench/routing/run.ts
+++ b/bench/routing/run.ts
@@ -12,9 +12,9 @@
  * with no artifact behind it is not a number this project publishes.
  */
 
-import type { Driver, LoadResult } from './drivers'
+import type { Driver } from './drivers'
 import type { BusyProcess } from './host-load'
-import type { Measurement, RunMeta } from './report'
+import type { Measurement, RoutingRepeat, RunMeta } from './report'
 import type { ScenarioParityEvidence } from './runtime'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { arch, cpus, platform, release } from 'node:os'
@@ -230,7 +230,7 @@ async function main(): Promise<void> {
   const targetRows: Array<{ id: string, label: string, skipped?: string }> = []
   const availableTargets = new Set<string>()
   const unavailableTargets = new Set<string>()
-  const collected = new Map<string, { results: LoadResult[], cpuReadings: number[] }>()
+  const collected = new Map<string, RoutingRepeat[]>()
 
   for (const scenario of scenarios) {
     console.error(`\n[bench] === ${scenario.title}`)
@@ -272,11 +272,24 @@ async function main(): Promise<void> {
             durationSeconds: opts.durationSeconds,
           }, booted.pid)
           const key = `${target.id}:${scenario.id}`
-          const bucket = collected.get(key) ?? { results: [], cpuReadings: [] }
+          const bucket = collected.get(key) ?? []
           collected.set(key, bucket)
-          if (cpuPercent != null) bucket.cpuReadings.push(cpuPercent)
 
-          bucket.results.push(result)
+          // Every repeat is retained, including one that produced no CPU
+          // reading. Dropping those before the median made a repeat with no
+          // CPU evidence invisible to the quality gate (stacksjs/stacks#2470).
+          bucket.push({
+            targetId: target.id,
+            scenarioId: scenario.id,
+            run,
+            rpsMean: result.rpsMean,
+            rpsP50: result.rpsP50,
+            latencyMs: result.latencyMs,
+            requests: result.requests,
+            errors: result.errors,
+            cpuPercent,
+            rawBytes: result.raw.length,
+          })
           writeFileSync(join(rawDir, `${target.id}--${scenario.id}--run${run}.txt`), result.raw)
           if (warmupResult)
             writeFileSync(join(rawDir, `${target.id}--${scenario.id}--run${run}--warmup.txt`), warmupResult.raw)
@@ -308,38 +321,58 @@ async function main(): Promise<void> {
     if (!availableTargets.has(target.id))
       continue
     for (const scenario of scenarios) {
-      const bucket = collected.get(`${target.id}:${scenario.id}`)
-      if (!bucket || bucket.results.length !== opts.runs)
+      const results = collected.get(`${target.id}:${scenario.id}`)
+      if (!results || results.length !== opts.runs)
         throw new Error(`Incomplete measurements for ${target.id}:${scenario.id}`)
-      const { results, cpuReadings } = bucket
       const rpsValues = results.map(r => r.rpsMean)
       const p50s = results.map(r => r.rpsP50).filter((v): v is number => v != null)
-      const rawResults = collected.get(`bun-raw:${scenario.id}`)?.results
+      const rawResults = collected.get(`bun-raw:${scenario.id}`)
+
+      /*
+       * Aggregate all-or-nothing.
+       *
+       * A median taken over the repeats that happened to report a metric is a
+       * number with no stated coverage: it reads the same whether three
+       * repeats agreed or one repeat was the only evidence. Where a metric is
+       * missing from any repeat the aggregate is `null`, which the report
+       * renders as `-` and publication rejects with a reason naming the run.
+       */
+      const everyValue = (pick: (r: RoutingRepeat) => number | null): number | null => {
+        const values = results.map(pick)
+        return values.every((v): v is number => v != null && Number.isFinite(v)) ? median(values) : null
+      }
+
+      // Pooled rather than the mean of per-repeat rates, so a repeat that
+      // served fewer requests carries proportionally less weight - and a
+      // repeat that served none contributes nothing instead of a free 0.
+      const pooledRequests = results.reduce((sum, r) => sum + r.requests, 0)
+      const pooledErrors = results.reduce((sum, r) => sum + r.errors, 0)
+
       measurements.push({
         targetId: target.id,
         scenarioId: scenario.id,
         rpsMean: median(rpsValues),
         rpsP50: p50s.length ? median(p50s) : null,
         latencyMs: {
-          p50: median(results.map(r => r.latencyMs.p50)),
-          p90: median(results.map(r => r.latencyMs.p90)),
-          p99: median(results.map(r => r.latencyMs.p99)),
+          p50: everyValue(r => r.latencyMs.p50),
+          p90: everyValue(r => r.latencyMs.p90),
+          p99: everyValue(r => r.latencyMs.p99),
         },
-        errorRate: results.reduce((sum, r) => sum + (r.requests ? r.errors / r.requests : 0), 0) / results.length,
-        cpuPercent: cpuReadings.length ? median(cpuReadings) : null,
+        errorRate: pooledRequests > 0 ? pooledErrors / pooledRequests : null,
+        cpuPercent: everyValue(r => r.cpuPercent),
         spread: { min: Math.min(...rpsValues), max: Math.max(...rpsValues) },
         rangeRatio: relativeRange(rpsValues),
         relativeToRaw: rawResults
           ? relativeThroughput(rpsValues, rawResults.map(r => r.rpsMean))
           : null,
-        runs: opts.runs,
+        runs: results.length,
       })
     }
   }
 
   meta.publicationIssues = [...new Set([
     ...(meta.publicationIssues ?? []),
-    ...routingMeasurementPublicationIssues(targetRows, scenarios, measurements, opts.runs, parityChecks),
+    ...routingMeasurementPublicationIssues(targetRows, scenarios, measurements, opts.runs, parityChecks, [...collected.values()].flat()),
   ])]
   meta.sourceAtEnd = await readSourceState(REPO_ROOT)
   if (sourceStateChanged(meta.source, meta.sourceAtEnd))
@@ -349,6 +382,18 @@ async function main(): Promise<void> {
   const report = renderReport({ meta, scenarios, targets: targetRows, measurements })
   writeFileSync(join(outDir, 'report.md'), report)
   writeFileSync(join(outDir, 'measurements.json'), `${JSON.stringify({
+    /*
+     * 2: latency percentiles and errorRate became nullable, errorRate became
+     * pooled rather than the mean of per-repeat rates, cpuPercent requires
+     * every repeat to have reported, and `runs` counts repeats RETAINED
+     * rather than requested (stacksjs/stacks#2470).
+     *
+     * The values are unchanged for a clean run - verified against diagnostic
+     * 34196555986, where pooled and mean-of-rates agree on all 32 rows - but
+     * the definitions differ the moment a repeat fails, so a committed
+     * baseline needs to say which rules produced it.
+     */
+    schemaVersion: 2,
     meta,
     targets: targetRows,
     workload: {


### PR DESCRIPTION
Closes #2470.

Three defects, one root cause: **absence was not representable**. A percentile the tool did not report became `0`, a repeat with no CPU reading was dropped before the median, and publication only ever saw the aggregate.

## The key path was verified, not assumed

Making a null percentile a hard blocker is only safe if `latencyPercentiles` is really oha's key. If it were wrong, today's symptom is a fake `0.00 ms` column; afterwards it would be **every oha run permanently unpublishable**. Nothing in the repo pinned it - the existing fixture at `drivers.test.ts:33-36` omits the key entirely, silently exercising `?? 0`, and `oha` is not installed locally.

Resolved by pulling the artifact from diagnostic run `34196555986`:

```
top-level keys: [details, errorDistribution, firstByteHistogram, firstBytePercentiles,
                 latencyPercentiles, metrics, responseTimeHistogram, rps,
                 statusCodeDistribution, summary]
latencyPercentiles: {"p50": 0.000407146, "p90": 0.00050315, "p99": 0.00076389, ...}
```

The key is real and holds **seconds**, so the existing `* 1000` is correct. The new tests use these exact shapes.

## The defects are latent, not live

From that same run: **96** measured samples, **0** missing a percentile, **0** with zero requests, **0** unparseable; **32** published rows, **0** with a null CPU reading. This is hardening, not a repair of published numbers.

## Changes

**Absence is representable.** `LatencyPercentiles` is `number | null` per percentile. All four drivers preserve absence, not just oha - the other three render into the same tables and pass the same validator, so a partial fix means honest nulls for oha and fake zeros elsewhere. Unit conversion moved into shared helpers that reject non-numeric input, so a string percentile becomes `null` rather than `NaN`.

**Repeats are retained.** `RoutingRepeat` carries each repeat's own CPU reading, run ordinal and raw-output size. The `if (cpuPercent != null)` drop is deleted - that single line is the second bullet of the issue.

**Every repeat is validated**, with the run named so its raw file can be found. The completeness predicate is the one the parity checks already use.

**Aggregates are all-or-nothing.** A median over the repeats that happened to report a metric reads identically whether three agreed or one was the only evidence.

## Metric definitions changed, so the payload says so

`measurements.json` carries `schemaVersion: 2`:

| field | was | now |
|---|---|---|
| `errorRate` | mean of per-repeat rates | pooled errors / pooled requests, `null` when no requests |
| `cpuPercent` | median of *available* readings | `null` unless every repeat reported |
| `runs` | repeats requested | repeats retained |
| `latencyMs.*` | `0` when absent | `null` when absent |

Pooled and mean-of-rates **agree on all 32 rows** of run `34196555986`, so no published number moves today. The definitions diverge the moment a repeat fails, which is exactly why a committed baseline needs to say which rules produced it. Documented in the README too.

## Deliberately not included

- **The `Incomplete measurements` throw is kept.** Removing it was tempting, but two other paths (`run.ts:250`, `runtime.ts:248`) abort earlier for the same class of problem, so removing it buys little while making every `median` reachable with a short sample.
- **`rpsP50` all-or-null** - no acceptance clause asks for it, and `drivers.ts` documents null as legitimate. It would be a fourth silent redefinition bought for consistency.
- **A `capture()` error-message change** - unrelated to this issue.

## Verification

- `bench/routing`: **123 pass / 1 fail**; the one failure is `peer versions`, identical on a clean tree
- Tests confirmed red by restoring `?? 0`: 4 of the new driver tests fail
- Typecheck (`tsc --noEmit --strict`, the only gate - `bench/routing` is in no tsconfig and no CI job): **1 error, identical to the clean-tree baseline**, none from this change
- root suite: **406 pass / 0 fail**
- `./buddy lint`: clean for these files
- No em-dashes added to the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)