### PR TITLE
fix(env): stop env:set stranding a file's existing encrypted values

### DIFF
--- a/storage/framework/core/env/src/cli.ts
+++ b/storage/framework/core/env/src/cli.ts
@@ -189,6 +189,70 @@ export function envKeyNames(file?: string): { publicKeyName: string, privateKeyN
  * With no ciphertext there is nothing to stay consistent with, so a fresh
  * keypair is both safe and correct.
  */
+/**
+ * Every public-key name a file may legitimately declare, in preference order.
+ *
+ * `dotenvx` accepts both the suffixed `DOTENV_PUBLIC_KEY_<ENV>` and the plain
+ * `DOTENV_PUBLIC_KEY`, and real projects use the plain form. Looking only for
+ * the suffixed name meant a file declaring the plain one appeared to have no
+ * key at all, so a fresh keypair was generated, a SECOND declaration was
+ * prepended, and every value already encrypted under the original key was
+ * stranded (stacksjs/stacks#2489).
+ */
+export function envPublicKeyNames(file?: string): string[] {
+  const { publicKeyName } = envKeyNames(file)
+  return publicKeyName === 'DOTENV_PUBLIC_KEY' ? [publicKeyName] : [publicKeyName, 'DOTENV_PUBLIC_KEY']
+}
+
+/** Likewise for the private half. */
+export function envPrivateKeyNames(file?: string): string[] {
+  const { privateKeyName } = envKeyNames(file)
+  return privateKeyName === 'DOTENV_PRIVATE_KEY' ? [privateKeyName] : [privateKeyName, 'DOTENV_PRIVATE_KEY']
+}
+
+/**
+ * Does this file already hold ciphertext, under any key name?
+ *
+ * The witness that makes rotation unsafe. If ANY value is encrypted, some key
+ * out there decrypts it, and generating a new one strands those values whether
+ * or not we recognise the name their public key was declared under. Deliberately
+ * name-agnostic: the name is exactly what the previous guards got wrong.
+ */
+export function envHasCiphertext(envContent: string): boolean {
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#'))
+      continue
+    const match = trimmed.match(/^([^=]+)=(.*)$/)
+    if (!match?.[1] || match[2] === undefined)
+      continue
+    const value = match[2].trim().replace(/^["']|["']$/g, '')
+    if (value.startsWith('encrypted:') || value.startsWith('enc:'))
+      return true
+  }
+  return false
+}
+
+/**
+ * The public key an env file declares, whichever accepted name it uses, plus
+ * that name so callers write back to the same line instead of adding a second.
+ */
+export function declaredEnvPublicKey(envContent: string, file?: string): { name: string, key: string } | undefined {
+  const names = envPublicKeyNames(file)
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#'))
+      continue
+    const match = trimmed.match(/^([^=]+)=["']?([^"'\n]+)["']?/)
+    if (!match?.[1] || !match[2])
+      continue
+    const key = match[1].trim()
+    if (names.includes(key))
+      return { name: key, key: match[2] }
+  }
+  return undefined
+}
+
 export function reusableEnvPublicKey(envContent: string, publicKeyName: string): string | undefined {
   let publicKey: string | undefined
   let hasCiphertext = false
@@ -434,7 +498,18 @@ export function setEnv(
 ): { success: boolean, output?: string, error?: string } {
   const cwd = options.cwd || process.cwd()
   const envPath = resolve(cwd, options.file || '.env')
-  const keysPath = resolve(cwd, options.keysFile || '.env.keys')
+  /*
+   * Beside the env file, not beside the process.
+   *
+   * This resolved against the CWD, so `env:set --file ../other/.env` wrote its
+   * keys into whatever directory you happened to be standing in - landing on
+   * that project's own `.env.keys` and replacing the private halves for every
+   * value it had already encrypted, while reporting success
+   * (stacksjs/stacks#2489).
+   */
+  const keysPath = options.keysFile
+    ? resolve(cwd, options.keysFile)
+    : resolve(dirname(envPath), '.env.keys')
 
   try {
     let content = ''
@@ -456,17 +531,12 @@ export function setEnv(
     const publicKeyName = env ? `DOTENV_PUBLIC_KEY_${env}` : 'DOTENV_PUBLIC_KEY'
     const privateKeyName = env ? `DOTENV_PRIVATE_KEY_${env}` : 'DOTENV_PRIVATE_KEY'
 
-    // First pass: find public key for this file
-    for (const line of lines) {
-      const trimmed = line.trim()
-      if (trimmed.startsWith(`${publicKeyName}=`)) {
-        const match = trimmed.match(/^[^=]+=["']?([^"'\n]+)["']?/)
-        if (match) {
-          publicKey = match[1]
-        }
-        break
-      }
-    }
+    // The key the file actually declares, under EITHER accepted name, and the
+    // name it used - so the write below updates that line instead of adding a
+    // second declaration beside it (stacksjs/stacks#2489).
+    const declared = declaredEnvPublicKey(content, options.file)
+    const declaredName = declared?.name ?? publicKeyName
+    publicKey = declared?.key
 
     // A public key found in the .env file is only usable if its matching
     // private key is actually saved in the keys file. Reusing a public key
@@ -479,7 +549,8 @@ export function setEnv(
       if (existsSync(keysPath)) {
         const keysContent = readFileSync(keysPath, 'utf-8')
         const { parsed: keys } = parse(keysContent)
-        hasMatchingPrivateKey = Boolean(keys[privateKeyName])
+        // Either accepted name, matching the public half.
+        hasMatchingPrivateKey = envPrivateKeyNames(options.file).some(name => Boolean(keys[name]))
       }
 
       // Missing locally is not the same as missing. `.env.keys` is gitignored,
@@ -493,9 +564,32 @@ export function setEnv(
       // this public key is the one the rest of the file already uses and it has
       // to stay. Only when the file carries no ciphertext, and no private key is
       // reachable either way, is a fresh keypair the safe answer.
-      if (!hasMatchingPrivateKey && !process.env[privateKeyName]
-        && !reusableEnvPublicKey(content, publicKeyName)) {
+      const privateKeyInEnv = envPrivateKeyNames(options.file).some(name => Boolean(process.env[name]))
+      if (!hasMatchingPrivateKey && !privateKeyInEnv && !envHasCiphertext(content)) {
         publicKey = undefined
+      }
+    }
+
+    /*
+     * Never rotate a key for a file that already holds ciphertext.
+     *
+     * This is the invariant stacksjs/stacks#2348 wanted and #2489 showed was
+     * still reachable. If any value in the file is encrypted, some key decrypts
+     * it; generating a new one re-encrypts nothing and silently strands every
+     * one of them. Failing here is the only honest option, because there is no
+     * way to proceed that keeps them readable.
+     *
+     * A round-trip check on the value being written would NOT catch this: the
+     * new value encrypts and decrypts perfectly under the new key. It is the
+     * OTHER values that die.
+     */
+    if (!options.plain && !publicKey && envHasCiphertext(content)) {
+      return {
+        success: false,
+        error: `${options.file || '.env'} already contains encrypted values, but no key that can be used to add another was found.\n`
+          + `Generating one would leave every existing encrypted value unreadable.\n`
+          + `Provide the private key as ${envPrivateKeyNames(options.file)[0]} in the environment, restore ${keysPath}, `
+          + `or use --plain to write this value unencrypted.`,
       }
     }
 
@@ -515,15 +609,20 @@ export function setEnv(
 
       // Drop any stale/orphaned public key line(s) for this file before
       // adding the fresh one, so repeated regeneration can't pile up
-      // duplicate DOTENV_PUBLIC_KEY* lines.
+      // duplicate DOTENV_PUBLIC_KEY* lines. BOTH accepted names, or a file
+      // declaring the plain form ends up with two declarations naming
+      // different keys (stacksjs/stacks#2489).
+      const staleNames = envPublicKeyNames(options.file)
       for (let i = lines.length - 1; i >= 0; i--) {
         const lineEntry = lines[i]
-        if (lineEntry !== undefined && lineEntry.trim().startsWith(`${publicKeyName}=`))
+        if (lineEntry !== undefined && staleNames.some(name => lineEntry.trim().startsWith(`${name}=`)))
           lines.splice(i, 1)
       }
 
-      // Add public key to .env file
-      lines.unshift(`${publicKeyName}="${publicKey}"`)
+      // Under the name the file already used, so a project that deliberately
+      // writes the plain `DOTENV_PUBLIC_KEY` keeps it and dotenvx keeps
+      // looking for the private half under the matching plain name.
+      lines.unshift(`${declaredName}="${publicKey}"`)
     }
 
     // Encrypt value if needed

--- a/storage/framework/core/env/tests/plain-key-name-drift.test.ts
+++ b/storage/framework/core/env/tests/plain-key-name-drift.test.ts
@@ -1,0 +1,144 @@
+/**
+ * stacksjs/stacks#2489 - the plain `DOTENV_PUBLIC_KEY` name.
+ *
+ * #2348 established that one env file must never hold two key generations, and
+ * `reusableEnvPublicKey` enforced it. But every guard looked for the SUFFIXED
+ * name, `DOTENV_PUBLIC_KEY_PRODUCTION`. `dotenvx` also accepts the plain
+ * `DOTENV_PUBLIC_KEY`, and real projects use it.
+ *
+ * Against such a file the key appeared absent, so `env:set` generated a fresh
+ * keypair, prepended a SECOND declaration, wrote a `.env.keys` holding only the
+ * new private half, and stranded every value already encrypted under the
+ * original key. Same failure as #2348, reached through a different door.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { decryptValue, encryptValue, generateKeypair } from '../src/crypto'
+import { envHasCiphertext, envPublicKeyNames, setEnv } from '../src/cli'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'stacks-env-2489-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+  delete process.env.DOTENV_PRIVATE_KEY_PRODUCTION
+})
+
+/** A file declaring its key under the PLAIN name, with ciphertext under it. */
+function plainKeyFile(publicKey: string, values: Record<string, string>): string {
+  const lines = [`DOTENV_PUBLIC_KEY="${publicKey}"`, '']
+  for (const [k, v] of Object.entries(values))
+    lines.push(`${k}="${encryptValue(v, publicKey)}"`)
+
+  const path = join(dir, '.env.production')
+  writeFileSync(path, `${lines.join('\n')}\n`, 'utf-8')
+  return path
+}
+
+function valueOf(path: string, key: string): string {
+  const line = readFileSync(path, 'utf-8').split('\n').find(l => l.startsWith(`${key}=`))
+  return (line ?? '').slice(key.length + 1).replace(/^["']|["']$/g, '')
+}
+
+describe('a file declaring the plain DOTENV_PUBLIC_KEY', () => {
+  test('keeps its existing values readable when another is added', () => {
+    const { publicKey, privateKey } = generateKeypair()
+    const path = plainKeyFile(publicKey, { EXISTING: 'original' })
+
+    const result = setEnv('ADDED', 'second', { file: path, cwd: dir })
+    expect(result.success).toBe(true)
+
+    // The whole point. Before the fix this threw, because ADDED landed under a
+    // freshly generated key and EXISTING stayed under the original.
+    expect(decryptValue(valueOf(path, 'EXISTING'), privateKey)).toBe('original')
+    expect(decryptValue(valueOf(path, 'ADDED'), privateKey)).toBe('second')
+  })
+
+  test('does not rotate the key', () => {
+    const { publicKey } = generateKeypair()
+    const path = plainKeyFile(publicKey, { EXISTING: 'original' })
+
+    setEnv('ADDED', 'second', { file: path, cwd: dir })
+
+    expect(valueOf(path, 'DOTENV_PUBLIC_KEY')).toBe(publicKey)
+  })
+
+  test('does not add a second key declaration', () => {
+    const { publicKey } = generateKeypair()
+    const path = plainKeyFile(publicKey, { EXISTING: 'original' })
+
+    setEnv('ADDED', 'second', { file: path, cwd: dir })
+
+    // Two declarations naming different keys is what made the damage
+    // intermittent: later runs reused the suffixed one and looked stable.
+    const declarations = readFileSync(path, 'utf-8')
+      .split('\n')
+      .filter(l => l.trim().startsWith('DOTENV_PUBLIC_KEY'))
+    expect(declarations).toHaveLength(1)
+    expect(declarations[0]).toContain('DOTENV_PUBLIC_KEY=')
+  })
+})
+
+describe('the keys file location', () => {
+  test('is written beside the env file, not beside the process', () => {
+    // It resolved against the CWD, so `--file ../other/.env` wrote keys into
+    // whatever directory you were standing in - landing on that project's own
+    // `.env.keys` and replacing private halves it still needed.
+    const nested = mkdtempSync(join(tmpdir(), 'stacks-env-2489-elsewhere-'))
+    try {
+      const path = join(nested, '.env.production')
+      writeFileSync(path, 'HELLO=world\n', 'utf-8')
+
+      setEnv('SECRET', 'value', { file: path, cwd: dir })
+
+      expect(existsSync(join(nested, '.env.keys'))).toBe(true)
+      expect(existsSync(join(dir, '.env.keys'))).toBe(false)
+    }
+    finally { rmSync(nested, { recursive: true, force: true }) }
+  })
+})
+
+describe('refusing to strand values', () => {
+  test('fails rather than generating a key for a file that already has ciphertext', () => {
+    // No declaration and no reachable private key: there is no way to add a
+    // value that keeps the existing ones readable, so the honest answer is to
+    // refuse. A round-trip check on the NEW value would have passed here.
+    const { publicKey } = generateKeypair()
+    const path = join(dir, '.env.production')
+    writeFileSync(path, `EXISTING="${encryptValue('original', publicKey)}"\n`, 'utf-8')
+
+    const result = setEnv('ADDED', 'second', { file: path, cwd: dir })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('already contains encrypted values')
+    // And it left the file alone.
+    expect(readFileSync(path, 'utf-8')).not.toContain('ADDED=')
+  })
+
+  test('still writes plaintext when asked, since that strands nothing', () => {
+    const { publicKey } = generateKeypair()
+    const path = join(dir, '.env.production')
+    writeFileSync(path, `EXISTING="${encryptValue('original', publicKey)}"\n`, 'utf-8')
+
+    expect(setEnv('ADDED', 'second', { file: path, cwd: dir, plain: true }).success).toBe(true)
+  })
+})
+
+describe('the helpers the guards rest on', () => {
+  test('both accepted names are recognised, suffixed first', () => {
+    expect(envPublicKeyNames('.env.production')).toEqual(['DOTENV_PUBLIC_KEY_PRODUCTION', 'DOTENV_PUBLIC_KEY'])
+    expect(envPublicKeyNames('.env')).toEqual(['DOTENV_PUBLIC_KEY'])
+  })
+
+  test('ciphertext is detected regardless of which key name declared it', () => {
+    expect(envHasCiphertext('A="encrypted:v2:abc"\n')).toBe(true)
+    expect(envHasCiphertext('A="plain"\n')).toBe(false)
+    expect(envHasCiphertext('# A="encrypted:v2:abc"\n')).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #2489.

`dotenvx` accepts both `DOTENV_PUBLIC_KEY_<ENV>` and the plain `DOTENV_PUBLIC_KEY`, and real projects use the plain form. Every guard here looked only for the suffixed name, so against such a file the key appeared absent: `env:set` generated a fresh keypair, prepended a **second** declaration, wrote a `.env.keys` holding only the new private half, and left **every value already encrypted under the original key unreadable**.

This is #2348 reached through a different door. The docblock on `reusableEnvPublicKey` says reusing the file's own public key makes that "structurally impossible" - and it does, for the one name it was looking for.

## Reproduced, then fixed

```
before:  DOTENV_PUBLIC_KEY  HELLO  EXISTING
after:   DOTENV_PUBLIC_KEY_PRODUCTION  DOTENV_PUBLIC_KEY  HELLO  EXISTING  NEWVAL

EXISTING -> encrypted:v2:eyJ2Ijoy…   (stranded)
```

With this change, same scenario:

```
key declarations: 1        same key reused, no rotation
EXISTING -> original       recovered
NEWVAL   -> second
THIRD    -> boom           a later add stays under the same key
```

All three decrypt under the **original** private key. One key generation per file, which is the invariant #2348 wanted.

## Four changes

**Both accepted names are recognised**, suffixed first, so nothing that resolves today resolves differently. The public key line is rewritten under the name the file already uses instead of a second one being added beside it.

**Rotation is refused** for a file that already holds ciphertext with no reachable key. There is no way to proceed that keeps the existing values readable, so failing is the only honest option:

```
.env.production already contains encrypted values, but no key that can be used to add another was found.
Generating one would leave every existing encrypted value unreadable.
Provide the private key as DOTENV_PRIVATE_KEY_PRODUCTION in the environment, restore .env.keys, or use --plain.
```

`--plain` still works, since writing plaintext strands nothing.

**The ciphertext witness is name-agnostic.** Keying it on a recognised key name is precisely what let the rotation through.

**`.env.keys` is written beside the env file**, not beside the process. It resolved against the CWD, so `env:set --file ../other/.env` wrote keys into whatever directory you were standing in - landing on that project's own `.env.keys` and replacing private halves it still needed, while reporting success.

## One correction to the issue's suggested fix

The issue proposes verifying the round trip before writing. **That would not have caught this, and would have added a green light to a destructive operation.** The new value encrypts and decrypts perfectly under the new key. It is the *other* values that die, and a round-trip check on the value being written never looks at them.

Also corrected on the issue: `env:set` can read back what it writes. The `dotenvx get` in the report fails because Stacks uses its own `encrypted:v2:` envelope (`core/env/src/crypto.ts:23`), not dotenvx's format - it borrows dotenvx's key *naming* without its ciphertext format. So the newly written values were never lost; the pre-existing ones were.

## Verification

- `core/env`: **253 pass / 0 fail** (8 new)
- Root suite: **409 pass / 0 fail**
- `core/buddy`: 828 pass / 3 fail, the known dist-only `package manifests` baseline
- Two of the new tests confirmed red by reverting the plain-name fallback
- Framework typecheck 13, baseline, none in the touched file
- `./buddy lint` clean for these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)