### PR TITLE
test(auth): pin the two RBAC regressions that made it unusable

### DIFF
--- a/storage/framework/core/auth/tests/rbac-default-store.test.ts
+++ b/storage/framework/core/auth/tests/rbac-default-store.test.ts
@@ -1,0 +1,62 @@
+/**
+ * RBAC works without anyone wiring a store.
+ *
+ * stacksjs/stacks#2563: `setRbacStore()` is called from exactly one place,
+ * `defaults/bootstrap.ts`, which the route loader imports only when default
+ * routes are being loaded. So `STACKS_SKIP_DEFAULT_ROUTES=1` - the documented
+ * escape hatch for apps that do not ship every framework model - also
+ * disabled the RBAC *service*, and every `hasRole()` / `role:` guard answered
+ * `RBAC store not configured. Call setRbacStore() first.`
+ *
+ * `getStore()` now installs the query-builder-backed store the first time one
+ * is needed, so registration is opt-out rather than opt-in and the bootstrap's
+ * call is an optimisation rather than a prerequisite.
+ *
+ * Runs in a subprocess on purpose: the store is module-level state, and a
+ * sibling test file that calls `setRbacStore()` with a double would otherwise
+ * satisfy this one for the wrong reason.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+
+const RBAC_MODULE = join(import.meta.dir, '../src/rbac.ts')
+
+const PROBE = `
+const { findRole } = await import(${JSON.stringify(RBAC_MODULE)})
+try {
+  await findRole('a-role-that-does-not-exist')
+  console.log('PROBE:resolved')
+}
+catch (error) {
+  console.log('PROBE:' + (error instanceof Error ? error.message : String(error)))
+}
+`
+
+function probe(): string {
+  const proc = Bun.spawnSync(['bun', '-e', PROBE], {
+    // The flag is the whole point: this is the configuration in which the
+    // bootstrap that used to be the only caller of setRbacStore() never runs.
+    env: { ...process.env, STACKS_SKIP_DEFAULT_ROUTES: '1' },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  })
+
+  const line = proc.stdout.toString().split('\n').find(l => l.startsWith('PROBE:'))
+
+  return line ?? `PROBE:no output (stderr: ${proc.stderr.toString().slice(0, 400)})`
+}
+
+describe('RBAC default store', () => {
+  test('an RBAC call with no setRbacStore() resolves a store', () => {
+    const result = probe()
+
+    // The call may still fail on the environment - no database file, no
+    // `roles` table - and that is fine here. What must never come back is the
+    // store itself being missing, which is the #2563 failure.
+    expect(result).not.toMatch(/store not configured/i)
+    expect(result).not.toMatch(/setRbacStore/)
+    expect(result).not.toMatch(/undefined is not an object|Cannot read propert/i)
+    expect(result).toStartWith('PROBE:')
+  })
+})

--- a/tests/unit/authorization-middleware-user-contract.test.ts
+++ b/tests/unit/authorization-middleware-user-contract.test.ts
@@ -1,0 +1,49 @@
+/**
+ * How the scaffold's authorization middleware are allowed to read "the user".
+ *
+ * stacksjs/stacks#2561: every one of them opened with
+ *
+ *     const user = request.user || request._user || request._authenticatedUser
+ *
+ * `request.user` is the lazily-resolving macro `enhanceRequest()` installs - a
+ * FUNCTION. Truthy, so the `||` chain stopped there and the "unauthenticated"
+ * check passed, then RBAC read `.id` off a function and every `role:` /
+ * `permission:` guarded route answered 500. `_user` is assigned nowhere in the
+ * framework at all.
+ *
+ * `authenticatedUser()` is the one place that resolves this correctly, and
+ * core/auth/tests/authenticated-user.test.ts pins its behaviour. What is left
+ * un-pinned is that the middleware actually ask it - so this asserts the shape
+ * of the call site, which is what regressed.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const MIDDLEWARE_DIR = join(import.meta.dir, '../../storage/framework/defaults/app/Middleware')
+
+/** The middleware that answer "is this user allowed?" and so must resolve one. */
+const AUTHORIZATION_MIDDLEWARE = ['Can', 'EnsureEmailIsVerified', 'Permission', 'Role', 'Team']
+
+function source(name: string): string {
+  return readFileSync(join(MIDDLEWARE_DIR, `${name}.ts`), 'utf8')
+}
+
+describe('authorization middleware resolve the user through authenticatedUser()', () => {
+  for (const name of AUTHORIZATION_MIDDLEWARE) {
+    test(`${name} awaits authenticatedUser(request)`, () => {
+      const code = source(name)
+      expect(code).toContain('authenticatedUser')
+      expect(code).toMatch(/await authenticatedUser\(request\)/)
+    })
+
+    test(`${name} never reads request.user or request._user directly`, () => {
+      const code = source(name)
+      // `request.user` is a function; `request._user` does not exist. Reading
+      // either is the #2561 bug, whichever way the fallback chain is written.
+      expect(code).not.toMatch(/request\.user\b/)
+      expect(code).not.toMatch(/request\._user\b/)
+    })
+  }
+})


