### PR TITLE
fix(release): capture the lockfile baseline before anything can rewrite it

### DIFF
--- a/storage/framework/core/actions/src/bump.ts
+++ b/storage/framework/core/actions/src/bump.ts
@@ -299,6 +299,33 @@ async function refreshPantryLock(): Promise<void> {
   }
 }
 
+// Capture the committed lockfiles BEFORE anything in this release can rewrite
+// them. They are the baseline for both the restore paths and the format check
+// below, and a baseline read too late is not a baseline at all.
+//
+// `refreshPantryLock()` runs `pantry install`, which reaches for Bun and
+// rewrites bun.lock once `pinLockstepDeps` has changed the manifests. Reading
+// the bun.lock baseline after that compared an already-rewritten file against
+// itself: on a machine whose Bun predates the committed format, `expected` and
+// `produced` were both the downgraded version, so the guard below passed on
+// exactly the lockfile it exists to reject. v0.74.33 committed a v1 lockfile
+// into a repository that requires v2, and CI failed on the release commit.
+const bunLockPath = p.projectPath('bun.lock')
+const pantryLockPath = p.projectPath('pantry.lock')
+const committedBunLock = existsSync(bunLockPath) ? readFileSync(bunLockPath) : null
+const committedPantryLock = existsSync(pantryLockPath) ? readFileSync(pantryLockPath) : null
+
+// An aborted release must leave the lockfiles exactly as it found them. Only
+// bun.lock used to be restored, so a release that stopped here still left a
+// pantry.lock rewritten by the failed attempt in the working tree - with, on
+// this machine, the `bun.sh` toolchain pin silently dropped from it.
+function restoreCommittedLockfiles(): void {
+  if (committedBunLock)
+    writeFileSync(bunLockPath, committedBunLock)
+  if (committedPantryLock)
+    writeFileSync(pantryLockPath, committedPantryLock)
+}
+
 if (!isDryRun)
   await refreshPantryLock()
 
@@ -306,9 +333,9 @@ if (!isDryRun)
 // Keep the root Bun lockfile synchronized in the same release commit; otherwise
 // every post-release CI job using `bun install --frozen-lockfile` fails before
 // lint, typecheck, or tests can run.
-if (!isDryRun && existsSync(p.projectPath('bun.lock'))) {
-  const lockPath = p.projectPath('bun.lock')
-  const previousLock = readFileSync(lockPath)
+if (!isDryRun && committedBunLock) {
+  const lockPath = bunLockPath
+  const previousLock = committedBunLock
 
   // Bun updates package resolutions in place, but it does not rewrite stale
   // workspace manifest snapshots after the release changes lockstep ranges.
@@ -322,7 +349,7 @@ if (!isDryRun && existsSync(p.projectPath('bun.lock'))) {
     })
   }
   catch (error) {
-    writeFileSync(lockPath, previousLock)
+    restoreCommittedLockfiles()
     throw error
   }
 
