### PR TITLE
fix(database): stop one unrunnable migration blocking the whole batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,10 @@ storage/framework/core/defaults/*
 !storage/framework/core/defaults/tests/
 !storage/framework/core/defaults/tests/**
 /storage/framework/stacks/storage/framework/stx/bundle-tmp
+
+# Migration files set aside during a run: the SQLite quarantine
+# (stacksjs/stacks#2477) and the feature gate's own sidecars. All three are
+# restored when the run finishes, so one on disk means a run was killed.
+database/migrations/*.sql.unsupported
+database/migrations/*.sql.disabled
+database/migrations/*.sql.ungated

--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -9,7 +9,7 @@ import type { UnsafeRowsResult } from './utils'
 import type { Result } from '@stacksjs/error-handling'
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { isPackageMigration, stagePackageMigrations } from './package-migrations'
-import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { log as _log } from '@stacksjs/logging'
 
 // Defensive log wrapper to handle cases where log methods might not be initialized.
@@ -554,14 +554,44 @@ function enumMembers(list: string): string[] {
   return [...list.matchAll(/'(?:[^']|'')*'/g)].map(match => match[0])
 }
 
-export function preprocessSqliteMigrations(): void {
+export function preprocessSqliteMigrations(): Array<{ original: string, hidden: string, feature: string }> {
   const migrationsDir = migrationDirectory('sqlite')
+  /*
+   * Files moved aside because SQLite cannot execute part of them.
+   *
+   * Returned rather than handled here so the caller can put them back through
+   * the same `restoreHiddenMigrations` path the feature gate already uses, and
+   * so it can refuse to report success while any of them are still pending.
+   */
+  const quarantined: Array<{ original: string, hidden: string, feature: string }> = []
+  /*
+   * Put back anything a previous run left quarantined.
+   *
+   * The restore normally happens in `runDatabaseMigration`'s `finally`, but a
+   * SIGKILL between the rename and that block would strand the file outside
+   * the corpus - invisible, and silently absent from every later run. This
+   * runs under the migration lock, so no other process is mid-rename.
+   */
+  try {
+    for (const stale of readdirSync(migrationsDir).filter(f => f.endsWith('.sql.unsupported'))) {
+      const original = join(migrationsDir, stale.slice(0, -'.unsupported'.length))
+      try {
+        if (!existsSync(original))
+          renameSync(join(migrationsDir, stale), original)
+        else
+          unlinkSync(join(migrationsDir, stale))
+      }
+      catch { /* best effort: the sweep must never stop a migrate */ }
+    }
+  }
+  catch { /* directory does not exist yet; handled below */ }
+
   let files: string[]
   try {
     files = readdirSync(migrationsDir).filter(f => f.endsWith('.sql'))
   }
   catch {
-    return // directory doesn't exist yet
+    return quarantined // directory doesn't exist yet
   }
 
   // Track which migrations we drop so we can mark them executed in the
@@ -573,6 +603,60 @@ export function preprocessSqliteMigrations(): void {
     log.info(`Skipping migration on SQLite (${reason}): ${file}`)
     droppedMigrations.push(file)
   }