### PR DESCRIPTION
Closes #2561, closes #2563.

Both reported bugs are **already fixed on main** — the report was made against an older installed framework. Neither fix is pinned by a test that would catch it coming back, which is what this PR adds.

## #2561 — Role/Permission middleware read `request.user`

Fixed by 383114c4e0 (2026-08-16, shipped in v0.72.10). The five authorization middleware opened with

```ts
const user = request.user || request._user || request._authenticatedUser
```

where `user` is the lazily-resolving macro `enhanceRequest()` installs — a function, truthy, so the chain stopped there — and `_user` is assigned nowhere in the framework. They all route through `authenticatedUser()` now.

The traceback in the issue confirms the version: `at handle (defaults/app/Middleware/Role.ts:36:31)`. Line 36 of the **pre-fix** file is exactly `const hasRequired = await hasAnyRole(user, requiredRoles)`; line 36 of the current file is a comment.

`core/auth/tests/authenticated-user.test.ts` covers the resolver itself well. What was not covered is that the middleware actually *call* it, which is the part that regressed — so `tests/unit/authorization-middleware-user-contract.test.ts` asserts the call site for all five, and that none of them reads `request.user` / `request._user` directly. Verified red against the exact pre-fix source (2 failures on `Role`).

## #2563 — `STACKS_SKIP_DEFAULT_ROUTES=1` disabled RBAC

Fixed by 7bbe600c41 (2026-07-26, shipped in v0.70.183), which took the issue's own suggested option 2: `getStore()` installs the query-builder-backed store the first time one is needed, so registration is opt-out rather than opt-in and `defaults/bootstrap.ts` calling it is an optimisation rather than a prerequisite. The string `RBAC store not configured` no longer exists in any code path — only in two comments describing the old behaviour.

Verified directly rather than by reading: with `STACKS_SKIP_DEFAULT_ROUTES=1` and no `setRbacStore()` call anywhere, `findRole('admin')` resolves against the database instead of throwing.

`core/auth/tests/rbac-default-store.test.ts` pins that. It runs in a subprocess on purpose — the store is module-level state, and a sibling test file installing a double would otherwise satisfy it for the wrong reason — and tolerates an environment error (no database file, no `roles` table) while failing on the store itself being missing. Verified red by restoring the old throw in `getStore()`.

## For the app that hit these

Both are in v0.72.10+ and the current release is v0.74.32; upgrading picks them up. #2562 (`getUserId()` rejecting string ids) was the one of the three that was genuinely still open, and landed separately.

## Verification

- `bun test` on the two new files: 11 pass; both confirmed red against the pre-fix code.
- `bun run typecheck`: 19 errors, unchanged from the main baseline.
- `./buddy lint`: 1 pre-existing error in an untracked local file, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)