@@ -343,7 +370,7 @@ if (!isDryRun && existsSync(p.projectPath('bun.lock'))) {
    * Restore first, then say which it was.
    */
   if (!existsSync(lockPath)) {
-    writeFileSync(lockPath, previousLock)
+    restoreCommittedLockfiles()
     throw new Error(
       'Release aborted: `bun install --lockfile-only` wrote no lockfile, so the previous one has been restored. '
       + 'This usually means a dependency range this bump just raised names a version that is not published yet - '
@@ -355,7 +382,7 @@ if (!isDryRun && existsSync(p.projectPath('bun.lock'))) {
   const regeneratedLock = readFileSync(lockPath, 'utf8')
   const producedVersion = lockfileVersion(regeneratedLock)
   if (expectedLockfileVersion == null || producedVersion !== expectedLockfileVersion) {
-    writeFileSync(lockPath, previousLock)
+    restoreCommittedLockfiles()
 
     // Say which side is behind. The mismatch has two opposite causes and only
     // one of them is the operator's Bun:

--- a/storage/framework/core/actions/tests/release-artifacts.test.ts
+++ b/storage/framework/core/actions/tests/release-artifacts.test.ts
@@ -95,4 +95,56 @@ describe('framework release artifact staging', () => {
     expect(source()).toContain('the committed lockfile predates the Bun this repository declares')
     expect(source()).toContain("this machine's Bun is older than the one that wrote the committed lockfile")
   })
+
+  /**
+   * The guard above can only work if its baseline predates every step that can
+   * rewrite a lockfile.
+   *
+   * `refreshPantryLock()` runs `pantry install`, which reaches for Bun and
+   * rewrites bun.lock once `pinLockstepDeps` has changed the manifests. While
+   * the baseline was read after that call, a machine whose Bun predates the
+   * committed format produced the same downgraded version on both sides of the
+   * comparison - so the guard passed on exactly the lockfile it exists to
+   * reject. v0.74.33 committed a v1 lockfile into a repository that requires
+   * v2, and CI failed on the release commit.
+   */
+  test('captures the lockfile baseline before anything can rewrite it', () => {
+    const src = source()
+    const captured = src.indexOf('const committedBunLock')
+    const pantryRefresh = src.indexOf('await refreshPantryLock()')
+    const regenerated = src.indexOf("['bun', 'install', '--lockfile-only']")
+
+    expect(captured).toBeGreaterThan(-1)
+    expect(pantryRefresh).toBeGreaterThan(-1)
+    expect(captured).toBeLessThan(pantryRefresh)
+    expect(captured).toBeLessThan(regenerated)
+
+    // The comparison must read that pre-refresh capture, not the working tree.
+    expect(src).toContain('const previousLock = committedBunLock')
+  })
+
+  /**
+   * An aborted release has to leave the lockfiles exactly as it found them.
+   * Only bun.lock was restored before, so a release that stopped after the
+   * Pantry refresh left a rewritten pantry.lock behind - and on a machine that
+   * cannot download the pinned toolchain, that rewrite silently drops the
+   * `bun.sh` pin from it.
+   */
+  test('every abort path restores both committed lockfiles', () => {
+    const src = source()
+
+    expect(src).toContain('function restoreCommittedLockfiles()')
+    expect(src).toContain('writeFileSync(bunLockPath, committedBunLock)')
+    expect(src).toContain('writeFileSync(pantryLockPath, committedPantryLock)')
+
+    // All three aborts inside the lockfile block: a failed regeneration, a
+    // regeneration that wrote nothing, and a format mismatch.
+    const block = src.slice(src.indexOf('const committedBunLock'))
+    expect(block.split('restoreCommittedLockfiles()').length - 1).toBeGreaterThanOrEqual(4)
+
+    // And none of them may fall back to the single-file restore this replaced.
+    // Scoped to this block: refreshPantryLock keeps its own local restore for
+    // its own failure, which is correct and unrelated.
+    expect(block).not.toContain('writeFileSync(lockPath, previousLock)')
+  })
 })


### PR DESCRIPTION
## The bug

`bump.ts` already guards against releasing a lockfile in the wrong format. It compares the version Bun just regenerated against the version already committed, and aborts when they disagree — with a carefully written message that names which side is stale.

The guard is correct. **Its baseline was read too late.**

```
277  pinLockstepDeps(nextVersion)      // rewrites hundreds of manifests
303  await refreshPantryLock()         // runs `pantry install` -> reaches for Bun
311  const previousLock = readFileSync(lockPath)   // <- baseline, AFTER the above
317  unlinkSync(lockPath)
319  bun install --lockfile-only
354  const expectedLockfileVersion = lockfileVersion(previousLock...)
```

`refreshPantryLock()` runs `pantry install`, which reaches for Bun and rewrites `bun.lock` once `pinLockstepDeps` has changed the manifests. So on a machine whose Bun predates the committed format, `bun.lock` was *already* downgraded by line 311 — and `expected` and `produced` were both the downgraded version. The guard compared the corrupted file against itself, passed, and let the release continue.

That is how **v0.74.33 committed a `lockfileVersion: 1` lockfile into a repository that requires v2**, tagged it and pushed. CI failed on the release commit; the tag had to be deleted and the commit reverted.

## The fix

Capture both lockfiles before the pantry refresh, and compare against that.

Also restore `pantry.lock` alongside `bun.lock` on every abort path. Only `bun.lock` was restored before, so a release that stopped here left a rewritten `pantry.lock` in the working tree — and on a machine that cannot download the pinned toolchain, that rewrite silently drops the `bun.sh` pin from it. All three aborts (failed regeneration, regeneration that wrote nothing, format mismatch) now go through one `restoreCommittedLockfiles()`.

`refreshPantryLock`'s own internal restore is untouched — it is correct and unrelated.

## Verified end to end

Not just unit-tested. I ran the real `./buddy release --bump patch` on the machine with the older Bun (1.3.14 against a repo pinning 1.4.1 in `deps.yml`), with `remote.origin.pushurl` pointed at a nonexistent path so nothing could escape if the fix were wrong.

Result:

```
Release aborted: regenerating bun.lock produced lockfileVersion 1, but the
committed one is v2 — this machine's Bun is older than the one that wrote the
committed lockfile. Re-run the release with the repository's declared Bun
toolchain through `pantry install`.
```

| | after the fix |
| --- | --- |
| exit code | `1` |
| release commit | none created |
| tag | none created |
| `bun.lock` | restored to v2 |
| `pantry.lock` | restored — system block and all 4 `bun.sh` pins intact |

Before this change, the identical command on the identical machine committed, tagged and pushed.

## Tests

Two added to `release-artifacts.test.ts`, which reads `bump.ts` as source because it runs its release on import:

- **`captures the lockfile baseline before anything can rewrite it`** — asserts by source position that the capture precedes both `refreshPantryLock()` and the regeneration, and that the comparison reads that capture rather than the working tree. This is the actual regression: nothing about the guard's own logic was wrong, only when its input was read.
- **`every abort path restores both committed lockfiles`** — pins the shared restore and that no abort inside the block falls back to the single-file version.

The existing `preserves the canonical lockfile format during a release` test pins the exact `expectedLockfileVersion` line, so I kept the `previousLock` name rather than renaming through it.

## Checks

- `release-artifacts` 9 pass / 0 fail, `release-preflight` 13 pass / 0 fail
- `./buddy lint` — exit 0, 0 errors and 0 warnings across 3449 files
- `bun run typecheck` — 13 pre-existing errors, **none in `bump.ts`**. That is two fewer than the 15 I measured yesterday; both differences are unrelated resolution errors (`stx generateCss`, `ts-css/engine`) that cleared when the verification runs' `bun install` refreshed node_modules, not anything this change did.

## Note

This does not make releases possible from a machine with the wrong toolchain — it makes them *fail* there instead of shipping something broken. Releasing still needs Bun 1.4.1 and a working `pantry install`; on this machine `pantry install` reports `bun.sh@1.4.1 (DownloadFailed)`, which is a separate problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
