### PR TITLE
fix(setup): fail the install when the initial migration fails

### DIFF
--- a/storage/framework/core/buddy/src/commands/setup.ts
+++ b/storage/framework/core/buddy/src/commands/setup.ts
@@ -11,6 +11,8 @@ import { path as p } from '@stacksjs/path'
 import { copyFile, storage } from '@stacksjs/storage'
 import { ExitCode } from '@stacksjs/types'
 import { setupPrettyDevEnvironment } from './dev'
+import type { Reachability } from '../initial-migration'
+import { runInitialMigration } from '../initial-migration'
 import { resultFailed } from '../result'
 
 interface SetupOptions extends CliOptions {
@@ -265,36 +267,36 @@ export async function ensureAppKey(cwd: string): Promise<void> {
   log.success('Generated application key')
 }
 
-async function runInitialMigration(cwd: string): Promise<void> {
-  // Setup also runs on deploy/CI targets, where onboarding must not touch
-  // the database. Only a local/dev context gets the automatic first pass.
-  const appEnv = (process.env.APP_ENV || process.env.NODE_ENV || 'local').toLowerCase()
-
-  if (!['local', 'development', 'dev', 'test'].includes(appEnv)) {
-    log.info(`Skipping initial migration in the ${appEnv} environment`)
-    return
-  }
-
-  log.info('Running initial database migration...')
-
+/**
+ * Can the configured database be reached right now?
+ *
+ * This is the whole basis for "required vs best-effort" in
+ * `runInitialMigration`. Nothing here decides whether a migration is a good
+ * idea - only whether a failure would mean the schema is wrong (the database
+ * answered) or that the environment is not ready (it did not).
+ *
+ * SQLite and DynamoDB have no target to probe: SQLite creates its file on
+ * open, so it counts as reachable. When the probe itself cannot run, the
+ * migration gets to speak for itself rather than being pre-emptively excused.
+ */
+async function databaseIsReachable(): Promise<Reachability> {
   try {
-    // The migrate action is non-interactive (the confirmation guards live in
-    // the `buddy migrate` command, not the action), so this is safe to run
-    // unattended. Best-effort either way: a fresh project may have no models
-    // or no reachable database yet, and neither should fail onboarding.
-    const result = await runAction(Action.Migrate, { cwd })
+    const { describeTarget, probeTargetDatabase, resolveConnectionTarget } = await import('@stacksjs/database')
+    const target = resolveConnectionTarget()
 
-    if (resultFailed(result)) {
-      log.warn('Initial migration did not complete - you can run it later via ./buddy migrate')
-      log.debug(result.error)
-      return
-    }
+    if (!target)
+      return { ok: true }
 
-    log.success('Database is migrated')
+    const probe = await probeTargetDatabase(target)
+
+    if (probe.ok)
+      return { ok: true }
+
+    return { ok: false, reason: `${describeTarget(target)} is not reachable yet (${probe.kind})` }
   }
-  catch (error) {
-    log.warn('Initial migration did not complete - you can run it later via ./buddy migrate')
-    log.debug(error)
+  catch {
+    // Could not tell. Run the migration and judge it on its own result.
+    return { ok: true }
   }
 }
 
@@ -309,7 +311,13 @@ async function initializeProject(options: SetupOptions): Promise<void> {
     await ensureAppKey(cwd)
   }
 
-  await runInitialMigration(cwd)
+  const migration = await runInitialMigration({
+    appEnv: process.env.APP_ENV || process.env.NODE_ENV || 'local',
+    isReachable: databaseIsReachable,
+    migrate: () => runAction(Action.Migrate, { cwd }),
+    failed: resultFailed,
+    log,
+  })
 
   ensureIdeSettings(cwd)
 
@@ -336,6 +344,19 @@ async function initializeProject(options: SetupOptions): Promise<void> {
       log.warn('AWS not configured - you can do this later via ./buddy configure:aws')
       log.debug(error)
     }
+  }
+
+  // stacksjs/stacks#2560: the remaining steps above are worth finishing either
+  // way - IDE settings and AWS do not depend on the schema - but setup does not
+  // get to claim success over a database that a migration failed on. Written
+  // synchronously to stderr because the logger writes asynchronously and a
+  // hard exit drops anything it has not flushed yet.
+  if (migration === 'failed') {
+    process.stderr.write('\nInitial database migration FAILED, so this project is not set up.\n')
+    process.stderr.write('Its database did not receive the schema; the error is above.\n')
+    process.stderr.write('Fix the migration, then run `./buddy migrate`.\n')
+    await log.flush()
+    process.exit(ExitCode.FatalError)
   }
 
   log.success('Project is setup')

--- a/storage/framework/core/buddy/src/initial-migration.ts
+++ b/storage/framework/core/buddy/src/initial-migration.ts
@@ -1,0 +1,100 @@
+/**
+ * The first migration `buddy setup` runs, and whether failing it fails setup.
+ *
+ * stacksjs/stacks#2560: this step used to downgrade every failure to
+ * `Initial migration did not complete - you can run it later`, and setup went
+ * on to print "Project is setup" and exit 0. A first install could therefore
+ * complete, report success, and leave a database that never received its
+ * schema, with the only signal a stack trace in output nobody reads on a green
+ * run. Every check downstream then ran against that broken state and passed.
+ *
+ * The rule here is that reachability decides:
+ *
+ *   - the database answered  -> the migration is REQUIRED, and a failure is
+ *     setup's failure
+ *   - it did not answer      -> the migration is SKIPPED, said out loud, with
+ *     the follow-up command named
+ *
+ * which is the "decide explicitly whether this is required or best-effort"
+ * the issue asked for, rather than a step that looks required and behaves
+ * optional. The decision is a pure function of injected dependencies so it can
+ * be tested without a database, a subprocess, or a scaffolded project.
+ */
+
+/** What the initial migration did, as far as the rest of setup is concerned. */
+export type MigrationOutcome = 'migrated' | 'skipped' | 'failed'
+
+/** Whether the configured database can be reached, and why not when it cannot. */
+export type Reachability = { ok: true } | { ok: false, reason: string }
+
+export interface InitialMigrationDeps {
+  /** The resolved application environment, lowercased. */
+  appEnv: string
+  /** Probe the configured database. */
+  isReachable: () => Promise<Reachability>
+  /** Run the migration. Resolves to a Result-like; rejects on a thrown error. */
+  migrate: () => Promise<unknown>
+  /** Whether a Result-like value is a failure (`resultFailed`). */
+  failed: (result: unknown) => boolean
+  log: {
+    info: (message: string) => unknown
+    warn: (message: string) => unknown
+    success: (message: string) => unknown
+    debug: (message: unknown) => unknown
+  }
+}
+
+/**
+ * Environments whose setup run may touch the database.
+ *
+ * Setup also runs on deploy and CI targets, where onboarding migrating the
+ * database on its own would be a surprise.
+ */
+const MIGRATING_ENVIRONMENTS = ['local', 'development', 'dev', 'test']
+
+export function migratesDuringSetup(appEnv: string): boolean {
+  return MIGRATING_ENVIRONMENTS.includes(appEnv.toLowerCase())
+}
+
+/**
+ * Run the initial migration and report what happened.
+ *
+ * Never exits or throws: the caller decides what an outcome costs.
+ */
+export async function runInitialMigration(deps: InitialMigrationDeps): Promise<MigrationOutcome> {
+  if (!migratesDuringSetup(deps.appEnv)) {
+    deps.log.info(`Skipping initial migration in the ${deps.appEnv} environment`)
+    return 'skipped'
+  }
+
+  const reachable = await deps.isReachable()
+
+  if (!reachable.ok) {
+    deps.log.warn(`Skipping the initial migration: ${reachable.reason}`)
+    deps.log.warn('Run `./buddy migrate` once the database is up - this project has no schema until you do.')
+    return 'skipped'
+  }
+
+  deps.log.info('Running initial database migration...')
+
+  try {
+    // The migrate action is non-interactive (the confirmation guards live in
+    // the `buddy migrate` command, not the action), so this is safe to run
+    // unattended. The database answered a moment ago, so a failure here is a
+    // failure of the migrations themselves, and setup does not paper over it.
+    const result = await deps.migrate()
+
+    if (deps.failed(result)) {
+      deps.log.debug(result)
+      return 'failed'
+    }
+
+    deps.log.success('Database is migrated')
+
+    return 'migrated'
+  }
+  catch (error) {
+    deps.log.debug(error)
+    return 'failed'
+  }
+}

--- a/storage/framework/core/buddy/tests/initial-migration.test.ts
+++ b/storage/framework/core/buddy/tests/initial-migration.test.ts
@@ -1,0 +1,97 @@
+/**
+ * stacksjs/stacks#2560 - a failed post-install migrate must fail the install.
+ *
+ * `buddy setup` used to downgrade every migration failure to a warning and go
+ * on to print "Project is setup" and exit 0, so a first install could complete,
+ * report success, and leave a database with no schema. These pin the three
+ * answers apart: migrated, deliberately skipped, and failed.
+ */
+
+import type { InitialMigrationDeps, Reachability } from '../src/initial-migration'
+import { describe, expect, test } from 'bun:test'
+import { migratesDuringSetup, runInitialMigration } from '../src/initial-migration'
+
+function deps(overrides: Partial<InitialMigrationDeps> = {}): InitialMigrationDeps & { messages: string[] } {
+  const messages: string[] = []
+
+  return {
+    messages,
+    appEnv: 'local',
+    isReachable: async (): Promise<Reachability> => ({ ok: true }),
+    migrate: async () => ({ isErr: () => false }),
+    failed: (result: unknown) => Boolean((result as { isErr?: () => boolean })?.isErr?.()),
+    log: {
+      info: (m: string) => messages.push(`info: ${m}`),
+      warn: (m: string) => messages.push(`warn: ${m}`),
+      success: (m: string) => messages.push(`success: ${m}`),
+      debug: (m: unknown) => messages.push(`debug: ${String(m)}`),
+    },
+    ...overrides,
+  }
+}
+
+describe('migratesDuringSetup', () => {
+  test('runs in the environments a human is onboarding in', () => {
+    for (const env of ['local', 'development', 'dev', 'test', 'LOCAL'])
+      expect(migratesDuringSetup(env)).toBe(true)
+  })
+
+  test('leaves deploy and CI targets alone', () => {
+    for (const env of ['production', 'staging', 'ci'])
+      expect(migratesDuringSetup(env)).toBe(false)
+  })
+})
+
+describe('runInitialMigration', () => {
+  test('reports a clean run as migrated', async () => {
+    const d = deps()
+    expect(await runInitialMigration(d)).toBe('migrated')
+    expect(d.messages).toContain('success: Database is migrated')
+  })
+
+  test('a failing migration FAILS - it is not downgraded to a warning', async () => {
+    const d = deps({ migrate: async () => ({ isErr: () => true, error: new Error('there is already another table or index with this name: receipts') }) })
+
+    expect(await runInitialMigration(d)).toBe('failed')
+    // The old behaviour: "you can run it later", and setup carried on.
+    expect(d.messages.join('\n')).not.toMatch(/run it later/)
+  })
+
+  test('a migration that throws also fails', async () => {
+    const d = deps({ migrate: async () => { throw new Error('spawn failed') } })
+    expect(await runInitialMigration(d)).toBe('failed')
+  })
+
+  test('an unreachable database skips, says why, and names the follow-up', async () => {
+    const d = deps({ isReachable: async () => ({ ok: false, reason: 'postgres@localhost:5432 is not reachable yet (server-unreachable)' }) })
+
+    expect(await runInitialMigration(d)).toBe('skipped')
+    const output = d.messages.join('\n')
+    expect(output).toContain('server-unreachable')
+    expect(output).toContain('./buddy migrate')
+    expect(output).toContain('no schema until you do')
+  })
+
+  test('does not even probe outside the onboarding environments', async () => {
+    let probed = false
+    const d = deps({
+      appEnv: 'production',
+      isReachable: async () => { probed = true; return { ok: true } },
+      migrate: async () => { throw new Error('must not run') },
+    })
+
+    expect(await runInitialMigration(d)).toBe('skipped')
+    expect(probed).toBe(false)
+  })
+
+  test('an unreachable database never runs the migration', async () => {
+    let migrated = false
+    const d = deps({
+      isReachable: async () => ({ ok: false, reason: 'down' }),
+      migrate: async () => { migrated = true; return { isErr: () => false } },
+    })
+
+    await runInitialMigration(d)
+    expect(migrated).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #2560.

## The gap

`buddy setup` — what `./bootstrap` and the curl-pipe installer run — took the initial migration's failure and turned it into a warning:

```ts
if (resultFailed(result)) {
  log.warn('Initial migration did not complete - you can run it later via ./buddy migrate')
  log.debug(result.error)
  return
}
```

then carried on to `log.success('Project is setup')` and exit 0. The child is honest: `buddy migrate` exits 1 and its stderr is inherited, so the SQL error reaches the terminal. The wrapper discarded the status. A first install could therefore complete, report success, and leave a database with no schema — and as the issue puts it, every downstream check then runs against a broken state and passes.

## Why not just make it required

The best-effort behaviour was written for a real case, stated in the original comment: onboarding may run somewhere the database is not reachable yet. Blanket-failing would break `./bootstrap` for anyone whose Postgres service is not up.

So reachability decides which of the two this is:

| database | the migration is | a failure |
| --- | --- | --- |
| answered | **required** | fails setup, non-zero exit |
| did not answer | **skipped**, out loud | n/a — it never runs |

That is the "decide explicitly whether a post-install migrate is required or best-effort, and if it is best-effort say so" the issue asked for, rather than a step that looks required and behaves optional. The skip path names the reason and the follow-up command, and says plainly that the project has no schema until it is run.

The probe is `probeTargetDatabase()` / `resolveConnectionTarget()`, the same pair `database-preflight.ts` already uses. SQLite and DynamoDB have no target to probe — SQLite creates its file on open — so they count as reachable, which is exactly #2534's configuration: that install now fails.

When a required migration does fail, the remaining setup steps still finish (IDE settings and AWS do not depend on the schema), and then setup says what happened and exits non-zero. The message goes to `process.stderr` synchronously, because the logger writes asynchronously and a hard exit drops whatever it has not flushed.

## Structure

The decision moved out of the command into `core/buddy/src/initial-migration.ts` as a pure function over injected dependencies, so all three outcomes are testable without a database, a subprocess, or a scaffolded project. `setup.ts` keeps only the wiring plus the reachability probe.

## Verification

- 8 new tests in `core/buddy/tests/initial-migration.test.ts`: migrated / skipped / failed, that a failure is no longer worded as "run it later", that an unreachable database never runs the migration, and that a non-onboarding environment does not even probe.
- `bun test ./storage/framework/core/buddy/tests/`: 796 pass, 3 fail — the same 3 `package manifests` failures main has locally (they need a built `dist/`).
- One catch worth naming: the CLI's own `error-before-exit-is-awaited` scanner went red on the first draft, because the new `process.exit` brought two pre-existing unawaited `log.warn` calls in the AWS block within its 16-line window — via a comment of mine that contained the literal `process.exit()`. Reworded; the scanner is green, and it did its job.
- `bun run typecheck`: 19 errors, unchanged from the main baseline. `./buddy lint`: 1 pre-existing error in an untracked local file, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)