+  /*
+   * What to do with a file containing SQL that SQLite cannot execute.
+   *
+   * ALL unsupported: the historical behaviour, unchanged. The file is valid on
+   * MySQL/Postgres, so it stays on disk and is only marked executed for SQLite
+   * (stacksjs/stacks#1916).
+   *
+   * MIXED: quarantined. It used to fall straight through to the runner, which
+   * handed SQLite an `ADD CONSTRAINT` and got `near "FOREIGN": syntax error`,
+   * aborting the whole batch - so ONE bad file stopped every later migration
+   * from applying (stacksjs/stacks#2477).
+   *
+   * Quarantine moves it aside so the rest of the corpus applies, and leaves it
+   * PENDING. It is deliberately not run-the-supported-half-and-record: nothing
+   * here executes SQL, so the only way to run half a file is to rewrite it, and
+   * recording it afterwards would claim on a filename-keyed ledger that a
+   * statement ran when it never did. A table without the foreign key its model
+   * declares, asserted as complete, is worse than a failure that keeps saying so.
+   */
+  const partitionUnsupported = (
+    file: string,
+    filePath: string,
+    statements: string[],
+    pattern: RegExp,
+    feature: string,
+  ): 'skipped' | 'quarantined' | 'runnable' => {
+    const unsupported = statements.filter(s => pattern.test(s))
+    if (unsupported.length === statements.length) {
+      skipMigration(file, `SQLite does not support ${feature}`)
+      return 'skipped'
+    }
+
+    const hiddenPath = `${filePath}.unsupported`
+    try {
+      renameSync(filePath, hiddenPath)
+    }
+    catch (error) {
+      // A read-only corpus. Fall through to the runner and let it fail loudly,
+      // which is today's behaviour. Never mark it executed: the statements did
+      // not run, and saying otherwise is permanent and undetectable.
+      log.error(`[migration] Could not quarantine ${file}: ${error instanceof Error ? error.message : String(error)}`)
+      return 'runnable'
+    }
+
+    quarantined.push({ original: filePath, hidden: hiddenPath, feature })
+    log.warn(
+      `[migration] ${file} mixes ${unsupported.length} ${feature} statement(s) SQLite cannot run `
+      + `with ${statements.length - unsupported.length} it can, so none of it was applied. `
+      + `Split them into separate migrations, or run this app on MySQL/Postgres. `
+      + `The rest of the corpus was applied.`,
+    )
+    return 'quarantined'
+  }
+
   const deleteMigration = (file: string, filePath: string, reason: string): void => {
     // Genuinely dead file — duplicate or unreachable. Safe to remove.
     log.info(`Dropping no-op migration (${reason}): ${file}`)
@@ -730,10 +814,16 @@ export function preprocessSqliteMigrations(): void {
     // it as executed in the migrations table for SQLite. A later
     // DB_CONNECTION flip can replay these files against the new
     // backend. (stacksjs/stacks#1916)
-    const allAddConstraint = statements.every(s => addConstraintPattern.test(s))
-    if (allAddConstraint) {
-      skipMigration(file, 'SQLite does not support ALTER TABLE ADD CONSTRAINT')
-      continue
+    if (statements.some(s => addConstraintPattern.test(s))) {
+      const disposition = partitionUnsupported(
+        file,
+        filePath,
+        statements,
+        addConstraintPattern,
+        'ALTER TABLE ADD CONSTRAINT',
+      )
+      if (disposition !== 'runnable')
+        continue
     }
 
     // Skip files that only contain CREATE TYPE ... AS ENUM (Postgres enum
@@ -744,10 +834,16 @@ export function preprocessSqliteMigrations(): void {
     // migrate with `near "TYPE": syntax error`. Same skip-and-keep policy
     // as ADD CONSTRAINT above: the file is valid on MySQL/Postgres, so
     // leave it on disk and just mark it executed for SQLite. (#1916)
-    const allCreateType = statements.every(s => createTypePattern.test(s))
-    if (allCreateType) {
-      skipMigration(file, 'SQLite does not support CREATE TYPE (enum types)')
-      continue
+    if (statements.some(s => createTypePattern.test(s))) {
+      const disposition = partitionUnsupported(
+        file,
+        filePath,
+        statements,
+        createTypePattern,
+        'CREATE TYPE (enum types)',
+      )
+      if (disposition !== 'runnable')
+        continue
     }
 
     /*
@@ -933,6 +1029,8 @@ export function preprocessSqliteMigrations(): void {
       log.debug(`[migration] Could not record dropped migrations as executed: ${e}`)
     }
   }
+
+  return quarantined
 }
 
 /**
@@ -1512,6 +1610,12 @@ function makeMigrationsIdempotent(): void {
 export async function runDatabaseMigration(): Promise<Result<string, Error>> {
   const startedAt = Date.now()
   const hidden = await hideDisabledFeatureMigrations()
+  /*
+   * Files SQLite could not execute, set aside so the rest of the corpus could
+   * apply. Tracked here because a migrate that left one of these pending has
+   * not finished, and must not report success (stacksjs/stacks#2477).
+   */
+  let quarantinedMigrations: Array<{ original: string, hidden: string, feature: string }> = []
   // Lock handle is acquired AFTER ensureDatabaseExists (PG/MySQL need
   // the target DB to exist before we can connect to it for the
   // advisory lock). SQLite is fine to lock immediately.
@@ -1577,7 +1681,10 @@ export async function runDatabaseMigration(): Promise<Result<string, Error>> {
     // the lock is held so concurrent processes can't corrupt each
     // other's disk state (stacksjs/stacks#1876 D-2).
     if (dialect === 'sqlite') {
-      preprocessSqliteMigrations()
+      // Anything quarantined joins the feature gate's own hidden list, so the
+      // `finally` below restores it through one path.
+      quarantinedMigrations = preprocessSqliteMigrations()
+      hidden.push(...quarantinedMigrations)
     }
     else if (dialect === 'postgres') {
       // Make ALTER migrations idempotent so re-runs / replays of "transient"
@@ -1657,6 +1764,28 @@ export async function runDatabaseMigration(): Promise<Result<string, Error>> {
     await writeMigrateMarker(appliedCount)
 
     log.debug(`Database migration completed in ${Date.now() - startedAt}ms (applied ${appliedCount}).`)
+
+    /*
+     * A migrate that left a file pending has not finished.
+     *
+     * Reported AFTER everything else has applied, on purpose: the point of
+     * quarantining is that one unrunnable file no longer blocks the other
+     * hundred. But returning `ok` here would turn a loud abort into a green
+     * deploy, which is strictly worse than the bug this fixes - the incident
+     * in stacksjs/stacks#2477 was six days of invisibility, not a syntax error.
+     */
+    if (quarantinedMigrations.length > 0 && process.env.STACKS_ALLOW_PENDING_MIGRATIONS !== '1') {
+      const names = quarantinedMigrations.map(q => basename(q.original))
+      return err(new Error(
+        `Applied ${appliedCount} migration${appliedCount === 1 ? '' : 's'}, but `
+        + `${names.length} could not run on SQLite and ${names.length === 1 ? 'is' : 'are'} still pending: `
+        + `${names.join(', ')}. `
+        + `${names.length === 1 ? 'It mixes' : 'They mix'} statements SQLite cannot execute with statements it can, `
+        + `so splitting them into separate migrations lets the runnable half apply. `
+        + `Set STACKS_ALLOW_PENDING_MIGRATIONS=1 to proceed anyway.`,
+      ))
+    }
+
     return ok(appliedCount === 0
       ? 'Nothing to migrate.'
       : `Applied ${appliedCount} migration${appliedCount === 1 ? '' : 's'}.`)

--- a/storage/framework/core/database/tests/preprocess-sqlite.test.ts
+++ b/storage/framework/core/database/tests/preprocess-sqlite.test.ts
@@ -45,11 +45,16 @@ describe('preprocessSqliteMigrations - keep portable files (stacksjs/stacks#1916
 
   it('keeps ALTER TABLE ADD CONSTRAINT files on disk (portable to MySQL/Postgres)', () => {
     const fkFile = join(migrationsDir, '0000000010-alter-posts-user_id.sql')
-    writeFileSync(fkFile, 'ALTER TABLE "posts" ADD CONSTRAINT "posts_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE;')
+    const fkSql = 'ALTER TABLE "posts" ADD CONSTRAINT "posts_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE;'
+    writeFileSync(fkFile, fkSql)
 
     preprocessSqliteMigrations()
 
     expect(existsSync(fkFile)).toBe(true)
+    // Byte-for-byte. Without this, a future per-statement fix could gut every
+    // constraint file and stay green, which is exactly the failure mode that
+    // makes a filename-keyed ledger dangerous.
+    expect(readFileSync(fkFile, 'utf-8')).toBe(fkSql)
   })
 
   it('keeps CREATE UNIQUE INDEX files on disk (portable to MySQL/Postgres)', () => {
@@ -353,5 +358,122 @@ describe('preprocessSqliteMigrations - unique-index files must run (stacksjs/sta
       expect(content).not.toContain('SELECT 1')
       expect(content).toMatch(/CREATE\s+UNIQUE\s+INDEX\s+IF\s+NOT\s+EXISTS/i)
     }
+  })
+})
+
+
+/**
+ * A migration SQLite can only partly execute (stacksjs/stacks#2477).
+ *
+ * The guard used to be `statements.every(s => addConstraintPattern.test(s))`,
+ * so a file was only set aside when ALL of it was unsupported. A generated
+ * file mixing a supported statement with an `ADD CONSTRAINT` fell through to
+ * the runner, SQLite rejected it with `near "FOREIGN": syntax error`, and the
+ * batch aborted - so one bad file stopped every later migration from applying.
+ *
+ * Both existing ADD CONSTRAINT tests above write SINGLE-statement files, which
+ * is precisely why the defect survived: on a one-statement file, per-file and
+ * per-statement are indistinguishable.
+ */
+describe('preprocessSqliteMigrations - mixed files (stacksjs/stacks#2477)', () => {
+  let workspace: string
+  let migrationsDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    originalCwd = process.cwd()
+    workspace = mkdtempSync(join(tmpdir(), 'preprocess-sqlite-mixed-'))
+    migrationsDir = join(workspace, 'database', 'migrations')
+    mkdirSync(migrationsDir, { recursive: true })
+    process.chdir(workspace)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  const mixedFk = 'CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY, "user_id" INTEGER);\n'
+    + 'ALTER TABLE "posts" ADD CONSTRAINT "posts_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id");\n'
+
+  it('leaves no file SQLite cannot execute in the corpus for the runner', () => {
+    const file = '0000000200-alter-posts-columns.sql'
+    writeFileSync(join(migrationsDir, file), mixedFk)
+
+    const quarantined = preprocessSqliteMigrations()
+
+    // Red on main: the file stayed put and was handed to SQLite verbatim.
+    expect(existsSync(join(migrationsDir, file))).toBe(false)
+    // Basenames: macOS resolves the temp dir through /private, so the absolute
+    // paths differ in form while naming the same file.
+    expect(quarantined.map(q => q.original.split('/').pop())).toEqual([file])
+  })
+
+  it('preserves the quarantined file verbatim, so restoring it loses nothing', () => {
+    const file = '0000000200-alter-posts-columns.sql'
+    writeFileSync(join(migrationsDir, file), mixedFk)
+
+    preprocessSqliteMigrations()
+
+    expect(readFileSync(join(migrationsDir, `${file}.unsupported`), 'utf-8')).toBe(mixedFk)
+  })
+
+  it('does NOT record a mixed file as executed', () => {
+    // This is what blocks the obvious wrong fix. Swapping `.every()` for
+    // `.some()` would mark the file applied on a filename-keyed ledger while
+    // its CREATE TABLE never ran - a table missing, asserted as created, with
+    // nothing downstream able to detect it.
+    const file = '0000000200-alter-posts-columns.sql'
+    writeFileSync(join(migrationsDir, file), mixedFk)
+
+    preprocessSqliteMigrations()
+
+    const db = new Database(join(workspace, 'database', 'stacks.sqlite'))
+    try {
+      const table = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='migrations'").get()
+      if (table) {
+        const row = db.query('SELECT migration FROM migrations WHERE migration = ?').get(file)
+        expect(row).toBeNull()
+      }
+    }
+    finally { db.close() }
+  })
+
+  it('still applies the same treatment to CREATE TYPE, which had the identical defect', () => {
+    const file = '0000000201-auto-misc.sql'
+    writeFileSync(join(migrationsDir, file),
+      'CREATE TABLE "orders" ("id" INTEGER PRIMARY KEY);\n'
+      + `CREATE TYPE "order_status" AS ENUM ('open', 'closed');\n`)
+
+    const quarantined = preprocessSqliteMigrations()
+
+    expect(existsSync(join(migrationsDir, file))).toBe(false)
+    expect(quarantined).toHaveLength(1)
+  })
+
+  it('leaves a fully-unsupported file exactly as before', () => {
+    // The #1916 contract: all-unsupported still stays on disk, unquarantined,
+    // so a later DB_CONNECTION flip can replay it.
+    const file = '0000000202-alter-posts-fk.sql'
+    const sql = 'ALTER TABLE "posts" ADD CONSTRAINT "a" FOREIGN KEY ("b") REFERENCES "c"("d");\n'
+    writeFileSync(join(migrationsDir, file), sql)
+
+    const quarantined = preprocessSqliteMigrations()
+
+    expect(existsSync(join(migrationsDir, file))).toBe(true)
+    expect(readFileSync(join(migrationsDir, file), 'utf-8')).toBe(sql)
+    expect(quarantined).toEqual([])
+  })
+
+  it('restores a sidecar left behind by a killed run', () => {
+    const file = '0000000203-alter-posts-columns.sql'
+    writeFileSync(join(migrationsDir, `${file}.unsupported`), mixedFk)
+
+    preprocessSqliteMigrations()
+
+    // Swept back in, then quarantined again by this run - either way it is
+    // never silently absent from the corpus.
+    expect(existsSync(join(migrationsDir, `${file}.unsupported`))).toBe(true)
+    expect(readFileSync(join(migrationsDir, `${file}.unsupported`), 'utf-8')).toBe(mixedFk)
   })
 })


### PR DESCRIPTION
Closes #2477.

```js
const allAddConstraint = statements.every(s => addConstraintPattern.test(s))
```

A migration was skipped only when **every** statement was `ADD CONSTRAINT`. A file mixing a supported statement with an unsupported one fell through to the runner, SQLite rejected it, and the batch aborted at the first failure - so one bad file stopped **every later migration** from applying. That is what turned a syntax error into six days with no migrations and 192,000 `no such table: queue_circuit_state` events.

The `CREATE TYPE` guard 14 lines below had the identical defect. Fixing only the one the issue names would have shipped the same bug again, so both are now one partition.

## Why not the fix the issue suggests

The issue proposes running the supported statements and skipping the unsupported ones. **There is no seam for that.** `preprocessSqliteMigrations` executes no SQL, and `executeMigration(dirs)` takes directories and nothing else - so "run half a file" is only expressible by rewriting the file on disk.

And then recording it. The ledger is keyed on filename with no content hash, so `migration ran` becomes permanent and undetectable, while the table exists **without the foreign key its model declares**. A wrong schema asserted as complete is worse than a failure that keeps saying so. A literal `.every()` → `.some()` swap produces exactly that; there is now a test blocking it.

Worth stating plainly: on SQLite a standalone `ADD CONSTRAINT` is unrunnable in **every** disposition. No fix here produces the foreign key. The only question is whether the system knows, and keeps saying so.

## What it does instead

| | today | this PR |
|---|---|---|
| all-unsupported file | kept on disk, marked executed | **unchanged, byte for byte** (#1916) |
| mixed file | runs → syntax error → whole batch aborts | quarantined, stays **pending** |
| rest of the corpus | never applies | **applies** |
| ledger | nothing recorded | nothing recorded |
| operator sees | opaque error, swallowed by deploy | warning naming both halves, non-zero exit, **every run until fixed** |

Quarantine is a rename aside. Quarantined files join the feature gate's existing hidden list so the same `finally` restores them, and a sweep at the top of preprocessing puts back anything a killed run stranded. If the rename fails (read-only corpus) it falls through to today's loud failure - never to `skipMigration`.

**The `err` return is load-bearing, not garnish.** It fires after everything else has applied. Strip it and this change turns a loud abort into a green deploy, which is worse than the bug - the incident was about invisibility, not about a syntax error. `STACKS_ALLOW_PENDING_MIGRATIONS=1` mirrors the existing `STACKS_ALLOW_DIALECT_MISMATCH`.

## Why it survived this long

Both existing `ADD CONSTRAINT` tests write **single-statement** files. On a one-statement file, per-file and per-statement are indistinguishable. One of them now also asserts the file's bytes are untouched, so a future per-statement attempt cannot gut every constraint file and stay green.

## Verification

- 4 of the new tests confirmed **red against the unmodified source**, green with the fix
- `core/database`: **950 pass / 1 fail**; the failure is the pre-existing clock-sensitive `sql-datetime` test, identical on a clean tree
- Cold-cache typecheck: 13 errors, same as the clean-tree baseline, **none in the touched file**
- `./buddy lint`: clean for these files

## Not in this change

- The deploy step swallowing a failed `migrate`. That is the actual cause of the six days, it is framework-side rather than CI, and it is written up in a comment on #2477 - including the finding that buddy already exits non-zero when told, so the failure is being lost inside ts-cloud's per-site result rather than by buddy.
- `groupGeneratedStatements` routing a bare `ADD CONSTRAINT` into `alter-<table>-columns`, which is the upstream cause for freshly generated corpora. It changes generated filenames and should not ride inside this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)