### PR TITLE
fix(database): open the after-commit scope for db.transaction()

### DIFF
--- a/storage/framework/core/database/src/utils.ts
+++ b/storage/framework/core/database/src/utils.ts
@@ -14,6 +14,7 @@ import { config as queryBuilderConfig, createQueryBuilder, registerPersistentQue
 // These can be overridden later once config is fully loaded
 // Read from environment variables first
 import { SQL } from 'bun'
+import { runInTransactionScope } from './transaction-context'
 import { env as envVars } from '@stacksjs/env'
 import type { QueryBuilderDialect } from './dialect'
 import type { FrameworkSchema } from './framework-schema'
@@ -592,6 +593,38 @@ function applySqliteTransactionSerialization(instance: RawQueryBuilder): void {
 }
 
 /**
+ * Open the after-commit dispatch scope for every `db.transaction()` call.
+ *
+ * `runInTransactionScope` is what `isInTransaction()` and
+ * `enqueueAfterCommit()` read, and it was only ever opened by
+ * `@stacksjs/orm`'s `transaction()`. The raw builder's own
+ * `db.transaction()` got SQLite serialization and replica routing but not
+ * this - so a `job(...).dispatch()` inside its callback saw
+ * `isInTransaction() === false` and dispatched immediately instead of
+ * buffering until commit (stacksjs/stacks#2539).
+ *
+ * That is not merely early. A rollback then leaves the side effect done: the
+ * row can roll back with the shared SQLite connection, but a Redis push or an
+ * HTTP call cannot, which is exactly what after-commit buffering exists to
+ * prevent. The queue's own comments describe `db.transaction(...)` as
+ * activating it.
+ *
+ * Applied BEFORE the routing patch, so routing stays the outermost wrapper as
+ * documented below and the buffered callbacks flush while the routing context
+ * is still open. Flushing outside it would send an after-commit read to a
+ * replica, which can lag the commit that callback is predicated on.
+ *
+ * Reentrant, so the ORM's `transaction()` wrapping this one is a no-op beyond
+ * depth tracking, and `transactional()` / `savepoint()` - which call
+ * `this.transaction(...)` internally - are covered by the same patch.
+ */
+function applyTransactionDispatchScope(instance: RawQueryBuilder): void {
+  const original = (instance.transaction as (...args: any[]) => Promise<any>).bind(instance)
+  ;(instance).transaction = (...args: any[]) =>
+    runInTransactionScope(() => original(...args))
+}
+
+/**
  * Mark the routing context as "inside a transaction" for the duration of
  * every `db.transaction()` call.
  *
@@ -625,6 +658,8 @@ function getDb(): ReturnType<typeof createQueryBuilder> {
     // transaction serialization patch is needed here.
     if (getDialect() === 'sqlite')
       applySqliteTransactionSerialization(_dbInstance)
+    // Before the routing patch on purpose; see applyTransactionDispatchScope.
+    applyTransactionDispatchScope(_dbInstance)
     // Applied after the sqlite patch so the routing context is the
     // outermost wrapper — a read issued while queued behind another
     // transaction is then treated as in-transaction and stays on the

--- a/storage/framework/core/database/tests/raw-transaction-scope.test.ts
+++ b/storage/framework/core/database/tests/raw-transaction-scope.test.ts
@@ -1,0 +1,113 @@
+// stacksjs/stacks#2539 — `db.transaction()` must open the after-commit scope.
+//
+// `runInTransactionScope` is what `isInTransaction()` and `enqueueAfterCommit()`
+// read, and only `@stacksjs/orm`'s `transaction()` ever opened it. The raw
+// builder's own `db.transaction()` got SQLite serialization and replica routing
+// but not this, so a `job(...).dispatch()` inside its callback saw
+// `isInTransaction() === false` and dispatched immediately.
+//
+// Not merely early: on rollback the side effect is already done. The row can
+// roll back with the shared SQLite connection, but a Redis push or an HTTP call
+// cannot, which is the whole reason after-commit buffering exists.
+//
+// transaction-context.test.ts covers the primitive in isolation and says so in
+// its own header. That is exactly why this went unnoticed - the primitive was
+// always correct, and no test drove it through a public entry point.
+
+const originalDbConnection = process.env.DB_CONNECTION
+const originalDbDatabasePath = process.env.DB_DATABASE_PATH
+process.env.DB_CONNECTION = 'sqlite'
+process.env.DB_DATABASE_PATH = ':memory:'
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+
+let releaseDbConfigLock: () => void
+
+afterAll(() => {
+  if (originalDbConnection === undefined) delete process.env.DB_CONNECTION
+  else process.env.DB_CONNECTION = originalDbConnection
+  if (originalDbDatabasePath === undefined) delete process.env.DB_DATABASE_PATH
+  else process.env.DB_DATABASE_PATH = originalDbDatabasePath
+  releaseDbConfigLock?.()
+})
+
+const { acquireDbConfigLock, db, ensureDatabaseConfigLoaded, initializeDbConfig } = await import('../src/utils')
+const { enqueueAfterCommit, isInTransaction } = await import('../src/transaction-context')
+
+beforeAll(async () => {
+  releaseDbConfigLock = await acquireDbConfigLock()
+  await ensureDatabaseConfigLoaded()
+  initializeDbConfig({
+    database: {
+      default: 'sqlite',
+      connections: { sqlite: { database: ':memory:' } },
+    },
+  })
+})
+
+describe('db.transaction() and the after-commit scope', () => {
+  it('reports being inside a transaction', async () => {
+    // Red before the fix: false, so the buffering branch in the queue's
+    // dispatch was skipped entirely and it fell through to immediate.
+    let inside: boolean | undefined
+    await db.transaction(async () => { inside = isInTransaction() })
+
+    expect(inside).toBe(true)
+    expect(isInTransaction()).toBe(false)
+  })
+
+  it('buffers a callback until the transaction commits', async () => {
+    const fired: string[] = []
+
+    await db.transaction(async () => {
+      enqueueAfterCommit(async () => { fired.push('side-effect') })
+      // The assertion that matters: nothing has run yet.
+      expect(fired).toEqual([])
+    })
+
+    expect(fired).toEqual(['side-effect'])
+  })
+
+  it('discards buffered callbacks when the transaction rolls back', async () => {
+    // The case the row-level rollback cannot cover. A queued Redis push or an
+    // outbound HTTP call does not roll back with the connection.
+    const fired: string[] = []
+
+    await expect(db.transaction(async () => {
+      enqueueAfterCommit(async () => { fired.push('should-not-fire') })
+      throw new Error('rollback')
+    })).rejects.toThrow('rollback')
+
+    expect(fired).toEqual([])
+  })
+
+  it('fires exactly once when the orm wrapper nests around it', async () => {
+    // `@stacksjs/orm`'s `transaction()` already opens a scope and then calls
+    // `db.transaction()`, which now opens one too. The scope is reentrant, so
+    // the inner call only tracks depth - but a double flush here would send
+    // every queued job twice.
+    const { transaction } = await import('@stacksjs/orm')
+    const fired: string[] = []
+
+    await transaction(async () => {
+      enqueueAfterCommit(async () => { fired.push('once') })
+    })
+
+    expect(fired).toEqual(['once'])
+  })
+
+  it('lets the outermost transaction own the flush when nested directly', async () => {
+    const fired: string[] = []
+
+    await db.transaction(async () => {
+      await db.transaction(async () => {
+        enqueueAfterCommit(async () => { fired.push('inner') })
+      })
+      // Still buffered: the inner transaction committing is not the commit
+      // the callback was waiting on.
+      expect(fired).toEqual([])
+    })
+
+    expect(fired).toEqual(['inner'])
+  })
+})


### PR DESCRIPTION
Closes #2539.

`runInTransactionScope` is what `isInTransaction()` and `enqueueAfterCommit()` read, and **only `@stacksjs/orm`'s `transaction()` ever opened it**. The raw builder's own `db.transaction()` was patched in `getDb()` for SQLite serialization and replica routing, but not for this.

Measured before the fix:

```
outside any transaction  : false
inside db.transaction()  : false   ← the bug
inside orm transaction() : true
```

So inside `db.transaction()` the queue's buffering branch was skipped entirely - `isInTransaction()` false means `job(...).dispatch()` never even reaches `enqueueAfterCommit` and falls straight through to immediate dispatch.

## Why "early" understates it

On rollback the side effect has already happened. A database-backed enqueue can share the SQLite connection and roll back with it, but a Redis push or an outbound HTTP call cannot - which is the entire reason after-commit buffering exists. The queue's own comments describe `db.transaction(...)` as activating it.

## The fix, and why the ordering is deliberate

One patch in `getDb()`, applied **before** the routing patch so:

- routing stays the outermost wrapper, as its own comment documents
- buffered callbacks flush **while the routing context is still open**. Flushing outside it would route an after-commit read to a replica, which can lag the very commit that callback is predicated on

## Nesting verified, not assumed

The ORM's `transaction()` opens a scope and then calls `db.transaction()`, which now opens one too. The scope is reentrant so the inner call only tracks depth - but a double flush would send **every queued job twice**, so it is tested both ways:

```
orm transaction() wrapping db.transaction() -> fires exactly once
db.transaction() nested directly            -> inner stays buffered, outermost owns the flush
```

`transactional()` and `savepoint()` reach the same patch, since they call `this.transaction(...)` internally.

## Behaviour now

```
during transaction : []                buffered
after commit       : ["side-effect"]   fired
after rollback     : []                discarded
```

## The tests drive the real entry point

`transaction-context.test.ts` states in its own header that it covers the primitive in isolation, "no actual db.transaction". That is precisely why this went unnoticed: the primitive was always correct, and nothing proved the integration through a public entry point - which is the gap #2539 calls out.

3 of the 5 new tests confirmed red by reverting the one-line patch call.

## Verification

- `core/database`: **962 pass / 1 fail**, the pre-existing clock-sensitive `sql-datetime` test
- `core/orm`: **1952 pass / 0 fail**
- `core/queue`: **351 pass / 0 fail**
- Root suite: **409 pass / 0 fail**
- Framework typecheck: 19, identical to the clean-tree baseline, none in the touched file
- `./buddy lint` clean for these files

Not addressed here: #2538's performance candidate, and Redis execution, which the issue notes was not exercised by its reproduction either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)