### PR TITLE
fix(config): read the stx config under either name it accepts

### DIFF
--- a/storage/framework/core/buddy/src/production-server.ts
+++ b/storage/framework/core/buddy/src/production-server.ts
@@ -137,18 +137,36 @@ function containsTemplates(dir: string): boolean {
  * it {@link resolveUserPartialsPath} falls back to the conventions.
  */
 export async function loadStxPartialsDir(cwd = process.cwd()): Promise<string | undefined> {
-  const configPath = join(cwd, 'config/stx.ts')
-  if (!existsSync(configPath))
-    return undefined
+  /*
+   * Either filename, because stx itself accepts either.
+   *
+   * `loadStxConfig` resolves `{ name: 'stx', alias: 'ui' }`, and the Stacks
+   * starter produces `config/ui.ts` - so this, looking only for `config/stx.ts`,
+   * returned undefined for every scaffolded app and `partialsDir` was
+   * unreadable. A probe fallback in `resolveUserPartialsPath` quietly covered
+   * for it, which is why nothing ever reported the miss (stacksjs/stacks#2446).
+   *
+   * `stx.ts` stays first so no app that resolves today resolves differently.
+   */
+  for (const name of ['stx', 'ui']) {
+    const configPath = join(cwd, `config/${name}.ts`)
+    if (!existsSync(configPath))
+      continue
 
-  try {
-    const mod = await import(configPath)
-    const dir = mod.default?.partialsDir
-    return typeof dir === 'string' && dir.length > 0 ? dir : undefined
+    try {
+      const mod = await import(configPath)
+      const dir = mod.default?.partialsDir
+      if (typeof dir === 'string' && dir.length > 0)
+        return dir
+    }
+    catch {
+      // A malformed config is not this function's problem to report: the
+      // config loader surfaces it, and refusing to serve over it would be
+      // worse than falling back to the probe.
+    }
   }
-  catch {
-    return undefined
-  }
+
+  return undefined
 }
 
 /**

--- a/storage/framework/core/config/src/overrides.ts
+++ b/storage/framework/core/config/src/overrides.ts
@@ -7,6 +7,7 @@
  */
 
 import type { StacksConfig } from '@stacksjs/types'
+import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { defaults } from './defaults'
@@ -131,7 +132,20 @@ export const overrides: StacksConfig = sharedOverrides ?? (() => {
 
 // Files we attempt to load. The key on the left is the property name on
 // `overrides`; the path on the right is the project-local config file.
-const userConfigs: Array<[keyof StacksConfig, string]> = [
+/**
+ * `[configKey, filename, ...alternativeFilenames]`.
+ *
+ * The alternatives exist because stx accepts either name for its own config:
+ * `loadStxConfig` resolves `{ name: 'stx', alias: 'ui' }`, so an app can write
+ * `config/stx.ts` and stx reads it happily - while this loader looked only for
+ * `config/ui.ts` and left `config.ui` undefined. `resolveViewPatterns` treats
+ * undefined exactly like `true`, so such an app kept mounting the framework's
+ * demo views through a green build and a green deploy (stacksjs/stacks#2446).
+ *
+ * The first name that exists wins, and the primary stays first, so no app that
+ * resolves today resolves differently.
+ */
+const userConfigs: Array<[keyof StacksConfig, string, ...string[]]> = [
   ['ai', 'ai'],
   ['analytics', 'analytics'],
   ['app', 'app'],
@@ -178,8 +192,36 @@ const userConfigs: Array<[keyof StacksConfig, string]> = [
   ['services', 'services'],
   ['filesystems', 'filesystems'],
   ['team', 'team'],
-  ['ui', 'ui'],
+  ['ui', 'ui', 'stx'],
 ]
+
+/**
+ * Which of a config's accepted filenames this project actually ships.
+ *
+ * The first one on disk wins, and the primary name is first, so no project
+ * that resolves today resolves differently. Falling through the list rather
+ * than importing a missing path keeps the loader's ENOENT handling meaning
+ * "this project ships no config of this kind" rather than "the primary name
+ * was absent" - which is what made the stx/ui split invisible: `config/stx.ts`
+ * is a name stx itself accepts, and this loader read straight past it, leaving
+ * `config.ui` undefined while stx reported the file loaded fine
+ * (stacksjs/stacks#2446).
+ *
+ * Both present is ambiguous rather than wrong, so it warns and takes the
+ * primary instead of guessing silently.
+ */
+export function resolveUserConfigName(names: [string, ...string[]], cwd = process.cwd()): string {
+  const present = names.filter(candidate => existsSync(resolve(cwd, 'config', `${candidate}.ts`)))
+
+  if (present.length > 1) {
+    console.warn(
+      `[config] config/${present.join('.ts and config/')}.ts both exist and configure the same thing. `
+      + `Using config/${present[0]}.ts; delete the other so every consumer agrees on one.`,
+    )
+  }
+
+  return present[0] ?? names[0]
+}
 
 export function userConfigUrl(name: string, cwd = process.cwd()): string {
   return pathToFileURL(resolve(cwd, 'config', `${name}.ts`)).href
@@ -202,7 +244,8 @@ const sharedReady = globalScope[READY_KEY] as Promise<StacksConfig> | undefined
 export const overridesReady: Promise<StacksConfig> = sharedReady ?? (() => {
   const promise = skipConfigLoading
     ? Promise.resolve(overrides)
-    : Promise.all(userConfigs.map(async ([key, name]) => {
+    : Promise.all(userConfigs.map(async ([key, ...names]) => {
+      const name = resolveUserConfigName(names as [string, ...string[]])
       const modulePath = userConfigUrl(name)
       try {
         const mod = await import(modulePath)

--- a/storage/framework/core/config/tests/user-config-filename.test.ts
+++ b/storage/framework/core/config/tests/user-config-filename.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Which filename a config is read from (stacksjs/stacks#2446).
+ *
+ * stx accepts either `config/stx.ts` or `config/ui.ts` - `loadStxConfig`
+ * resolves `{ name: 'stx', alias: 'ui' }`. This loader accepted only `ui.ts`,
+ * and `loadStxPartialsDir` in the production server accepted only `stx.ts`.
+ * No single filename satisfied all three consumers, and both misses were
+ * silent.
+ *
+ * The one that mattered: under `config/stx.ts`, `config.ui` was undefined, and
+ * `resolveViewPatterns` treats undefined exactly like `true` - so an app that
+ * set `defaultViews: ['errors', 'emails']` to stop serving the framework's demo
+ * storefront kept serving it, through a green build and a green deploy.
+ */
+import { describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveUserConfigName } from '../src/overrides'
+
+function project(files: string[]): string {
+  const root = mkdtempSync(join(tmpdir(), 'user-config-name-'))
+  mkdirSync(join(root, 'config'), { recursive: true })
+  for (const f of files)
+    writeFileSync(join(root, 'config', f), 'export default {}\n')
+  return root
+}
+
+describe('resolveUserConfigName', () => {
+  it('reads the primary name when that is what the project ships', () => {
+    const root = project(['ui.ts'])
+    try {
+      expect(resolveUserConfigName(['ui', 'stx'], root)).toBe('ui')
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('reads the alternative name, which is the whole bug', () => {
+    // Red before the fix: the loader looked only for `ui.ts`, found nothing,
+    // and left `config.ui` undefined while stx read `stx.ts` perfectly well.
+    const root = project(['stx.ts'])
+    try {
+      expect(resolveUserConfigName(['ui', 'stx'], root)).toBe('stx')
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('prefers the primary when a project ships both', () => {
+    const root = project(['ui.ts', 'stx.ts'])
+    try {
+      expect(resolveUserConfigName(['ui', 'stx'], root)).toBe('ui')
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('falls back to the primary name when the project ships neither', () => {
+    // The loader then imports a path that does not exist, and its ENOENT
+    // branch means "this project ships no config of this kind" - which is the
+    // common case and must stay silent.
+    const root = project([])
+    try {
+      expect(resolveUserConfigName(['ui', 'stx'], root)).toBe('ui')
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('leaves a single-name config exactly as it was', () => {
+    const root = project(['database.ts'])
+    try {
+      expect(resolveUserConfigName(['database'], root)).toBe('database')
+      expect(resolveUserConfigName(['queue'], root)).toBe('queue')
+    }
+    finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})
+
+describe('the ui config accepts both of stx own names', () => {
+  it('is registered with stx as an alternative', () => {
+    // Pinned because the alias is the fix: dropping it silently restores the
+    // bug, and every other consumer would still look fine.
+    const source = require('node:fs').readFileSync(
+      new URL('../src/overrides.ts', import.meta.url),
+      'utf8',
+    )
+    expect(source).toContain(`['ui', 'ui', 'stx']`)
+  })
+})


### PR DESCRIPTION
Closes #2446.

Three consumers resolved the stx config file three different ways, and no single filename satisfied all of them:

| consumer | resolved |
|---|---|
| `loadStxConfig` | `{ name: 'stx', alias: 'ui' }` - **either** |
| `@stacksjs/config` | `['ui', 'ui']` - **`ui.ts` only** |
| `loadStxPartialsDir` | `join(cwd, 'config/stx.ts')` - **`stx.ts` only** |

Both misses were silent. Under `config/ui.ts` (what the starter produces) `loadStxPartialsDir` always returned `undefined`, and a probe fallback in `resolveUserPartialsPath` quietly covered for it. Under `config/stx.ts` - a name stx itself accepts - `config.ui` was `undefined` for every consumer of `@stacksjs/config`.

## Why the second one matters

`startProductionServer` passes `config?.ui?.defaultViews` into `resolveViewPatterns`, and that treats `undefined` **exactly like `true`** - mount everything. So an app that set `defaultViews: ['errors', 'emails']` to stop serving the framework's demo storefront kept serving it, through a green build and a green deploy, with `/cart` answering 200 on a reporting product's marketing site.

## The change

Both consumers now accept both names, each keeping **its own current primary first**, so no project that resolves today resolves differently:

- `@stacksjs/config`: `['ui', 'ui', 'stx']` - the table entry grew an alternative, and the loader picks the first name actually on disk
- `loadStxPartialsDir`: tries `config/stx.ts` then `config/ui.ts`

A project shipping **both** files is ambiguous rather than wrong, so it warns and names which one won instead of picking silently.

## Verified end to end, against this repo

```
config/ui.ts -> config/stx.ts

with this change:     config.ui.root = 'resources'   (from config/stx.ts:12)
with it reverted:     config.ui.root = undefined      ← the reported bug
```

That is the issue's own reproduction, run in both directions.

## Tests

`resolveUserConfigName` is extracted so the resolution is testable without the module-level `overridesReady` promise: primary wins, alternative is found, both-present prefers the primary, neither falls back to the primary, and a single-name config is unchanged. Plus a pin on the `['ui', 'ui', 'stx']` entry, because dropping the alias silently restores the bug while every other consumer still looks fine.

## Verification

- `core/config`: **214 pass / 0 fail** (6 new)
- `core/buddy`: **828 pass / 3 fail** - the 3 are the known dist-only `package manifests` checks, identical on a clean tree
- Framework typecheck: 13 errors, baseline, **none in the touched files**
- App typecheck: 2 errors, both pre-existing (one fixed by #2482, one dist-only subpath noise)
- `./buddy lint`: clean for these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)