### PR TITLE
fix(auth): accept the user id shape the database returns

### DIFF
--- a/storage/framework/core/auth/src/rbac.ts
+++ b/storage/framework/core/auth/src/rbac.ts
@@ -220,14 +220,40 @@ function getUserId(user: UserModel | { id: number } | number): number {
       throw new TypeError('RBAC user id must be a positive number')
     return user
   }
-  const id = (user as { id?: unknown }).id
-  if (typeof id !== 'number' || !Number.isFinite(id) || id <= 0) {
-    // Validate at the boundary so `user.id === undefined` doesn't
-    // collapse into a shared `undefined` cache slot (every such user
-    // would share the same cached roles/permissions). See
-    // stacksjs/stacks#1860 M-6.
-    throw new TypeError(`RBAC user id must be a positive number, got ${typeof id} (${String(id)})`)
-  }
+  const raw = (user as { id?: unknown }).id
+
+  /*
+   * Coerce, then validate.
+   *
+   * This required `typeof id === 'number'`, which made RBAC unusable on
+   * Postgres: `users.id` is BIGSERIAL and `bun:sql` returns it as a STRING, so
+   * every call carrying a user loaded from the database threw - `hasRole`,
+   * `hasAnyRole`, `hasPermission`, `assignRole`, `syncRoles`, all of them
+   * (stacksjs/stacks#2562).
+   *
+   * The guard's original reason still holds and is preserved: an `undefined`
+   * id must never collapse into a shared cache slot where every such user
+   * would read the same roles (stacksjs/stacks#1860 M-6). That argument is
+   * about nullish and nonsense ids, not about "125".
+   *
+   * Only number, string and bigint are coerced. `Number()` would happily turn
+   * `true` into 1 and `['125']` into 125, and an id arriving as either of
+   * those is a bug worth surfacing rather than silently authorising against
+   * user 1.
+   */
+  if (typeof raw !== 'number' && typeof raw !== 'string' && typeof raw !== 'bigint')
+    throw new TypeError(`RBAC user id must be a positive number, got ${typeof raw} (${String(raw)})`)
+
+  const id = Number(raw)
+  if (!Number.isInteger(id) || id <= 0)
+    throw new TypeError(`RBAC user id must be a positive number, got ${typeof raw} (${String(raw)})`)
+
+  // Above Number.MAX_SAFE_INTEGER two distinct BIGSERIAL ids can round to the
+  // same double, which would share a cache slot - the exact failure #1860 M-6
+  // exists to prevent, arriving by a different route.
+  if (!Number.isSafeInteger(id))
+    throw new TypeError(`RBAC user id exceeds the safe integer range, got ${String(raw)}`)
+
   return id
 }
 

--- a/storage/framework/core/auth/tests/rbac-user-id.test.ts
+++ b/storage/framework/core/auth/tests/rbac-user-id.test.ts
@@ -1,0 +1,96 @@
+import type { RbacStore } from '../src/rbac'
+// stacksjs/stacks#2562 — RBAC must accept the id shape the database returns.
+//
+// `getUserId()` required `typeof id === 'number'`. On Postgres `users.id` is
+// BIGSERIAL and `bun:sql` returns it as a STRING, so every RBAC call carrying a
+// user loaded from the database threw and RBAC was unusable on that dialect.
+//
+// The guard's original reason (stacksjs/stacks#1860 M-6) still holds and is
+// kept: a nullish id must never collapse into a shared cache slot where every
+// such user reads the same roles. That argument is about nonsense ids, not
+// about "125".
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { hasRole, setRbacStore } from '../src/rbac'
+
+/** Records which user id the store was asked about. */
+let askedFor: number[] = []
+
+function createStore(): RbacStore {
+  return {
+    async getUserRoles(userId: number) {
+      askedFor.push(userId)
+      return [{ id: 1, name: 'admin', guard_name: 'web' }]
+    },
+    async getUserPermissions() { return [] },
+  } as unknown as RbacStore
+}
+
+beforeEach(() => {
+  askedFor = []
+  setRbacStore(createStore())
+})
+
+describe('accepted id shapes', () => {
+  test('a number, as SQLite returns', async () => {
+    expect(await hasRole({ id: 125 } as never, 'admin')).toBe(true)
+    expect(askedFor).toEqual([125])
+  })
+
+  test('a numeric string, as Postgres BIGSERIAL returns', async () => {
+    // The whole bug. Red before the fix.
+    expect(await hasRole({ id: '125' } as never, 'admin')).toBe(true)
+    expect(askedFor).toEqual([125])
+  })
+
+  test('a bigint', async () => {
+    expect(await hasRole({ id: 125n } as never, 'admin')).toBe(true)
+    expect(askedFor).toEqual([125])
+  })
+
+  test('a bare number argument still works', async () => {
+    expect(await hasRole(125 as never, 'admin')).toBe(true)
+  })
+
+  test('string and number ids reach the same cache slot', async () => {
+    // They name one user, so they must not be cached separately - and the
+    // store must be asked with a number either way.
+    await hasRole({ id: 125 } as never, 'admin')
+    await hasRole({ id: '125' } as never, 'admin')
+
+    expect(askedFor.every(id => id === 125)).toBe(true)
+    expect(askedFor.every(id => typeof id === 'number')).toBe(true)
+  })
+})
+
+describe('rejected id shapes', () => {
+  // Each of these would otherwise share one cache slot, or authorise against
+  // the wrong user entirely.
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+    ['a non-numeric string', 'abc'],
+    ['zero', 0],
+    ['a negative number', -1],
+    ['a fractional number', 1.5],
+  ])('rejects %s', async (_label, id) => {
+    await expect(hasRole({ id } as never, 'admin')).rejects.toThrow(/positive number/)
+  })
+
+  test('rejects a boolean, which Number() would turn into user 1', async () => {
+    // `Number(true) === 1`. Coercing blindly would authorise against whoever
+    // user 1 happens to be, which on most installs is an administrator.
+    await expect(hasRole({ id: true } as never, 'admin')).rejects.toThrow(/positive number/)
+  })
+
+  test('rejects a single-element array, which Number() would unwrap', async () => {
+    await expect(hasRole({ id: [125] } as never, 'admin')).rejects.toThrow(/positive number/)
+  })
+
+  test('rejects an id beyond the safe integer range', async () => {
+    // Two distinct BIGSERIAL ids can round to the same double up here, which
+    // is #1860 M-6's shared-cache-slot failure arriving by another route.
+    await expect(hasRole({ id: '9007199254740993' } as never, 'admin'))
+      .rejects.toThrow(/safe integer range/)
+  })
+})


