### PR TITLE
fix(database): gate a SQLite table rebuild as one block

### DIFF
--- a/storage/framework/core/database/src/migrations.ts
+++ b/storage/framework/core/database/src/migrations.ts
@@ -1353,13 +1353,57 @@ export function statementReferencesTable(statement: string, table: string): bool
  *
  * A statement whose table cannot be identified is kept.
  */
+/**
+ * The table a SQLite rebuild is rebuilding, for either end of the dance.
+ *
+ * bun-query-builder cannot ALTER a column in place, so it emits a rebuild:
+ *
+ *   CREATE TABLE "_qb_tmp_receipts" (…)
+ *   INSERT INTO "_qb_tmp_receipts" (…) SELECT … FROM "receipts"
+ *   DROP TABLE "receipts"
+ *   ALTER TABLE "_qb_tmp_receipts" RENAME TO "receipts"
+ *   CREATE UNIQUE INDEX … ON "receipts" (…)
+ *
+ * Only the middle statements name `receipts` in a way the gate could see:
+ * `statementTable` reads the ALTER's SOURCE table (`_qb_tmp_receipts`), and
+ * `statementReferencesTable` matches FROM/JOIN/UPDATE/INTO but never RENAME TO.
+ *
+ * So gating a disabled feature's table deleted the INSERT, the DROP and the
+ * index while KEEPING the create and the rename - turning a rebuild into a bare
+ * create. The gated table was created anyway, without its unique indexes, and a
+ * second rebuild of the same table then renamed onto it:
+ * "there is already another table or index with this name: receipts"
+ * (stacksjs/stacks#2534).
+ *
+ * The crash was the lucky half. A table rebuilt only once got no error at all
+ * and simply existed, so a commerce-disabled install carried 34 of 41 commerce
+ * tables with non-unique uuid columns and nothing said so.
+ *
+ * Resolving both ends to the same name is what makes the gate treat the block
+ * as a unit: the create and the rename can no longer disagree about whether
+ * this table is gated.
+ */
+function rebuiltTable(statement: string): string | null {
+  const rename = /^\s*ALTER\s+TABLE\s+["`]?([a-z0-9_]+)["`]?\s+RENAME\s+TO\s+["`]?([a-z0-9_]+)["`]?/i.exec(statement)
+  if (rename?.[2])
+    return rename[2].toLowerCase()
+
+  const table = statementTable(statement)
+  if (table?.startsWith('_qb_tmp_'))
+    return table.slice('_qb_tmp_'.length)
+
+  return null
+}
+
 export function withoutGatedStatements(sql: string, gated: ReadonlySet<string>): string {
   if (gated.size === 0)
     return sql
 
   const statements = sql.split(';').map(s => s.trim()).filter(Boolean)
   const kept = statements.filter((statement) => {
-    const table = statementTable(statement)
+    // A rebuild's temp-table statements resolve to the table being rebuilt, so
+    // every statement in the block gates together (stacksjs/stacks#2534).
+    const table = rebuiltTable(statement) ?? statementTable(statement)
     if (table && gated.has(table))
       return false
 

--- a/storage/framework/core/database/tests/gated-statements.test.ts
+++ b/storage/framework/core/database/tests/gated-statements.test.ts
@@ -96,3 +96,73 @@ describe('withoutGatedStatements', () => {
     expect(withoutGatedStatements(sql, gated)).toBe('')
   })
 })
+
+/**
+ * A SQLite table rebuild has to gate as one block (stacksjs/stacks#2534).
+ *
+ * bun-query-builder cannot ALTER a column in place, so it rebuilds:
+ * create a `_qb_tmp_<t>`, copy into it, drop `<t>`, rename the temp over it,
+ * recreate the indexes.
+ *
+ * Only the copy and the drop name `<t>` in a way the gate could see. The ALTER
+ * names the temp table as its SOURCE, and `statementReferencesTable` matches
+ * FROM/JOIN/UPDATE/INTO but never RENAME TO. So gating deleted the copy, the
+ * drop and the index while KEEPING the create and the rename - and a rebuild
+ * became a bare create of the very table the gate was meant to suppress.
+ *
+ * A fresh commerce-disabled install therefore carried 34 of 41 commerce tables,
+ * each missing its unique indexes, and a table rebuilt twice crashed the
+ * install outright with "there is already another table or index with this
+ * name: receipts".
+ */
+describe('a gated table rebuild', () => {
+  const rebuild = [
+    'PRAGMA foreign_keys=OFF',
+    'BEGIN',
+    'CREATE TABLE "_qb_tmp_coupons" (\n  "id" INTEGER PRIMARY KEY,\n  "uuid" TEXT\n)',
+    'INSERT INTO "_qb_tmp_coupons" ("id", "uuid") SELECT "id", "uuid" FROM "coupons"',
+    'DROP TABLE "coupons"',
+    'ALTER TABLE "_qb_tmp_coupons" RENAME TO "coupons"',
+    'CREATE UNIQUE INDEX IF NOT EXISTS "coupons_uuid_unique" ON "coupons" ("uuid")',
+    'PRAGMA foreign_key_check',
+    'COMMIT',
+  ].join(';\n')
+
+  test('drops the temp create, so the gated table is never made', () => {
+    const kept = withoutGatedStatements(rebuild, gated)
+
+    // The statement that actually created the table on a commerce-disabled
+    // install. Red before the fix.
+    expect(kept).not.toContain('_qb_tmp_coupons')
+  })
+
+  test('drops the rename, which is what materialised the table', () => {
+    expect(withoutGatedStatements(rebuild, gated)).not.toContain('RENAME TO "coupons"')
+  })
+
+  test('leaves no half of the rebuild behind', () => {
+    const kept = withoutGatedStatements(rebuild, gated)
+
+    // A kept CREATE with a dropped RENAME strands a temp table; a kept RENAME
+    // with a dropped CREATE fails outright. Both ends gate together or neither.
+    expect(kept).not.toContain('coupons')
+    // The transaction scaffolding names no table and is still there.
+    expect(kept).toContain('BEGIN')
+    expect(kept).toContain('COMMIT')
+  })
+
+  test('leaves an ungated table\'s rebuild completely intact', () => {
+    const ungated = rebuild.replace(/coupons/g, 'receipts_kept')
+
+    const kept = withoutGatedStatements(ungated, gated)
+
+    expect(kept).toContain('CREATE TABLE "_qb_tmp_receipts_kept"')
+    expect(kept).toContain('DROP TABLE "receipts_kept"')
+    expect(kept).toContain('RENAME TO "receipts_kept"')
+    expect(kept).toContain('CREATE UNIQUE INDEX IF NOT EXISTS "coupons_uuid_unique"'.replace('coupons', 'receipts_kept'))
+  })
+
+  test('is a no-op when nothing is gated', () => {
+    expect(withoutGatedStatements(rebuild, new Set())).toBe(rebuild)
+  })
+})


### PR DESCRIPTION
Closes #2534. **This is a regression #2488 introduced**, and it is worse than the reported crash.

## The crash

`withoutGatedStatements` filters a migration one statement at a time. A SQLite table rebuild is five statements that only mean anything together:

```sql
CREATE TABLE "_qb_tmp_receipts" (…)
INSERT INTO "_qb_tmp_receipts" (…) SELECT … FROM "receipts"
DROP TABLE "receipts"
ALTER TABLE "_qb_tmp_receipts" RENAME TO "receipts"
CREATE UNIQUE INDEX … ON "receipts" (…)
```

Only the copy and the drop name `receipts` in a way the gate could see. The rename names the **temp** table as its source, and `statementReferencesTable` matches `FROM|JOIN|UPDATE|INTO` but never `RENAME TO`.

So gating deleted the copy, the drop and the index, and **kept the create and the rename**. A rebuild became a bare create of the very table the gate existed to suppress. A second rebuild of the same table then renamed onto it:

```
SQLiteError: there is already another table or index with this name: receipts
```

## The part that is worse than the crash

A table rebuilt only *once* produced no error at all. It simply existed.

```
commerce disabled, before this fix:  34 of 41 commerce tables present
```

Each one missing the unique indexes that *were* correctly stripped. So a commerce-disabled install was silently carrying phantom `products`, `orders`, `carts`, `payments`, `gift_cards` and the rest, with non-unique uuid columns, and nothing said so. **#2488 was not in force at the schema level.** The crash was the lucky half.

## Confirmed as my regression, not pre-existing

Flipping `config/commerce.ts` back to `enabled: true` and running a fresh migrate: **exit 0, zero collisions**. The failure needs the gate to be active, and #2488 is what activated it for commerce.

## The fix

Resolve both ends of a rebuild to the table being rebuilt, so the create and the rename can no longer disagree about whether it is gated. One helper, one changed line.

## Measured, full `buddy migrate` on a fresh SQLite database

| | exit | commerce tables | orphan `_qb_tmp_*` |
|---|---|---|---|
| commerce off, before | **1** | 34 | - |
| commerce off, after | **0** | **0** | 0 |
| commerce on, after | **0** | 5/5 | 0 |

127 migrations recorded in the passing run.

## Deliberately not done

**Deduplicating the three migrations that rebuild `receipts`.** They are successive shapes tracking real edits to `Receipt.ts`; squashing them loses schema deltas and leaves the same defect to fire on `coupons` instead.

**Making the filter parse `BEGIN`…`COMMIT` blocks.** Gating each statement by its true target already gates the block as a unit, proven by zero orphan temp tables in both arms.

## Separately, and not fixed here

`buddy migrate` already exits **1** on this failure. The installer reporting success over it is Pantry not propagating a non-zero exit - the same shape as the deploy finding noted on #2477, and worth its own issue rather than riding inside a data-integrity fix.

## Verification

- 5 new tests; 3 confirmed red by reverting the one-line change
- `core/database`: **957 pass / 1 fail**, the pre-existing clock-sensitive `sql-datetime` test
- Root suite: **409 pass / 0 fail**
- Framework typecheck: 19, identical to the clean-tree baseline, none in the touched file
- `./buddy lint` clean for these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)