### PR DESCRIPTION
Closes #2562.

`getUserId()` required `typeof id === 'number'`. On Postgres `users.id` is `BIGSERIAL` and `bun:sql` returns it as a **string**, so every RBAC call carrying a user loaded from the database threw. `hasRole`, `hasAnyRole`, `hasAllRoles`, `hasPermission`, `assignRole`, `syncRoles` - RBAC was simply unusable on that dialect.

## The original guard is preserved, not removed

It exists so an `undefined` id cannot collapse into a shared cache slot where every such user reads the same roles (#1860 M-6). That reasoning is about nullish and nonsense ids. `"125"` is a perfectly good cache key once coerced, and both shapes now reach the *same* numeric slot.

## Coercion is deliberately narrow

Only `number`, `string` and `bigint`. `Number()` would turn `true` into `1` and `['125']` into `125` - an id arriving as either is a bug worth surfacing, not one worth silently authorising against user 1, who on most installs is an administrator.

Ids beyond `Number.MAX_SAFE_INTEGER` are rejected as well: two distinct BIGSERIAL values can round to the same double up there, which is #1860 M-6's shared-slot failure arriving by another route.

## Verified across every shape

```
ok  number 125               accepted     ok  undefined            rejected
ok  string "125" (postgres)  accepted     ok  null                 rejected
ok  bigint 125n              accepted     ok  empty string         rejected
                                          ok  non-numeric string   rejected
                                          ok  zero                 rejected
                                          ok  negative             rejected
                                          ok  boolean true         rejected
                                          ok  array [125]          rejected
                                          ok  unsafe big string    rejected
```

4 of the 15 new tests confirmed red by restoring the `number`-only check.

## On the other two RBAC issues in this batch

Both are **already fixed on main**, verified by running them rather than by reading:

```
#2563  store auto-installs with STACKS_SKIP_DEFAULT_ROUTES=1  -> YES
#2561  authenticatedUser() resolves the async accessor        -> YES
```

- **#2561** was fixed in `383114c4e0` (2026-08-16), first shipped in **v0.72.7**. Both `Role.ts` and `Permission.ts` now call `await authenticatedUser(request)`, which invokes the async `user` macro correctly.
- **#2563** was fixed in `7bbe600c41` (2026-07-26), first shipped in **v0.70.183**. `getStore()` lazily installs the bqb-backed default, so the skip-routes flag no longer disables the service.

They should be closed as fixed rather than reimplemented. Worth checking whether the reporting app has published its own `app/Middleware/Role.ts`, since a userland copy would keep the old `request.user` read regardless of the framework version.

## Verification

- `core/auth`: **357 pass / 0 fail**
- Root suite: **409 pass / 0 fail**
- Framework typecheck: 19, identical to the clean-tree baseline
- `./buddy lint` clean for these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)